### PR TITLE
Possible Typo on Sentry.Context URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Sentry uses the [hackney HTTP client](https://github.com/benoitc/hackney) for HT
 
 Sentry has multiple options for including contextual information. They are organized into "Tags", "User", and "Extra", and Sentry's documentation on them is [here](https://docs.sentry.io/learn/context/).  Breadcrumbs are a similar concept and Sentry's documentation covers them [here](https://docs.sentry.io/learn/breadcrumbs/).
 
-In Elixir this can be complicated due to processes being isolated from one another. Tags context can be set globally through configuration, and all contexts can be set within a process, and on individual events.  If an event is sent within a process that has some context configured it will include that context in the event.  Examples of each are below, and for more information see the documentation of [Sentry.Context](https://hexdocs.pm/sentry/Sentry.html#module-filtering-exceptions).
+In Elixir this can be complicated due to processes being isolated from one another. Tags context can be set globally through configuration, and all contexts can be set within a process, and on individual events.  If an event is sent within a process that has some context configured it will include that context in the event.  Examples of each are below, and for more information see the documentation of [Sentry.Context](https://hexdocs.pm/sentry/Sentry.Context.html).
 
 ```elixir
 # Global Tags context via configuration:


### PR DESCRIPTION
This is a minor thing but I'm not sure the URL of Sentry.Context is correctly linked.
