### PR TITLE
Add check_dsn: false to source_code_path_pattern

### DIFF
--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -70,7 +70,7 @@ defmodule Sentry.Config do
   end
 
   def source_code_path_pattern do
-    get_config(:source_code_path_pattern, default: @default_path_pattern)
+    get_config(:source_code_path_pattern, default: @default_path_pattern, check_dsn: false)
   end
 
   def source_code_exclude_patterns do

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -20,4 +20,21 @@ defmodule Sentry.ConfigTest do
 
     assert "my_server" == Config.server_name()
   end
+
+  describe "source_code_path_pattern" do
+    test "retrieves from environment" do
+      modify_env(:sentry, source_code_path_pattern: "**/*test.ex")
+      assert "**/*test.ex" == Config.source_code_path_pattern()
+    end
+
+    test "returns default when not configured" do
+      assert "**/*.ex" == Config.source_code_path_pattern()
+    end
+
+    test "does not retrieve from DSN" do
+      dsn = "https://public:super_secret@app.getsentry.com/2?source_code_path_pattern=test"
+      modify_env(:sentry, dsn: dsn)
+      refute "test" == Config.source_code_path_pattern()
+    end
+  end
 end


### PR DESCRIPTION
It's me again.  :)  I forked this into our organization account and did a slightly better version of what was in #203 We're going to utilize this fork for the short-term until we can either merge this or find a better solution.  I'm going to close the other PR for now.  Sorry for the noise. 

### Problem
Because of the way our internal config tooling works, we will have a tuple in the configuration for the DSN.  This causes a compile-time issue in this package as it's evaluating the DSN and expecting a string when it's computing some attributes. 

## Here are the details from the original PR.

### How our config stuff works

We're doing Distillery releases for our production deployments, but we had to devise a way to make runtime config work in our current environment. So, we wrote a package that uses something very similar to the {:system, "KEY"} convention that you mention.

Basically, our config will look like this:

config :sentry, dsn: {:enviro, "sentry_dsn"}
Our tool knows where to get config values and replaces these tuples appropriately. Since that happens at runtime, we will have that tuple where the DSN should be. It's worth mentioning that our build servers do not have access to those configuration values.

### Alternative Possible Fix
We're kinda wondering if the DSN needs to be checked at all for this particular configuration value? Config.source_code_path_pattern() If that could be set to check_dsn: false when calling get_config, then I think that might be another way to resolve our issue.
