### PR TITLE
Warn on Sentry Error as Default

### DIFF
--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -103,7 +103,7 @@ defmodule Sentry.Client do
   end
 
   defp log_api_error(body) do
-    Logger.error(fn ->
+    Logger.warn(fn ->
       ["Failed to send sentry event.", ?\n, body]
     end)
   end


### PR DESCRIPTION
Spoke with Armin and he suggested we either ignore errors or just log as
a warning.

Fixes #89