### PR TITLE
Convenience function for capturing any exception produced by an anonymous function

### DIFF
--- a/lib/sentry.ex
+++ b/lib/sentry.ex
@@ -110,6 +110,33 @@ defmodule Sentry do
   end
 
   @doc """
+  Captures and retrows exception raised in the callback function.
+  """
+  @spec capture_exception((() -> any())) :: send_result
+  def capture_exception(fun) do
+    fun.()
+  rescue
+    e ->
+      stacktrace = __STACKTRACE__
+
+      Sentry.capture_exception(e, stacktrace: stacktrace)
+
+      Kernel.reraise(e)
+  catch
+    kind, reason ->
+      stacktrace = __STACKTRACE__
+      exception = Exception.normalize(kind, reason, stacktrace)
+
+      Sentry.capture_exception(
+        exception,
+        stacktrace: stacktrace,
+        error_type: kind
+      )
+
+      :erlang.raise(kind, reason, stacktrace)
+  end
+
+  @doc """
   Parses and submits an exception to Sentry if current environment is in included_environments.
   `opts` argument is passed as the second argument to `Sentry.send_event/2`.
   """


### PR DESCRIPTION
A common pattern we found useful in our services is to wrap relevant code segments
in a `capture` function that logs errors and reraises them for further processing.

Example usage:

``` elixir
Sentry.capture_exception(fn ->
  1 / 0
end)
```

The above example would send the exception to Sentry.