### PR TITLE
fix warning for GenEvent

### DIFF
--- a/lib/sentry/logger.ex
+++ b/lib/sentry/logger.ex
@@ -36,9 +36,9 @@ defmodule Sentry.Logger do
   With this solution, if a `Sentry.Logger` handler is already running, it will not add another.  One can add the code to each application, and there will only ever be one handler created.  This solution is safer, but slightly more complex to manage.
   """
 
-  use GenEvent
+  @behaviour :gen_event
 
-  def init(_mod, []), do: {:ok, []}
+  def init(_mod), do: {:ok, []}
 
   def handle_call({:configure, new_keys}, _state), do: {:ok, :ok, new_keys}
 


### PR DESCRIPTION
GenEvent module is deprecated.

> If you have to implement an event handler to integrate with an existing system, such as Elixir’s Logger, please use :gen_event instead.

So, I replaced `GenEvent` with `:gen_event`, just like: https://github.com/elixir-lang/elixir/blob/v1.5.2/lib/logger/lib/logger/error_handler.ex