### PR TITLE
allow specifying how to receive result

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ end
 
 ### Capture Exceptions
 
-Sometimes you want to capture specific exceptions, to do so use the `Sentry.capture_exception/3`.
+Sometimes you want to capture specific exceptions.  To do so, use `Sentry.capture_exception/3`.
 
 ```elixir
 try do

--- a/lib/mix/tasks/sentry.send_test_event.ex
+++ b/lib/mix/tasks/sentry.send_test_event.ex
@@ -44,13 +44,11 @@ defmodule Mix.Tasks.Sentry.SendTestEvent do
     if env_name in included_envs do
       Mix.shell.info "Sending test event..."
 
-      {:ok, task} = "Testing sending Sentry event"
+      {:ok, id} = "Testing sending Sentry event"
                     |> RuntimeError.exception
-                    |> Sentry.capture_exception
+                    |> Sentry.capture_exception(result: :sync)
 
-      Task.await(task)
-
-      Mix.shell.info "Test event sent!"
+      Mix.shell.info "Test event sent!  Event ID: #{id}"
     else
       Mix.shell.info "#{inspect env_name} is not in #{inspect included_envs} so no test event will be sent"
     end

--- a/lib/sentry.ex
+++ b/lib/sentry.ex
@@ -78,10 +78,12 @@ defmodule Sentry do
 
   ## Capturing Exceptions
 
-  Simply calling `capture_exception/2` will send the event.
+  Simply calling `capture_exception/2` will send the event.  By default, the event is sent asynchronously and the result can be awaited upon.  The `:result` option can be used to change this behavior.  See `Sentry.Client.send_event/2` for more information.
 
-      Sentry.capture_exception(my_exception)
-      Sentry.capture_exception(other_exception, [event_source: :my_source])
+      {:ok, task} = Sentry.capture_exception(my_exception)
+      {:ok, event_id} = Task.await(task)
+
+      {:ok, another_event_id} = Sentry.capture_exception(other_exception, [event_source: :my_source, result: :sync])
 
   ### Options
     * `:event_source` - The source passed as the first argument to `Sentry.EventFilter.exclude_exception?/2`
@@ -113,7 +115,8 @@ defmodule Sentry do
   end
 
   @doc """
-    Parses and submits an exception to Sentry if current environment is in included_environments.
+  Parses and submits an exception to Sentry if current environment is in included_environments.
+  `opts` argument is passed as the second argument to `Sentry.send_event/2`.
   """
   @spec capture_exception(Exception.t, Keyword.t) :: task
   def capture_exception(exception, opts \\ []) do
@@ -131,6 +134,8 @@ defmodule Sentry do
 
   @doc """
   Reports a message to Sentry.
+
+  `opts` argument is passed as the second argument to `Sentry.send_event/2`.
   """
   @spec capture_message(String.t, Keyword.t) :: task
   def capture_message(message, opts \\ []) do
@@ -141,7 +146,9 @@ defmodule Sentry do
   end
 
   @doc """
-    Sends a `Sentry.Event`
+  Sends a `Sentry.Event`
+
+  `opts` argument is passed as the second argument to `send_event/2` of the configured `Sentry.HTTPClient`.  See `Sentry.Client.send_event/2` for more information.
   """
   @spec send_event(Event.t, Keyword.t) :: task
   def send_event(event, opts \\ [])

--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -4,8 +4,7 @@ defmodule Sentry.Client do
   @moduledoc """
   This module is the default client for sending an event to Sentry via HTTP.
 
-  It makes use of `Task.Supervisor` to create unlinked asynchronous tasks
-  to avoid holding up a user's application to send a Sentry event.
+  It makes use of `Task.Supervisor` to allow sending tasks synchronously or asynchronously, and defaulting to asynchronous. See `Sentry.Client.send_event/2` for more information.
 
   ### Configuration
 
@@ -36,10 +35,12 @@ defmodule Sentry.Client do
   end
 
   @doc """
-  Starts an unlinked asynchronous task that will attempt to send the event to the Sentry
-  API up to 4 times with exponential backoff.
+  Attempts to send the event to the Sentry API up to 4 times with exponential backoff.
 
   The event is dropped if it all retries fail.
+
+  ### Options
+  * `:result` - Allows specifying how the result should be returned. Options include `:sync`, `:none`, and `:async`.  `:sync` will make the API call synchronously, and return `{:ok, event_id}` if successful.  `:none` sends the event from an unlinked child process under `Sentry.TaskSupervisor` and will return `:ok` regardless of the result.  `:async` will start an unlinked task and return a tuple of `{:ok, Task.t}` on success where the Task can be awaited upon to receive the result asynchronously.  When used in an OTP behaviour like GenServer, the task will send a message that needs to be matched with `GenServer.handle_info/2`.  See `Task.Supervisor.async_nolink/2` for more information.  `:async` is the default.
   """
   @spec send_event(Event.t) :: {:ok, Task.t | String.t} | :error | :ok
   def send_event(%Event{} = event, opts \\ []) do

--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -40,9 +40,9 @@ defmodule Sentry.Client do
   The event is dropped if it all retries fail.
 
   ### Options
-  * `:result` - Allows specifying how the result should be returned. Options include `:sync`, `:none`, and `:async`.  `:sync` will make the API call synchronously, and return `{:ok, event_id}` if successful.  `:none` sends the event from an unlinked child process under `Sentry.TaskSupervisor` and will return `:ok` regardless of the result.  `:async` will start an unlinked task and return a tuple of `{:ok, Task.t}` on success where the Task can be awaited upon to receive the result asynchronously.  When used in an OTP behaviour like GenServer, the task will send a message that needs to be matched with `GenServer.handle_info/2`.  See `Task.Supervisor.async_nolink/2` for more information.  `:async` is the default.
+  * `:result` - Allows specifying how the result should be returned. Options include `:sync`, `:none`, and `:async`.  `:sync` will make the API call synchronously, and return `{:ok, event_id}` if successful.  `:none` sends the event from an unlinked child process under `Sentry.TaskSupervisor` and will return `{:ok, ""}` regardless of the result.  `:async` will start an unlinked task and return a tuple of `{:ok, Task.t}` on success where the Task can be awaited upon to receive the result asynchronously.  When used in an OTP behaviour like GenServer, the task will send a message that needs to be matched with `GenServer.handle_info/2`.  See `Task.Supervisor.async_nolink/2` for more information.  `:async` is the default.
   """
-  @spec send_event(Event.t) :: {:ok, Task.t | String.t} | :error | :ok
+  @spec send_event(Event.t) :: {:ok, Task.t | String.t} | :error
   def send_event(%Event{} = event, opts \\ []) do
     result = Keyword.get(opts, :result, :async)
 
@@ -77,7 +77,7 @@ defmodule Sentry.Client do
       try_request(:post, endpoint, auth_headers, body)
     end)
 
-    :ok
+    {:ok, ""}
   end
 
   defp try_request(method, url, headers, body, current_attempt \\ 1)

--- a/lib/sentry/http_client.ex
+++ b/lib/sentry/http_client.ex
@@ -8,5 +8,5 @@ defmodule Sentry.HTTPClient do
   See `Sentry.Client` for `Sentry.TestClient` for example implementations.
   """
 
-  @callback send_event(Sentry.Event.t) :: any
+  @callback send_event(Sentry.Event.t, keyword()) :: any
 end

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -67,7 +67,8 @@ defmodule Sentry.ClientTest do
                            metadata = Map.new(Logger.metadata)
                            {user_id, rest_metadata} = Map.pop(metadata, :user_id)
                            %{e | extra: Map.merge(e.extra, rest_metadata), user: Map.put(e.user, :id, user_id)}
-                         end
+                         end,
+                         client: Sentry.Client
                        ]
     )
     Logger.metadata([key: "value", user_id: 1])
@@ -77,7 +78,7 @@ defmodule Sentry.ClientTest do
     rescue
       e ->
         assert capture_log(fn ->
-          Sentry.capture_exception(e)
+          Sentry.capture_exception(e, result: :sync)
         end)
     end
   end
@@ -91,7 +92,7 @@ defmodule Sentry.ClientTest do
       Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
     end
 
-    modify_env(:sentry, [dsn: "http://public:secret@localhost:#{bypass.port}/1", before_send_event: {Sentry.BeforeSendEventTest, :before_send_event}])
+    modify_env(:sentry, [dsn: "http://public:secret@localhost:#{bypass.port}/1", before_send_event: {Sentry.BeforeSendEventTest, :before_send_event}, client: Sentry.Client])
     Logger.metadata([key: "value", user_id: 1])
 
     try do
@@ -99,7 +100,7 @@ defmodule Sentry.ClientTest do
     rescue
       e ->
         assert capture_log(fn ->
-          Sentry.capture_exception(e)
+          Sentry.capture_exception(e, result: :sync)
         end)
     end
   end

--- a/test/mix/sentry.send_test_event_test.exs
+++ b/test/mix/sentry.send_test_event_test.exs
@@ -43,7 +43,7 @@ defmodule Mix.Tasks.Sentry.SendTestEventTest do
     hackney_opts: [recv_timeout: 50]
 
     Sending test event...
-    Test event sent!
+    Test event sent!  Event ID: 340
     """
   end
 end

--- a/test/sentry_test.exs
+++ b/test/sentry_test.exs
@@ -13,11 +13,11 @@ defmodule SentryTest do
      Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
    end
 
-   modify_env(:sentry, filter: Sentry.TestFilter, dsn: "http://public:secret@localhost:#{bypass.port}/1")
+   modify_env(:sentry, filter: Sentry.TestFilter, dsn: "http://public:secret@localhost:#{bypass.port}/1", client: Sentry.Client)
 
-   assert {:ok, _} = Sentry.capture_exception(%RuntimeError{message: "error"}, [event_source: :plug])
-   assert :excluded = Sentry.capture_exception(%ArithmeticError{message: "error"}, [event_source: :plug])
-   assert {:ok, _} = Sentry.capture_message("RuntimeError: error", [event_source: :plug])
+   assert {:ok, _} = Sentry.capture_exception(%RuntimeError{message: "error"}, [event_source: :plug, result: :sync])
+   assert :excluded = Sentry.capture_exception(%ArithmeticError{message: "error"}, [event_source: :plug, result: :sync])
+   assert {:ok, _} = Sentry.capture_message("RuntimeError: error", [event_source: :plug, result: :sync])
   end
 
   test "errors when taking too long to receive response" do

--- a/test/support/test_client.ex
+++ b/test/support/test_client.ex
@@ -1,7 +1,7 @@
 defmodule Sentry.TestClient do
   @behaviour Sentry.HTTPClient
 
-  def send_event(%Sentry.Event{} = event) do
+  def send_event(%Sentry.Event{} = event, _opts \\ []) do
     {endpoint, _public_key, _secret_key} = Sentry.Client.get_dsn!
     event = Sentry.Client.maybe_call_before_send_event(event)
     case Poison.encode(event) do


### PR DESCRIPTION
Attempts to close #172 

@jeregrine I don't know if I'm happy with the API, but it's a thing that needs to be specified and passed through from top to bottom.  Do you have a better way to do something like this?

- [x] Update documentation