### PR TITLE
Allow configuration of Sentry log level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ erl_crash.dump
 *.ez
 /doc
 .DS_Store
+.elixir_ls/

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@
 erl_crash.dump
 *.ez
 /doc
-.DS_Store
-.elixir_ls/

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ For optional settings check the [docs](https://hexdocs.pm/sentry/readme.html).
 | `source_code_path_pattern` | False  | `"**/*.ex"` | |
 | `filter` | False | | Module where the filter rules are defined (see [Filtering Exceptions](https://hexdocs.pm/sentry/Sentry.html#module-filtering-exceptions)) |
 | `json_library` | False | `Jason` | |
-| `log_level` | False | `:warn` | |
+| `log_level` | False | `:warn` | This sets the log level used when Sentry fails to send an event due to an invalid event or API error. |
 
 An example production config might look like this:
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ For optional settings check the [docs](https://hexdocs.pm/sentry/readme.html).
 | `source_code_path_pattern` | False  | `"**/*.ex"` | |
 | `filter` | False | | Module where the filter rules are defined (see [Filtering Exceptions](https://hexdocs.pm/sentry/Sentry.html#module-filtering-exceptions)) |
 | `json_library` | False | `Jason` | |
+| `log_level` | False | `:warn` | |
 
 An example production config might look like this:
 

--- a/lib/sentry.ex
+++ b/lib/sentry.ex
@@ -104,6 +104,7 @@ defmodule Sentry do
     ]
 
     validate_json_config!()
+    validate_log_level_config!()
 
     opts = [strategy: :one_for_one, name: Sentry.Supervisor]
     Supervisor.start_link(children, opts)
@@ -149,7 +150,7 @@ defmodule Sentry do
   def send_event(event, opts \\ [])
 
   def send_event(%Event{message: nil, exception: nil}, _opts) do
-    Logger.warn("Sentry: unable to parse exception")
+    Logger.log(Config.log_level(), "Sentry: unable to parse exception")
 
     :ignored
   end
@@ -190,6 +191,16 @@ defmodule Sentry do
                     """),
                     __STACKTRACE__
         end
+    end
+  end
+
+  defp validate_log_level_config!() do
+    value = Config.log_level()
+
+    if value in Config.permitted_log_level_values() do
+      :ok
+    else
+      raise ArgumentError.exception("#{inspect(value)} is not a valid :log_level configuration")
     end
   end
 end

--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -336,9 +336,12 @@ defmodule Sentry.Client do
   end
 
   defp log_api_error(body) do
-    Logger.warn(fn ->
-      ["Failed to send Sentry event.", ?\n, body]
-    end)
+    Logger.log(
+      Config.log_level(),
+      fn ->
+        ["Failed to send Sentry event.", ?\n, body]
+      end
+    )
   end
 
   defp sleep(1), do: :timer.sleep(2000)

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -130,10 +130,7 @@ defmodule Sentry.Config do
   end
 
   def log_level do
-    case get_config(:log_level, default: :warn, check_dsn: false) do
-      value when value in @permitted_log_level_values -> value
-      value -> value
-    end
+    get_config(:log_level, default: :warn, check_dsn: false)
   end
 
   def permitted_log_level_values, do: @permitted_log_level_values

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -14,6 +14,11 @@ defmodule Sentry.Config do
   @default_context_lines 3
   @default_sample_rate 1.0
 
+  @permitted_log_level_atom_values ~w(debug info warn error)a
+  @permitted_log_level_string_values ~w(debug info warn error)
+  @permitted_log_level_values @permitted_log_level_atom_values ++
+                                @permitted_log_level_string_values
+
   def validate_config! do
   end
 
@@ -126,6 +131,16 @@ defmodule Sentry.Config do
   def json_library do
     get_config(:json_library, default: Jason, check_dsn: false)
   end
+
+  def log_level do
+    case get_config(:log_level, default: :warn, check_dsn: false) do
+      value when value in @permitted_log_level_atom_values -> value
+      value when value in @permitted_log_level_string_values -> String.to_existing_atom(value)
+      value -> value
+    end
+  end
+
+  def permitted_log_level_values, do: @permitted_log_level_values
 
   defp get_config(key, opts \\ []) when is_atom(key) do
     default = Keyword.get(opts, :default)

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -14,10 +14,7 @@ defmodule Sentry.Config do
   @default_context_lines 3
   @default_sample_rate 1.0
 
-  @permitted_log_level_atom_values ~w(debug info warn error)a
-  @permitted_log_level_string_values ~w(debug info warn error)
-  @permitted_log_level_values @permitted_log_level_atom_values ++
-                                @permitted_log_level_string_values
+  @permitted_log_level_values ~w(debug info warn error)a
 
   def validate_config! do
   end
@@ -134,8 +131,7 @@ defmodule Sentry.Config do
 
   def log_level do
     case get_config(:log_level, default: :warn, check_dsn: false) do
-      value when value in @permitted_log_level_atom_values -> value
-      value when value in @permitted_log_level_string_values -> String.to_existing_atom(value)
+      value when value in @permitted_log_level_values -> value
       value -> value
     end
   end


### PR DESCRIPTION
Implements the feature of #304

Because `Logger` has explicit permitted macro levels, I’ve put in some validation.

We’re currently experiencing periodic spike protection and the Sentry logging is also causing some spiking on our log service, too (and because of the `?\n` in the log, each Sentry send failure is taking up three log lines). I’d like to handle such logging through `after_send_event`.