### PR TITLE
Check that DSN is binary before trying URI.parse

### DIFF
--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -222,7 +222,8 @@ defmodule Sentry.Client do
   def get_dsn do
     dsn = Config.dsn()
 
-    with %URI{userinfo: userinfo, host: host, port: port, path: path, scheme: protocol}
+    with dsn when is_binary(dsn) <- dsn,
+         %URI{userinfo: userinfo, host: host, port: port, path: path, scheme: protocol}
          when is_binary(path) and is_binary(userinfo) <- URI.parse(dsn),
          [public_key, secret_key] <- keys_from_userinfo(userinfo),
          [_, binary_project_id] <- String.split(path, "/"),

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -65,6 +65,22 @@ defmodule Sentry.ClientTest do
     end)
   end
 
+  test "errors on nil dsn" do
+    modify_env(:sentry, dsn: nil)
+
+    capture_log(fn ->
+      assert :error = Sentry.Client.get_dsn()
+    end)
+  end
+
+  test "errors on atom dsn" do
+    modify_env(:sentry, dsn: :error)
+
+    capture_log(fn ->
+      assert :error = Sentry.Client.get_dsn()
+    end)
+  end
+
   test "logs api errors" do
     bypass = Bypass.open()
 


### PR DESCRIPTION
I was setting up Sentry with DSN read from env, and got some crashes when the required variable was not set, because `URI.parse` was being called with `nil`, which doesn't match.

To fix this and get a nicer warning message instead of an exception (like #218), I added a `is_binary` guard in `Sentry.Client.get_dsn`. Plus a couple of tests to verify that it works as intended.