### PR TITLE
Extend Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ elixir:
   - 1.3.4
   - 1.4.0
   - 1.4.1
+  - 1.4
 otp_release:
   - 18.3
-  - 19.1
+  - 19.3
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Hi, 

A small update to the OTP version and also to always test against the latest version of Elixir v1.4 so that you don't need to remember to add the specific patch release to Travis.

Thanks
Sam