### PR TITLE
avoid default reporting of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ end
 | `after_send_event` | False | | |
 | `sample_rate` | False | 1.0 | |
 | `in_app_module_whitelist` | False | `[]` | |
-| `report_deps` | False | True | Will attempt to load Mix dependencies at compile time to report alongside events |
+| `report_deps` | False | False | Will attempt to load Mix dependencies at compile time to report alongside events. This was switched to default to false following a bug in the parallel compiler ([#232](https://github.com/getsentry/sentry-elixir/issues/232) / [elixir-lang/elixir#7699](https://github.com/elixir-lang/elixir/issues/7699)) |
 | `enable_source_code_context` | False | False | |
 | `root_source_code_path` | Required if `enable_source_code_context` is enabled | | Should generally be set to `File.cwd!`|
 | `context_lines` | False  | 3 | |

--- a/config/test.exs
+++ b/config/test.exs
@@ -4,4 +4,5 @@ config :sentry,
   environment_name: :test,
   included_environments: [:test],
   client: Sentry.TestClient,
-  hackney_opts: [recv_timeout: 50]
+  hackney_opts: [recv_timeout: 50],
+  report_deps: true

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -120,7 +120,7 @@ defmodule Sentry.Config do
   end
 
   def report_deps do
-    get_config(:report_deps, default: true, check_dsn: false)
+    get_config(:report_deps, default: false, check_dsn: false)
   end
 
   defp get_config(key, opts \\ []) when is_atom(key) do


### PR DESCRIPTION
As a temporary fix to #232 / https://github.com/elixir-lang/elixir/issues/7699