### PR TITLE
Avoid potential infinite loop when using a Sentry Logger backend

### DIFF
--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -160,7 +160,7 @@ defmodule Sentry.Client do
   defp log_api_error(body) do
     Logger.warn(fn ->
       ["Failed to send Sentry event.", ?\n, body]
-    end)
+    end, skip_sentry: true)
   end
 
   defp sleep(attempt_number) do


### PR DESCRIPTION
if an exception occurs encoding a message