### PR TITLE
Fix timestamp format to match the SDK docs.

### DIFF
--- a/lib/sentry/util.ex
+++ b/lib/sentry/util.ex
@@ -12,11 +12,13 @@ defmodule Sentry.Util do
   end
 
   @doc """
-    Generates a iso8601_timestamp
+    Generates a iso8601_timestamp without microseconds and timezone
   """
   @spec iso8601_timestamp :: String.t
   def iso8601_timestamp do
     DateTime.utc_now()
+    |> Map.put(:microsecond, {0, 0})
     |> DateTime.to_iso8601()
+    |> String.trim_trailing("Z")
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Sentry.Mixfile do
   def project do
     [
       app: :sentry,
-      version: "2.0.2",
+      version: "2.0.3",
       elixir: "~> 1.3",
       description: "The Official Elixir client for Sentry",
       package: package(),

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
   "bypass": {:hex, :bypass, "0.5.1", "cf3e8a4d376ee1dcd89bf362dfaf1f4bf4a6e19895f52fdc2bafbd8207ce435f", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}]},
   "certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
-  "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
+  "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:make, :rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "credo": {:hex, :credo, "0.5.3", "0c405b36e7651245a8ed63c09e2d52c2e2b89b6d02b1570c4d611e0fcbecf4a2", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -32,7 +32,7 @@ defmodule Sentry.EventTest do
       %{filename: "lib/ex_unit/runner.ex", function: "anonymous fn/3 in ExUnit.Runner.spawn_test/3", lineno: 246, module: ExUnit.Runner}])
     }
     assert event.tags == %{}
-    assert event.timestamp =~ ~r/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z/
+    assert event.timestamp =~ ~r/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
   end
 
   test "respects tags in config" do


### PR DESCRIPTION
The SDK docs say the timestamp should not have a timezone, and the example timestamp doesn't include microseconds: https://docs.sentry.io/clientdev/attributes/

This pull fixes the format to match what the docs describe.  Addresses https://github.com/getsentry/sentry-elixir/issues/99.