### PR TITLE
Change `capture_exception` arity to 2 instead of 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ end
 
 ### Capture Exceptions
 
-Sometimes you want to capture specific exceptions.  To do so, use `Sentry.capture_exception/3`.
+Sometimes you want to capture specific exceptions.  To do so, use `Sentry.capture_exception/2`.
 
 ```elixir
 try do


### PR DESCRIPTION
This function has only `1` and `2` arities – https://github.com/getsentry/sentry-elixir/blob/ec57fdb9f4ca0842512a1ef7991f1308968c9977/lib/sentry.ex#L117-L128