### PR TITLE
Use the stacktrace passed to Sentry.Event.transform_exception/2 when calling Exception.normalize/3

### DIFF
--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -143,7 +143,7 @@ defmodule Sentry.Event do
   @spec transform_exception(Exception.t(), keyword()) :: Event.t()
   def transform_exception(exception, opts) do
     error_type = Keyword.get(opts, :error_type) || :error
-    normalized = Exception.normalize(:error, exception)
+    normalized = Exception.normalize(:error, exception, Keyword.get(opts, :stacktrace, nil))
 
     type =
       if error_type == :error do


### PR DESCRIPTION
The stacktrace for certain errors (like `FunctionClauseError`) may resolve incorrectly inside [`Sentry.Event.transform_exception/2`](https://github.com/getsentry/sentry-elixir/blob/cd9ed8f886f9ede8ef892c95861f7d459dd5e29b/lib/sentry/event.ex#L146) due in part to the issue described in elixir-lang/elixir#7622.

To reproduce the issue, the following can be run to force a `FunctionClauseError` error report generated by a supervisor:

```elixir
:error_logger.add_report_handler(Sentry.Logger)
{:ok, pid} = Task.Supervisor.start_link()
Task.Supervisor.start_child(pid, fn -> :lists.last([]) end)
```

In the generated event, the message will show:

```
(FunctionClauseError) no function clause matching in Keyword.delete_key/3
```

Instead of reporting as expected:

```
(FunctionClauseError) no function clause matching in :lists.last/1
```