### PR TITLE
Add docs for Sentry.Context

### DIFF
--- a/test/context_test.exs
+++ b/test/context_test.exs
@@ -2,6 +2,8 @@ defmodule Sentry.ContextTest do
   use ExUnit.Case
   import Sentry.TestEnvironmentHelper
 
+  doctest Sentry.Context, except: [{:add_breadcrumb, 1}]
+
   test "storing extra context appears when generating event" do
     Sentry.Context.set_extra_context(%{"key" => "345"})
 


### PR DESCRIPTION
## Summary
- Adds docs for all functions in the `Sentry.Context` module.
- Adds typespecs for all public functions in the `Sentry.Context` module.
- Outputs a more straightforward ArgumentError when Sentry.Context.add_breadcrumb/1 receives a list which is not a keyword list.

Previous Behavior:
```
iex(1)> Sentry.Context.add_breadcrumb(["dog"])
** (ArgumentError) argument error
    (stdlib) :maps.from_list(["dog"])
    (elixir) lib/map.ex:174: Map.new/1
    (sentry) lib/sentry/context.ex:225: Sentry.Context.add_breadcrumb/1
```
New Behavior:
```
iex(2)> Sentry.Context.add_breadcrumb(["dog"])
** (ArgumentError) Sentry.Context.add_breadcrumb/1 only accepts keyword lists or maps.
Received a non-keyword list.

    (sentry) lib/sentry/context.ex:236: Sentry.Context.add_breadcrumb/1
```