### PR TITLE
skip sending error in endpoint if Phoenix.Router.NoRouteError

### DIFF
--- a/lib/sentry/phoenix_endpoint.ex
+++ b/lib/sentry/phoenix_endpoint.ex
@@ -28,6 +28,9 @@ defmodule Sentry.Phoenix.Endpoint do
         try do
           super(conn, opts)
         catch
+          kind, %Phoenix.Router.NoRouteError{} ->
+            :erlang.raise(kind, %Phoenix.Router.NoRouteError{}, __STACKTRACE__)
+
           kind, reason ->
             stacktrace = __STACKTRACE__
             request = Sentry.Plug.build_request_interface_data(conn, [])


### PR DESCRIPTION
Similar to the way we do for [Sentry.Plug](https://github.com/getsentry/sentry-elixir/blob/470b2e4cd02596f173e709cf698ff6f20ae62326/lib/sentry/plug.ex#L120)