### PR TITLE
Update to reflect apparent documentation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ defp deps do
 end
 ```
 
-Setup the application environment in your `config/prod.exs`
+Setup the application environment in your `config/conf.exs` you may overload these values or add additional values in other environment files.
 
 ```elixir
 config :sentry,


### PR DESCRIPTION
The documentation suggested to only add config to `config/prod.ex` however to run the mix tasks that are also documented or to run a local dev environment or tests then default DSN values are needed even if the service is disabled in all environments other than prod.
