### PR TITLE
set "a" at the end of sigil w to make it atom

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,7 +39,7 @@ Setup the application production environment in your ``config/prod.exs``
     tags: %{
       env: "production"
     },
-    included_environments: ~w(prod)
+    included_environments: ~w(prod)a
 
 If using an environment with Plug or Phoenix add the following to your router:
 


### PR DESCRIPTION
Currently, `included_environments:` is not an atom in the following document.
https://docs.sentry.io/hosted/clients/elixir/#configuration

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-elixir/66)
<!-- Reviewable:end -->
