### PR TITLE
Add structs to context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 erl_crash.dump
 *.ez
 /docs/_build
+/doc
 .DS_Store

--- a/lib/sentry/context.ex
+++ b/lib/sentry/context.ex
@@ -57,8 +57,9 @@ defmodule Sentry.Context do
     Process.get(@process_dictionary_key) || %{}
   end
 
-  def add_breadcrumb(map) when is_map(map) do
-    map = Map.put_new(map, "timestamp", Sentry.Util.unix_timestamp())
+  @spec add_breadcrumb(Sentry.Context.BreadCrumb.t) :: nil
+  def add_breadcrumb(%Sentry.Context.BreadCrumb{} = map) do
+    map = Map.put(map, :timestamp, Sentry.Util.unix_timestamp())
     current_context = get_context()
     breadcrumbs = Map.get(current_context, @breadcrumbs_key, [])
     new_breadcrumbs = breadcrumbs ++ [map]

--- a/lib/sentry/context/bread_crumb.ex
+++ b/lib/sentry/context/bread_crumb.ex
@@ -1,0 +1,16 @@
+defmodule Sentry.Context.BreadCrumb do
+
+  defstruct data: nil,
+    category: nil,
+    message: nil,
+    level: nil,
+    timestamp: nil
+
+  @type t :: %Sentry.Context.BreadCrumb{
+    data: %{} | nil,
+    category: binary() | nil,
+    message: binary() | nil,
+    level: :error | :warning | :info | :debug | nil,
+    timestamp: binary() | nil
+  }
+end

--- a/test/context_test.exs
+++ b/test/context_test.exs
@@ -13,8 +13,8 @@ defmodule Sentry.ContextTest do
   end
 
   test "storing breadcrumbs appears when generating event" do
-    Sentry.Context.add_breadcrumb(%{"category" => "a category", "message" => "a message"})
-    Sentry.Context.add_breadcrumb(%{"category" => "a category", "message" => "second message"})
+    Sentry.Context.add_breadcrumb(%Sentry.Context.BreadCrumb{category: "a category", message: "a message"})
+    Sentry.Context.add_breadcrumb(%Sentry.Context.BreadCrumb{category: "a category", message: "second message"})
 
     exception = RuntimeError.exception("error")
     event = Sentry.Event.transform_exception(exception, [])
@@ -25,11 +25,11 @@ defmodule Sentry.ContextTest do
     assert event.user == %{}
     assert event.extra == %{}
     assert event.tags == %{}
-    assert first_breadcrumb["category"] == "a category"
-    assert second_breadcrumb["category"] == "a category"
-    assert first_breadcrumb["message"] == "a message"
-    assert second_breadcrumb["message"] == "second message"
-    assert first_breadcrumb["timestamp"] <= second_breadcrumb["timestamp"]
+    assert first_breadcrumb.category == "a category"
+    assert second_breadcrumb.category == "a category"
+    assert first_breadcrumb.message == "a message"
+    assert second_breadcrumb.message == "second message"
+    assert first_breadcrumb.timestamp <= second_breadcrumb.timestamp
   end
 
   test "storing user context appears when generating event" do


### PR DESCRIPTION
What is acceptable to send is mostly missing in regards to context.
This change helps a bit with that to at least to have structs and
types for two context items, user and breadcrumbs.