### PR TITLE
adjust client to not send events when the DSN is set to an empty string

### DIFF
--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -58,15 +58,19 @@ defmodule Sentry.Client do
   """
   @spec send_event(Event.t) :: {:ok, Task.t | String.t} | :error | :unsampled
   def send_event(%Event{} = event, opts \\ []) do
-    result = Keyword.get(opts, :result, :async)
-    sample_rate = Keyword.get(opts, :sample_rate) || Config.sample_rate()
-
-    event = maybe_call_before_send_event(event)
-
-    if sample_event?(sample_rate) do
-      encode_and_send(event, result)
-    else
+    if Config.dsn() == "" do
       :unsampled
+    else
+      result = Keyword.get(opts, :result, :async)
+      sample_rate = Keyword.get(opts, :sample_rate) || Config.sample_rate()
+
+      event = maybe_call_before_send_event(event)
+
+      if sample_event?(sample_rate) do
+        encode_and_send(event, result)
+      else
+        :unsampled
+      end
     end
   end
 

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -198,4 +198,15 @@ defmodule Sentry.ClientTest do
         :unsampled = Sentry.capture_exception(e, result: :sync, sample_rate: 0.0)
     end
   end
+
+  test "does not send event when DSN is an empty string" do
+    modify_env(:sentry, [dsn: "", client: Sentry.Client])
+
+    try do
+      Event.not_a_function
+    rescue
+      e ->
+        :unsampled = Sentry.capture_exception(e, result: :sync, sample_rate: 1)
+    end
+  end
 end


### PR DESCRIPTION
I'm not sure if this is the best way to do this... but this will inhibit the attempt to transmit error reports back to Sentry when the DSN is set to an empty string.

In our application, we would like to have the Sentry client included in both local, dev, staging and live environments. However, we don't want to transmit errors from the local environment. As we have set our DSN as an environment variable, the variable is not set in local environments and the read is set to an empty string.

Please let me know what you think... and if there is a much easier way to achieve this without changing the source ;)