### PR TITLE
feat: Allow public DSNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ An example production config might look like this:
 
 ```elixir
 config :sentry,
-  dsn: "https://public:secret@app.getsentry.com/1",
+  dsn: "___PUBLIC_DSN___",
   environment_name: :prod,
   included_environments: [:prod],
   enable_source_code_context: true,
@@ -126,7 +126,7 @@ specific configuration like `config/prod.exs`.
 Alternatively, you could use Mix.env in your general configuration file:
 
 ```elixir
-config :sentry, dsn: "https://public:secret@app.getsentry.com/1",
+config :sentry, dsn: "___PUBLIC_DSN___",
   included_environments: [:prod],
   environment_name: Mix.env
 ```
@@ -137,7 +137,7 @@ to handle this without adding an additional Mix environment, you can set an
 environment variable that determines the release level.
 
 ```elixir
-config :sentry, dsn: "https://public:secret@app.getsentry.com/1",
+config :sentry, dsn: "___PUBLIC_DSN___",
   included_environments: ~w(production staging),
   environment_name: System.get_env("RELEASE_LEVEL") || "development"
 ```

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -8,7 +8,7 @@ Simply add configuration to the ``:sentry`` key in the file ``config/prod.exs``:
 .. code-block:: elixir
 
   config :sentry,
-    dsn: "https://public:secret@app.getsentry.com/1"
+    dsn: "___PUBLIC_DSN___"
 
 If using an environment with Plug or Phoenix add the following to your router:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,7 @@ Setup the application production environment in your ``config/prod.exs``
 .. code-block:: elixir
 
   config :sentry,
-    dsn: "https://public:secret@app.getsentry.com/1",
+    dsn: "___PUBLIC_DSN___",
     environment_name: :prod,
     enable_source_code_context: true,
     root_source_code_path: File.cwd!,
@@ -55,7 +55,7 @@ An alternative is to use ``Mix.env`` in your general configuration file:
 
 .. code-block:: elixir
 
-  config :sentry, dsn: "https://public:secret@app.getsentry.com/1"
+  config :sentry, dsn: "___PUBLIC_DSN___"
      included_environments: [:prod],
      environment_name: Mix.env
 
@@ -70,7 +70,7 @@ environment variable that determines the release level.
 
 .. code-block:: elixir
 
-  config :sentry, dsn: "https://public:secret@app.getsentry.com/1"
+  config :sentry, dsn: "___PUBLIC_DSN___"
     included_environments: ~w(production staging),
     environment_name: System.get_env("RELEASE_LEVEL") || "development"
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -11,7 +11,7 @@ Otherwise we provide a simple way to capture exceptions:
 
 .. code-block:: elixir
 
-    do
+    try do
       ThisWillError.reall()
     rescue
       my_exception ->

--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -212,7 +212,7 @@ defmodule Sentry.Client do
 
     with %URI{userinfo: userinfo, host: host, port: port, path: path, scheme: protocol}
          when is_binary(path) and is_binary(userinfo) <- URI.parse(dsn),
-         [public_key, secret_key | _] <- String.split(userinfo, ":", parts: 2) ++ [nil],
+         [public_key, secret_key] <- keys_from_userinfo(userinfo),
          [_, binary_project_id] <- String.split(path, "/"),
          {project_id, ""} <- Integer.parse(binary_project_id),
          endpoint <- "#{protocol}://#{host}:#{port}/api/#{project_id}/store/" do
@@ -302,6 +302,14 @@ defmodule Sentry.Client do
 
       _ ->
         map
+    end
+  end
+
+  defp keys_from_userinfo(userinfo) do
+    case String.split(userinfo, ":", parts: 2) do
+      [public, secret] -> [public, secret]
+      [public] -> [public, nil]
+      _ -> :error
     end
   end
 

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -16,6 +16,16 @@ defmodule Sentry.ClientTest do
              }, sentry_timestamp=\d{10}, sentry_key=public, sentry_secret=secret$/
   end
 
+  test "authorization without secret" do
+    modify_env(:sentry, dsn: "https://public@app.getsentry.com/1")
+    {_endpoint, public_key, private_key} = Client.get_dsn()
+
+    assert Client.authorization_header(public_key, private_key) =~
+             ~r/^Sentry sentry_version=5, sentry_client=sentry-elixir\/#{
+               Application.spec(:sentry, :vsn)
+             }, sentry_timestamp=\d{10}, sentry_key=public$/
+  end
+
   test "get dsn with default config" do
     modify_env(:sentry, dsn: "https://public:secret@app.getsentry.com/1")
 
@@ -31,8 +41,8 @@ defmodule Sentry.ClientTest do
              Sentry.Client.get_dsn()
   end
 
-  test "errors on bad public/secret keys" do
-    modify_env(:sentry, dsn: "https://public@app.getsentry.com/1")
+  test "errors on bad public keys" do
+    modify_env(:sentry, dsn: "https://app.getsentry.com/1")
 
     capture_log(fn ->
       assert :error = Sentry.Client.get_dsn()


### PR DESCRIPTION
The private DSNs (including secret keys) will be officially deprecated soon. This PR allows users to specify a public DSN and makes sure the `sentry_secret` is not included in the header anymore. For backwards compatibility, a private DSN can still be used, though. 

Also, this PR updates docs to use interactive DSN code snippets and fixes an invalid `try do ... rescue` statement.