### PR TITLE
Adjust inspect options for stacktrace arguments for increased visibility.

### DIFF
--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -255,7 +255,7 @@ defmodule Sentry.Event do
   def args_from_stacktrace([{_m, _f, a, _} | _]) when is_list(a) do
     Enum.with_index(a)
     |> Enum.into(%{}, fn {arg, index} ->
-      {"arg#{index}", inspect(arg)}
+      {"arg#{index}", inspect(arg, limit: :infinity, pretty: true, structs: false, width: 0)}
     end)
   end
 


### PR DESCRIPTION
Hi! We've been using this or a while since the regular inspect would cut off our stack traces if they were too long.