### PR TITLE
Docs - clarify opts for Sentry.Client.send_event/2

### DIFF
--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -60,6 +60,7 @@ defmodule Sentry.Client do
   ### Options
   * `:result` - Allows specifying how the result should be returned. Options include `:sync`, `:none`, and `:async`.  `:sync` will make the API call synchronously, and return `{:ok, event_id}` if successful.  `:none` sends the event from an unlinked child process under `Sentry.TaskSupervisor` and will return `{:ok, ""}` regardless of the result.  `:async` will start an unlinked task and return a tuple of `{:ok, Task.t}` on success where the Task can be awaited upon to receive the result asynchronously.  When used in an OTP behaviour like GenServer, the task will send a message that needs to be matched with `GenServer.handle_info/2`.  See `Task.Supervisor.async_nolink/2` for more information.  `:async` is the default.
   * `:sample_rate` - The sampling factor to apply to events.  A value of 0.0 will deny sending any events, and a value of 1.0 will send 100% of events.
+  * Other options, such as `:stacktrace` or `:extra` will be passed to `Sentry.Event.create_event/1` downstream. See `Sentry.Event.create_event/1` for available options.
   """
   @spec send_event(Event.t()) :: send_event_result
   def send_event(%Event{} = event, opts \\ []) do


### PR DESCRIPTION
Fixes #280 

The docs demonstrate `Sentry.capture_exception/2` usage with `:stacktrace` and `:extra` opts which will be passed to `create_event`, but don't explicitly state this in the docs. What do you think?

Thanks!