### PR TITLE
Always close the hackney client

### DIFF
--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -92,7 +92,8 @@ defmodule Sentry.Client do
             log_api_error(body)
             :error
         end
-      {:ok, status, headers, _client} ->
+      {:ok, status, headers, client} ->
+        :hackney.close(client)
         error_header = :proplists.get_value("X-Sentry-Error", headers, "")
         log_api_error("#{body}\nReceived #{status} from Sentry server: #{error_header}")
         :error


### PR DESCRIPTION
When the request to the server returns a status code != 200 the client is ignored and the body is not read. This makes the client to stay in the connection pool forever. Once the max number of connections is reached (50 by default) no more requests can be sent to the server.
