### PR TITLE
allow Sentry.Plug.handle_errors to be overridden

### DIFF
--- a/lib/sentry/plug.ex
+++ b/lib/sentry/plug.ex
@@ -113,6 +113,8 @@ defmodule Sentry.Plug do
         exception = Exception.normalize(kind, reason, stack)
         Sentry.capture_exception(exception, [stacktrace: stack, request: request, event_source: :plug])
       end
+
+      defoverridable [handle_errors: 2]
     end
   end
 


### PR DESCRIPTION
I have a use case where I want to use the `Sentry.Plug` module in my router, but also define some custom behavior in the `Plug.ErrorHandler.handle_errors/2` callback, such as sending metrics to our StatsD server, logging, etc.

Currently, the `handle_errors` method in the `Sentry.Plug` can't be overridden or extended, so I have to rescue exceptions and use `Sentry.capture_exception/2` in order to perform this extra behavior.