### PR TITLE
fix compile warning

### DIFF
--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -188,7 +188,9 @@ defmodule Sentry.Event do
         do_put_source_context(unquote(frame), unquote(file), unquote(line_number))
       end
     else
-      frame
+      quote do
+        unquote(frame)
+      end
     end
   end
 
@@ -218,7 +220,8 @@ defmodule Sentry.Event do
     |> Enum.reverse()
   end
 
-  defp do_put_source_context(frame, file, line_number) do
+  @spec do_put_source_context(map(), String.t(), integer()) :: map()
+  def do_put_source_context(frame, file, line_number) do
     {pre_context, context, post_context} =
       Sentry.Sources.get_source_context(@source_files, file, line_number)
 

--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -185,7 +185,7 @@ defmodule Sentry.Event do
   defmacrop put_source_context(frame, file, line_number) do
     if Config.enable_source_code_context() do
       quote do
-        macro_put_source_context(unquote(frame), unquote(file), unquote(line_number))
+        do_put_source_context(unquote(frame), unquote(file), unquote(line_number))
       end
     else
       frame
@@ -218,12 +218,12 @@ defmodule Sentry.Event do
     |> Enum.reverse()
   end
 
-  @spec macro_put_source_context(map(), String.t(), integer()) :: map()
-  def macro_put_source_context(frame, file, line_number) do
+  defp do_put_source_context(frame, file, line_number) do
     {pre_context, context, post_context} =
       Sentry.Sources.get_source_context(@source_files, file, line_number)
 
-    Map.put(frame, :context_line, context)
+    frame
+    |> Map.put(:context_line, context)
     |> Map.put(:pre_context, pre_context)
     |> Map.put(:post_context, post_context)
   end


### PR DESCRIPTION
Current implementation causes this warning because we're checking a compile-time module attribute at runtime, so the result is always the same. Looks like this:


```
  warning: this check/guard will always yield the same result
    lib/sentry/event.ex:195
```

Not super familiar with metaprogramming stuff, but this defines a macro that will either find and insert the source code context or return the frame as-is and remove the warning.
