### PR TITLE
Fix the backoff to really be exponential

### DIFF
--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -167,7 +167,7 @@ defmodule Sentry.Client do
 
   defp sleep(attempt_number) do
     # sleep 2^n seconds
-    :math.pow(attempt_number, 2)
+    :math.pow(2, attempt_number)
     |> Kernel.*(1000)
     |> Kernel.round()
     |> :timer.sleep()


### PR DESCRIPTION
Even though `send_event/1` docs told that the backoff is supposed to be
exponential it was quadratic