### PR TITLE
Handle :error when sending test event

### DIFF
--- a/lib/mix/tasks/sentry.send_test_event.ex
+++ b/lib/mix/tasks/sentry.send_test_event.ex
@@ -53,6 +53,8 @@ defmodule Mix.Tasks.Sentry.SendTestEvent do
       case result do
         {:ok, id} ->
           Mix.shell.info "Test event sent!  Event ID: #{id}"
+        :error ->
+          Mix.shell.info "Error sending event!"
         :excluded ->
           Mix.shell.info "No test event was sent because the event was excluded by a filter"
       end

--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -139,8 +139,8 @@ defmodule Sentry.Client do
         error_header = :proplists.get_value("X-Sentry-Error", headers, "")
         log_api_error("#{body}\nReceived #{status} from Sentry server: #{error_header}")
         :error
-      _ ->
-        log_api_error(body)
+      e ->
+        log_api_error("#{inspect(e)}\n#{body}")
         :error
     end
   end

--- a/test/mix/sentry.send_test_event_test.exs
+++ b/test/mix/sentry.send_test_event_test.exs
@@ -50,7 +50,7 @@ defmodule Mix.Tasks.Sentry.SendTestEventTest do
 
   test "handles :error when Sentry server is unreachable" do
     modify_env(:sentry, [dsn: "http://public:secret@localhost:0/1"])
-    capture_log(fn ->
+    assert capture_log(fn ->
       assert capture_io(fn ->
         Mix.Tasks.Sentry.SendTestEvent.run([])
       end) == """
@@ -65,6 +65,6 @@ defmodule Mix.Tasks.Sentry.SendTestEventTest do
       Sending test event...
       Error sending event!
       """
-    end)
+    end) =~ "Failed to send Sentry event"
   end
 end


### PR DESCRIPTION
Closes #226 

New output will look something like this if the test event fails to send:

```
Sending test event...

19:35:30.170 [warn]  Failed to send Sentry event.
{:error, :nxdomain}
{"user":{},"timestamp":"2017-11-10T01:35:30","tags":{"env":"production"},"server_name":"Mitchells-MacBook-Pro.local","request":{},"release":null,"platform":"elixir","modules":{"uuid":"1.1.7","ssl_verify_fun":"1.1.1","poison":"2.2.0","plug":"1.2.3","mimerl":"1.0.2","mime":"1.1.0","metrics":"1.0.1","hackney":"1.6.5"},"message":"(RuntimeError) Testing sending Sentry event","level":"error","fingerprint":["{{ default }}"],"extra":{},"exception":[{"value":"Testing sending Sentry event","type":"Elixir.RuntimeError","module":null}],"event_id":"6910c421e7f74881a8e7cc3c37795434","environment":"dev","culprit":null,"breadcrumbs":[]}

19:35:32.173 [warn]  Failed to send Sentry event.
{:error, :nxdomain}
{"user":{},"timestamp":"2017-11-10T01:35:30","tags":{"env":"production"},"server_name":"Mitchells-MacBook-Pro.local","request":{},"release":null,"platform":"elixir","modules":{"uuid":"1.1.7","ssl_verify_fun":"1.1.1","poison":"2.2.0","plug":"1.2.3","mimerl":"1.0.2","mime":"1.1.0","metrics":"1.0.1","hackney":"1.6.5"},"message":"(RuntimeError) Testing sending Sentry event","level":"error","fingerprint":["{{ default }}"],"extra":{},"exception":[{"value":"Testing sending Sentry event","type":"Elixir.RuntimeError","module":null}],"event_id":"6910c421e7f74881a8e7cc3c37795434","environment":"dev","culprit":null,"breadcrumbs":[]}

19:35:36.175 [warn]  Failed to send Sentry event.
{:error, :nxdomain}
{"user":{},"timestamp":"2017-11-10T01:35:30","tags":{"env":"production"},"server_name":"Mitchells-MacBook-Pro.local","request":{},"release":null,"platform":"elixir","modules":{"uuid":"1.1.7","ssl_verify_fun":"1.1.1","poison":"2.2.0","plug":"1.2.3","mimerl":"1.0.2","mime":"1.1.0","metrics":"1.0.1","hackney":"1.6.5"},"message":"(RuntimeError) Testing sending Sentry event","level":"error","fingerprint":["{{ default }}"],"extra":{},"exception":[{"value":"Testing sending Sentry event","type":"Elixir.RuntimeError","module":null}],"event_id":"6910c421e7f74881a8e7cc3c37795434","environment":"dev","culprit":null,"breadcrumbs":[]}

19:35:44.179 [warn]  Failed to send Sentry event.
{:error, :nxdomain}
{"user":{},"timestamp":"2017-11-10T01:35:30","tags":{"env":"production"},"server_name":"Mitchells-MacBook-Pro.local","request":{},"release":null,"platform":"elixir","modules":{"uuid":"1.1.7","ssl_verify_fun":"1.1.1","poison":"2.2.0","plug":"1.2.3","mimerl":"1.0.2","mime":"1.1.0","metrics":"1.0.1","hackney":"1.6.5"},"message":"(RuntimeError) Testing sending Sentry event","level":"error","fingerprint":["{{ default }}"],"extra":{},"exception":[{"value":"Testing sending Sentry event","type":"Elixir.RuntimeError","module":null}],"event_id":"6910c421e7f74881a8e7cc3c37795434","environment":"dev","culprit":null,"breadcrumbs":[]}
Error sending event!
```

Thanks to @jalcine for reporting this issue 🙂 