### PR TITLE
remove poison from applications list

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Sentry.Mixfile do
   def application do
     [
       mod: {Sentry, []},
-      applications: [:hackney, :poison, :logger]
+      applications: [:hackney, :logger]
     ]
   end
 


### PR DESCRIPTION
Hey there, I'm getting `** (Mix) Could not start application poison: could not find application file: poison.app`. My app uses Jason, so I'm using Jason with sentry as well. Maybe poison isn't needed in the app start list? Thanks!