### PR TITLE
include error_type in Plug.Sentry

### DIFF
--- a/lib/sentry/plug.ex
+++ b/lib/sentry/plug.ex
@@ -111,7 +111,8 @@ defmodule Sentry.Plug do
                  request_id_header: unquote(request_id_header)]
         request = Sentry.Plug.build_request_interface_data(conn, opts)
         exception = Exception.normalize(kind, reason, stack)
-        Sentry.capture_exception(exception, [stacktrace: stack, request: request, event_source: :plug])
+        Sentry.capture_exception(exception, [stacktrace: stack, request: request,
+                                             event_source: :plug, error_type: kind])
       end
     end
   end


### PR DESCRIPTION
We weren't including the kind of error when reporting errors from `Sentry.Plug` (`:error`, `:exit`, etc.) and this PR fixes that.

Issue originally mentioned in https://github.com/elixir-ecto/db_connection/issues/107#issuecomment-347787579