### PR TITLE
Bump hackney

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Sentry.Mixfile do
 
   defp deps do
     [
-      {:hackney, "~> 1.6.1"},
+      {:hackney, "~> 1.7.0"},
       {:uuid, "~> 1.0"},
       {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0"},
       {:plug, "~> 1.0", optional: true},


### PR DESCRIPTION
I was getting warnings from mix/hex that hackney 1.6.6 is retired. Looking at my lock file, it seems sentry is holding it back from updating to 1.7+.

Of course, I could lock it back to 1.6.5, but figured fixing it for everyone would be more beneficial.

Thanks,
Maz