### PR TITLE
Correct documentation on recompiling Sentry when using source code context

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,12 @@ Sentry uses the [hackney HTTP client](https://github.com/benoitc/hackney) for HT
 
 Sentry's server supports showing the source code that caused an error, but depending on deployment, the source code for an application is not guaranteed to be available while it is running.  To work around this, the Sentry library reads and stores the source code at compile time.  This has some unfortunate implications.  If a file is changed, and Sentry is not recompiled, it will still report old source code.
 
-The best way to ensure source code is up to date is to recompile Sentry itself via `mix do clean, compile`.  It's possible to create a Mix Task alias in `mix.exs` to do this.  The example below would allow one to run `mix sentry_recompile` which will force recompilation of Sentry so it has the newest source and then compile the project:
+The best way to ensure source code is up to date is to recompile Sentry itself via `mix deps.compile sentry --force`.  It's possible to create a Mix Task alias in `mix.exs` to do this.  The example below would allow one to run `mix sentry_recompile` which will force recompilation of Sentry so it has the newest source and then compile the project:
 
 ```elixir
 # mix.exs
 defp aliases do
-  [sentry_recompile: ["clean", "compile"]]
+  [sentry_recompile: ["deps.compile sentry --force", "compile"]]
 end
 ```
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -159,7 +159,7 @@ To enable, set ``:enable_source_code_context`` and ``root_source_code_path``:
     enable_source_code_context: true,
     root_source_code_path: File.cwd!
 
-For more documentation, see [Sentry.Sources](https://hexdocs.pm/sentry/Sentry.Sources.html).
+For more documentation, see `Sentry.Sources <https://hexdocs.pm/sentry/Sentry.Sources.html>`_.
 
 Deep Dive
 ---------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -142,13 +142,13 @@ Including Source Code
 
 Sentry's server supports showing the source code that caused an error, but depending on deployment, the source code for an application is not guaranteed to be available while it is running.  To work around this, the Sentry library reads and stores the source code at compile time. This has some unfortunate implications.  If a file is changed, and Sentry is not recompiled, it will still report old source code.
 
-The best way to ensure source code is up to date is to recompile Sentry itself via ``mix do clean, compile``.  It's possible to create a Mix Task alias in ``mix.exs`` to do this.  The example below would allow one to run ``mix.sentry_recompile`` which will force recompilation of Sentry so it has the newest source and then compile the project:
+The best way to ensure source code is up to date is to recompile Sentry itself via ``mix deps.compile sentry --force``.  It's possible to create a Mix Task alias in ``mix.exs`` to do this.  The example below would allow one to run ``mix.sentry_recompile`` which will force recompilation of Sentry so it has the newest source and then compile the project:
 
 .. code-block:: elixir
 
   # mix.exs
   defp aliases do
-    [sentry_recompile: ["clean", "compile"]]
+    [sentry_recompile: ["deps.compile sentry --force", "compile"]]
   end
 
 To enable, set ``:enable_source_code_context`` and ``root_source_code_path``:

--- a/lib/sentry/sources.ex
+++ b/lib/sentry/sources.ex
@@ -37,13 +37,13 @@ defmodule Sentry.Sources do
   it will still report old source code.
 
   The best way to ensure source code is up to date is to recompile Sentry
-  itself via `mix do clean, compile`.  It's possible to create a Mix
+  itself via `mix deps.compile sentry --force`.  It's possible to create a Mix
   Task alias in `mix.exs` to do this.  The example below would allow one to
   run `mix.sentry_recompile` which will force recompilation of Sentry so
   it has the newest source and then compile the project:
 
       defp aliases do
-        [sentry_recompile: ["clean", "compile"]]
+        [sentry_recompile: ["deps.compile sentry --force", "compile"]]
       end
 
   """


### PR DESCRIPTION
Closes #241 