### PR TITLE
Fix typos in the docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,7 +64,7 @@ atom is, but it will only send events if the current environment is ``:prod``,
 since that is the only entry in the ``included_environments`` key.
 
 You can even rely on more custom determinations of the environment name. It's
-not uncommmon for most applications to have a "staging" environment. In order
+not uncommon for most applications to have a "staging" environment. In order
 to handle this without adding an additional Mix environment, you can set an
 environment variable that determines the release level.
 

--- a/docs/plug.rst
+++ b/docs/plug.rst
@@ -1,7 +1,7 @@
 Sentry.Plug
 =============
 
-Sentry.Plug provides basic funcitonality to handle Plug.ErrorHandler.
+Sentry.Plug provides basic functionality to handle Plug.ErrorHandler.
 
 To capture errors, simply put the following in your router:
 

--- a/lib/sentry/plug.ex
+++ b/lib/sentry/plug.ex
@@ -7,13 +7,13 @@ defmodule Sentry.Plug do
   @scrubbed_value "*********"
 
   @moduledoc """
-  Provides basic funcitonality to handle Plug.ErrorHandler
+  Provides basic functionality to handle Plug.ErrorHandler
 
   #### Usage
 
   Add the following to your router.ex:
 
-      use Plug.ErrorLogger
+      use Plug.ErrorHandler
       use Sentry.Plug
 
   ### Sending Post Body Params


### PR DESCRIPTION
* Fixes misspellings
* Fixes incorrect module name: Plug.ErrorLogger -> Plug.ErrorHandler