### PR TITLE
Bring Sentry.Plug in line with Plug.ErrorLogger expectations

### DIFF
--- a/lib/sentry/plug.ex
+++ b/lib/sentry/plug.ex
@@ -82,12 +82,13 @@ defmodule Sentry.Plug do
     request_id_header = Keyword.get(env, :request_id_header, nil)
 
     quote do
-      defp handle_errors(conn, %{kind: kind, reason: reason, stack: stack}) do
+      def handle_errors(conn, opts = %{kind: kind, reason: reason, stack: stack}) do
         opts = [body_scrubber: unquote(body_scrubber), header_scrubber: unquote(header_scrubber),
                  request_id_header: unquote(request_id_header)]
         request = Sentry.Plug.build_request_interface_data(conn, opts)
         exception = Exception.normalize(kind, reason, stack)
         Sentry.capture_exception(exception, [stacktrace: stack, request: request, event_source: :plug])
+        super(conn, opts)
       end
     end
   end


### PR DESCRIPTION
This goes back to #90. I finally got to circle back to it in our application, and I had a bit of a V8 moment when I realized what was going on.

As background: I was trying to figure out why our application kept disposing of the CORS headers when we encountered an error. I _thought_ that the issue was our utilization of `Plug.ErrorLogger` (and ancillary to that `Sentry.Plug` for reporting), since the definition of `Plug.ErrorLogger` captures the original `conn` and passes that to the error handler function. After reading elixir-lang/plug#486, I _thought_ that perhaps the answer was to utilize multiple plug pipeline as Jose suggested. But this last piece from Jose was confusing:

> That's how Phoenix solves the issue

So if Phoenix already implements the multiple plug pipeline strategy, I _shouldn't_ have to.

Queue more digging last week when the CORS errors brought our front-end team to a grinding halt, I did some digging and realized that Plug/Cowboy was having a fit because there was never a response sent when an exception occurred. And thus my V8 moment when I realized that adding `use Sentry.Plug` defines a function that doesn't send a response. I deleted the `use` call, and replaced it with the following:

```elixir
  def handle_errors(conn, opts = %{kind: kind, reason: reason, stack: stack}) do
    body_scrubber = {Sentry.Plug, :default_body_scrubber}
    header_scrubber = {Sentry.Plug, :default_header_scrubber}
    request_id_header = nil

    opts = [
      body_scrubber: body_scrubber,
      header_scrubber: header_scrubber,
      request_id_header: request_id_header
    ]

    request = Sentry.Plug.build_request_interface_data(conn, opts)
    exception = Exception.normalize(kind, reason, stack)
    Sentry.capture_exception(exception, [stacktrace: stack, request: request, event_source: :plug])
    super(conn, opts)
  end
```

This is essentially the code the `Sentry.Plug` macro will generate, with two important distinctions:

1. It defines `handle_error/2` as a public function, which is the same visibility as [the function it overrides](https://github.com/elixir-lang/plug/blob/v1.3.0/lib/plug/error_handler.ex#L49).
2. It calls `super/2` to fall back to the function it overrides, and that function _sends a response_.

I'm not sure that the public visibility is a big issue, but sending the response is. I've opened this PR to address both.

But I am surprised: am I the only person encountering this issue?