### PR TITLE
Ignore dsn if it's a tuple

### DIFF
--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -16,7 +16,8 @@ defmodule Sentry.Config do
   end
 
   def dsn do
-    get_config(:dsn, check_dsn: false)
+    dsn = get_config(:dsn, check_dsn: false)
+    if is_tuple(dsn), do: nil, else: dsn
   end
 
   def included_environments do

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -16,8 +16,8 @@ defmodule Sentry.Config do
   end
 
   def dsn do
-    dsn = get_config(:dsn, check_dsn: false)
-    if is_tuple(dsn), do: nil, else: dsn
+    _dsn = get_config(:dsn, check_dsn: false)
+    if is_tuple(_dsn), do: nil, else: _dsn
   end
 
   def included_environments do

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -20,4 +20,10 @@ defmodule Sentry.ConfigTest do
 
     assert "my_server" == Config.server_name()
   end
+
+  test "returns false when dsn is tuple" do
+    modify_env(:sentry, dsn: {1,2})
+
+    assert nil == Config.dsn()
+  end
 end


### PR DESCRIPTION
We have a config tool that uses tuples in mix config that get replaced at runtime.  The tuple makes the URI parse blow up during compile.  This would probably fix our issue.

Considering this WIP, but curious to get input from maintainers.  

**EDIT**
The reason this happens is due to to some attributes in the event module that use config values.  