### PR TITLE
Event Struct Rendering

### DIFF
--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -218,6 +218,13 @@ defmodule Sentry.Client do
     @hackney_pool_name
   end
 
+  @doc """
+  Transform the Event struct into JSON map.
+
+  Most Event attributes map directly to JSON map, with stacktrace being the
+  exception.  If the event does not have stacktrace frames, it should not
+  be included in the JSON body.
+  """
   def render_event(%Event{} = event) do
     map =  %{
       event_id: event.event_id,

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -63,6 +63,7 @@ defmodule Sentry.ClientTest do
       request_map = Poison.decode!(body)
       assert request_map["extra"] == %{"key" => "value"}
       assert request_map["user"]["id"] == 1
+      assert is_nil(request_map["stacktrace"]["frames"])
       Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
     end
 

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -164,7 +164,9 @@ defmodule Sentry.ClientTest do
   test "sends event with sample_rate of 1" do
     bypass = Bypass.open
     Bypass.expect bypass, fn conn ->
-      {:ok, _body, conn} = Plug.Conn.read_body(conn)
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      request_map = Poison.decode!(body)
+      assert Enum.count(request_map["stacktrace"]["frames"]) > 0
       Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
     end
 
@@ -177,7 +179,8 @@ defmodule Sentry.ClientTest do
       Event.not_a_function
     rescue
       e ->
-        {:ok, _} = Sentry.capture_exception(e, result: :sync, sample_rate: 1)
+        {:ok, _} = Sentry.capture_exception(e, stacktrace: System.stacktrace,
+                                            result: :sync, sample_rate: 1)
     end
   end
 

--- a/test/support/test_client.exs
+++ b/test/support/test_client.exs
@@ -5,7 +5,9 @@ defmodule Sentry.TestClient do
   def send_event(%Sentry.Event{} = event, _opts \\ []) do
     {endpoint, _public_key, _secret_key} = Sentry.Client.get_dsn!
     event = Sentry.Client.maybe_call_before_send_event(event)
-    case Poison.encode(event) do
+    Sentry.Client.render_event(event)
+    |> Poison.encode()
+    |> case do
       {:ok, body} ->
         Sentry.Client.request(:post, endpoint, [], body)
       {:error, error} ->


### PR DESCRIPTION
Closes #161 and closes #223 

The issue in #223 is that we are sending `stacktrace: %{ frames: []}`, which is not handled/parsed by the Sentry server, and results in an error showing.  The event still works and shows everything properly, but better to avoid the message.

To avoid it, the `stacktrace` key is not sent up to the server if there are no frames.