### PR TITLE
define :gen_event functions

### DIFF
--- a/lib/sentry/logger.ex
+++ b/lib/sentry/logger.ex
@@ -71,6 +71,17 @@ defmodule Sentry.Logger do
     {:ok, state}
   end
 
+  def handle_info(_msg, state) do
+    {:ok, state}
+  end
+
+  def code_change(_old, state, _extra) do
+    {:ok, state}
+  end
+
+  def terminate(_reason, _state) do
+    :ok
+  end
 
   defp get_exception_and_stacktrace({kind, {exception, sub_stack}, _stack}) when is_list(sub_stack) do
     {kind, exception, sub_stack}


### PR DESCRIPTION
Related to #237 

The Elixir GenEvent Behaviour had default implementations of these functions:  https://github.com/elixir-lang/elixir/blob/v1.5.2/lib/elixir/lib/gen_event.ex#L117-L129

and erlang gives some warnings now because of that:

```
warning: undefined behaviour function code_change/3 (for behaviour :gen_event)
  lib/sentry/logger.ex:1

warning: undefined behaviour function handle_info/2 (for behaviour :gen_event)
  lib/sentry/logger.ex:1

warning: undefined behaviour function terminate/2 (for behaviour :gen_event)
  lib/sentry/logger.ex:1
```

So I defined them