### PR TITLE
fix documentation around exception filtering

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -110,9 +110,9 @@ new process and it fails you might lose your context. That said using the contex
 Filtering Events
 ----------------
 
-If you would like to prevent certain exceptions, the :filter configuration option
+If you would like to prevent certain exceptions, the ``:filter`` configuration option
 allows you to implement the ``Sentry.EventFilter`` behaviour.  The first argument is the
-source of the event, and the second is the exception to be sent.  ``Sentry.Plug``
+exception to be sent, and the second is the source of the event.  ``Sentry.Plug``
 will have a source of ``:plug``, and ``Sentry.Logger`` will have a source of ``:logger``.
 If an exception does not come from either of those sources, the source will be nil
 unless the ``:event_source`` option is passed to ``Sentry.capture_exception/2``
@@ -122,12 +122,12 @@ allows other exceptions to be sent.
 
 .. code-block:: elixir
 
-  # sentry_event_filter.exs
+  # sentry_event_filter.ex
   defmodule MyApp.SentryEventFilter do
     @behaviour Sentry.EventFilter
 
-    def exclude_exception?(:plug, %Elixir.Phoenix.Router.NoRouteError{}), do: true
-    def exclude_exception?(_, ), do: false
+    def exclude_exception?(%Elixir.Phoenix.Router.NoRouteError{}, :plug), do: true
+    def exclude_exception?(_exception, _source), do: false
   end
 
   # config.exs

--- a/lib/sentry.ex
+++ b/lib/sentry.ex
@@ -53,9 +53,9 @@ defmodule Sentry do
 
   ## Filtering Exceptions
 
-  If you would like to prevent certain exceptions, the :filter configuration option
+  If you would like to prevent certain exceptions, the `:filter` configuration option
   allows you to implement the `Sentry.EventFilter` behaviour.  The first argument is the
-  source of the event, and the second is the exception to be sent.  `Sentry.Plug`
+  exception to be sent, and the second is the source of the event.  `Sentry.Plug`
   will have a source of `:plug`, and `Sentry.Logger` will have a source of `:logger`.
   If an exception does not come from either of those sources, the source will be nil
   unless the `:event_source` option is passed to `Sentry.capture_exception/2`
@@ -63,12 +63,12 @@ defmodule Sentry do
   A configuration like below will prevent sending `Phoenix.Router.NoRouteError` from `Sentry.Plug`, but
   allows other exceptions to be sent.
 
-      # sentry_event_filter.exs
+      # sentry_event_filter.ex
       defmodule MyApp.SentryEventFilter do
         @behaviour Sentry.EventFilter
 
-        def exclude_exception?(:plug, %Elixir.Phoenix.Router.NoRouteError{}), do: true
-        def exclude_exception?(_, ), do: false
+        def exclude_exception?(%Elixir.Phoenix.Router.NoRouteError{}, :plug), do: true
+        def exclude_exception?(_exception, _source), do: false
       end
 
       # config.exs

--- a/lib/sentry/event_filter.ex
+++ b/lib/sentry/event_filter.ex
@@ -1,5 +1,5 @@
 defmodule Sentry.EventFilter do
-  @callback exclude_exception?(atom, Exception.t) :: any
+  @callback exclude_exception?(Exception.t, atom) :: any
 end
 
 defmodule Sentry.DefaultEventFilter do

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
   "bypass": {:hex, :bypass, "0.5.1", "cf3e8a4d376ee1dcd89bf362dfaf1f4bf4a6e19895f52fdc2bafbd8207ce435f", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}]},
   "certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
-  "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
+  "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:make, :rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "credo": {:hex, :credo, "0.5.3", "0c405b36e7651245a8ed63c09e2d52c2e2b89b6d02b1570c4d611e0fcbecf4a2", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},


### PR DESCRIPTION
Documentation and `Sentry.EventFilter` callback didn't seem to match what was actually being used.

Failing test `test/event_test.exs:13`. The line number check doesn't match for me. 