### PR TITLE
Default configs

### DIFF
--- a/lib/sentry.ex
+++ b/lib/sentry.ex
@@ -93,6 +93,7 @@ defmodule Sentry do
 
   @client Application.get_env(:sentry, :client, Sentry.Client)
   @use_error_logger Application.get_env(:sentry, :use_error_logger, false)
+  @default_environment_name Mix.env
 
   def start(_type, _opts) do
     children = [
@@ -144,8 +145,8 @@ defmodule Sentry do
   end
 
   def send_event(event = %Event{}) do
-    included_environments = Application.get_env(:sentry, :included_environments)
-    environment_name = Application.get_env(:sentry, :environment_name)
+    included_environments = Application.get_env(:sentry, :included_environments, [:dev, :test, :prod])
+    environment_name = Application.get_env(:sentry, :environment_name, @default_environment_name)
 
     if environment_name in included_environments do
       @client.send_event(event)


### PR DESCRIPTION
**Set default configs in `Sentry.Mixfile.application[:env]`**

From the `config/config.exs` generated by `mix new`:

> This configuration is loaded before any dependency and is restricted
> to this project. If another project depends on this project, this
> file won't be loaded nor affect the parent project. For this reason,
> if you want to provide default values for your application for
> 3rd-party users, it should be done in your "mix.exs" file.

From `mix help compile.app`:

> `:env` - default values for the application environment. The application
> environment is one of the most common ways to configure applications.