### PR TITLE
Fixes dialyzer warning when using the Sentry.Phoenix.Endpoint macro

### DIFF
--- a/lib/sentry/phoenix_endpoint.ex
+++ b/lib/sentry/phoenix_endpoint.ex
@@ -36,13 +36,14 @@ defmodule Sentry.Phoenix.Endpoint do
             request = Sentry.Plug.build_request_interface_data(conn, [])
             exception = Exception.normalize(kind, reason, stacktrace)
 
-            Sentry.capture_exception(
-              exception,
-              stacktrace: stacktrace,
-              request: request,
-              event_source: :endpoint,
-              error_type: kind
-            )
+            _ =
+              Sentry.capture_exception(
+                exception,
+                stacktrace: stacktrace,
+                request: request,
+                event_source: :endpoint,
+                error_type: kind
+              )
 
             :erlang.raise(kind, reason, stacktrace)
         end

--- a/lib/sentry/plug.ex
+++ b/lib/sentry/plug.ex
@@ -171,22 +171,12 @@ if Code.ensure_loaded?(Plug) do
         headers: handle_data(conn, header_scrubber),
         env: %{
           "REMOTE_ADDR" => remote_address(conn.remote_ip),
-          "REMOTE_PORT" => remote_port(conn),
+          "REMOTE_PORT" => Plug.Conn.get_peer_data(conn).port,
           "SERVER_NAME" => conn.host,
           "SERVER_PORT" => conn.port,
           "REQUEST_ID" => Plug.Conn.get_resp_header(conn, request_id) |> List.first()
         }
       }
-    end
-
-    defp remote_port(conn) do
-      case Plug.Conn.get_peer_data(conn) do
-        %{port: port} ->
-          port
-
-        _ ->
-          ""
-      end
     end
 
     defp remote_address(address) do


### PR DESCRIPTION
When using the Sentry.Phoenix.Endpoint on a Phoenix project with Dialyzer, set with the `:unmatched_returns` flag, Dialyzer will complain with a `../endpoint.ex:1:umatched_return`, with the expectation of the 'send_result()' type signature.

By assigning the return of `Sentry.capture_exception/2` to `_`, projects using this macro won't see the warning.