### PR TITLE
Docs: Add parens to File.cwd! to prevent confusion

### DIFF
--- a/lib/sentry/sources.ex
+++ b/lib/sentry/sources.ex
@@ -14,7 +14,7 @@ defmodule Sentry.Sources do
   * `:enable_source_code_context` - when `true`, enables reporting source code
     alongside exceptions.
   * `:root_source_code_path` - The path from which to start recursively reading files from.
-    Should usually be set to `File.cwd!`.
+    Should usually be set to `File.cwd!()`.
   * `:context_lines` - The number of lines of source code before and after the line that
     caused the exception to be included.  Defaults to `3`.
   * `:source_code_exclude_patterns` - a list of Regex expressions used to exclude file paths that
@@ -28,7 +28,7 @@ defmodule Sentry.Sources do
       config :sentry,
         dsn: "https://public:secret@app.getsentry.com/1",
         enable_source_code_context: true,
-        root_source_code_path: File.cwd!,
+        root_source_code_path: File.cwd!(),
         context_lines: 5
 
   ### Source code storage


### PR DESCRIPTION
There seems to be a bug in the documentation engine that results in the docs coming out wrong. It is inserting parens into `File.cwd!` at the wrong position, creating invalid syntax.

![image](https://user-images.githubusercontent.com/2864935/58414064-9246f500-807a-11e9-89fa-d932148d1bb0.png)
![image](https://user-images.githubusercontent.com/2864935/58414109-ba365880-807a-11e9-8378-4dffaef222fd.png)

I didn't find an issue about this in `ex_doc`, but I didn't look very closely. It might be that this has been fixed in a release of `ex_doc` and you might not need this PR at all if you update. Or maybe you guys should open an issue yourself :man_shrugging: 