### PR TITLE
Allow Hackney 1.9 and later

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Sentry.Mixfile do
 
   defp deps do
     [
-      {:hackney, "~> 1.8.0 or 1.6.5"},
+      {:hackney, "~> 1.8 or 1.6.5"},
       {:uuid, "~> 1.0"},
       {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0"},
       {:plug, "~> 1.0", optional: true},


### PR DESCRIPTION
`~> 1.8.0 or 1.6.5` is too strict; it should be `~> 1.8 or 1.6.5` to permit later compatible versions of Hackney.