### PR TITLE
Use `get_peer_data` function

### DIFF
--- a/lib/sentry/plug.ex
+++ b/lib/sentry/plug.ex
@@ -171,7 +171,7 @@ if Code.ensure_loaded?(Plug) do
         headers: handle_data(conn, header_scrubber),
         env: %{
           "REMOTE_ADDR" => remote_address(conn.remote_ip),
-          "REMOTE_PORT" => remote_port(conn.peer),
+          "REMOTE_PORT" => Plug.Conn.get_peer_data(conn).port,
           "SERVER_NAME" => conn.host,
           "SERVER_PORT" => conn.port,
           "REQUEST_ID" => Plug.Conn.get_resp_header(conn, request_id) |> List.first()
@@ -184,8 +184,6 @@ if Code.ensure_loaded?(Plug) do
       |> :inet.ntoa()
       |> to_string()
     end
-
-    defp remote_port({_, port}), do: port
 
     defp handle_data(_conn, nil), do: %{}
 

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Sentry.Mixfile do
       {:hackney, "~> 1.8 or 1.6.5"},
       {:uuid, "~> 1.0"},
       {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0"},
-      {:plug, "~> 1.0", optional: true},
+      {:plug, "~> 1.6", optional: true},
       {:phoenix, "~> 1.3", optional: true},
       {:dialyxir, "> 0.0.0", only: [:dev], runtime: false},
       {:ex_doc, "~> 0.18.0", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -16,7 +16,7 @@
   "parse_trans": {:hex, :parse_trans, "3.2.0", "2adfa4daf80c14dc36f522cf190eb5c4ee3e28008fc6394397c16f62a26258c2", [:rebar3], [], "hexpm"},
   "phoenix": {:hex, :phoenix, "1.3.2", "2a00d751f51670ea6bc3f2ba4e6eb27ecb8a2c71e7978d9cd3e5de5ccf7378bd", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, repo: "hexpm", optional: false]}, {:plug, "~> 1.3.3 or ~> 1.4", [hex: :plug, repo: "hexpm", optional: false]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [:mix], [], "hexpm"},
-  "plug": {:hex, :plug, "1.5.0", "224b25b4039bedc1eac149fb52ed456770b9678bbf0349cdd810460e1e09195b", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "plug": {:hex, :plug, "1.6.0", "90d338a44c8cd762c32d3ea324f6728445c6145b51895403854b77f1536f1617", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.4", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -462,7 +462,7 @@ defmodule Sentry.EventTest do
              mime: "1.2.0",
              mimerl: "1.0.2",
              parse_trans: "3.2.0",
-             plug: "1.5.0",
+             plug: "1.6.0",
              poison: "3.1.0",
              ranch: "1.3.2",
              ssl_verify_fun: "1.1.1",


### PR DESCRIPTION
In elixir-plug/plug@d24ba4f7c859b47866b7031a1ea68469f1808183, the `peer` field got replaced with a `get_peer_data` function.

This makes the package require Plug 1.6.0 and uses this new function to resolve the remote port.