### PR TITLE
No logger logging

### DIFF
--- a/lib/mix/tasks/sentry.send_test_event.ex
+++ b/lib/mix/tasks/sentry.send_test_event.ex
@@ -58,8 +58,8 @@ defmodule Mix.Tasks.Sentry.SendTestEvent do
         {:ok, id} ->
           Mix.shell().info("Test event sent!  Event ID: #{id}")
 
-        :error ->
-          Mix.shell().info("Error sending event!")
+        {:error, reason} ->
+          Mix.shell().info("Error sending event: #{inspect(reason)}")
 
         :excluded ->
           Mix.shell().info("No test event was sent because the event was excluded by a filter")

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -44,41 +44,31 @@ defmodule Sentry.ClientTest do
   test "errors on bad public keys" do
     modify_env(:sentry, dsn: "https://app.getsentry.com/1")
 
-    capture_log(fn ->
-      assert :error = Sentry.Client.get_dsn()
-    end)
+    assert {:error, :invalid_dsn} = Sentry.Client.get_dsn()
   end
 
   test "errors on non-integer project_id" do
     modify_env(:sentry, dsn: "https://public:secret@app.getsentry.com/Mitchell")
 
-    capture_log(fn ->
-      assert :error = Sentry.Client.get_dsn()
-    end)
+    assert {:error, :invalid_dsn} = Sentry.Client.get_dsn()
   end
 
   test "errors on no project_id" do
     modify_env(:sentry, dsn: "https://public:secret@app.getsentry.com")
 
-    capture_log(fn ->
-      assert :error = Sentry.Client.get_dsn()
-    end)
+    assert {:error, :invalid_dsn} = Sentry.Client.get_dsn()
   end
 
   test "errors on nil dsn" do
     modify_env(:sentry, dsn: nil)
 
-    capture_log(fn ->
-      assert :error = Sentry.Client.get_dsn()
-    end)
+    assert {:error, :invalid_dsn} = Sentry.Client.get_dsn()
   end
 
   test "errors on atom dsn" do
     modify_env(:sentry, dsn: :error)
 
-    capture_log(fn ->
-      assert :error = Sentry.Client.get_dsn()
-    end)
+    assert {:error, :invalid_dsn} = Sentry.Client.get_dsn()
   end
 
   test "logs api errors" do
@@ -114,7 +104,7 @@ defmodule Sentry.ClientTest do
     unencodable_event = %Sentry.Event{message: "error", level: {:a, :b}}
 
     capture_log(fn ->
-      assert :error = Sentry.Client.send_event(unencodable_event)
+      assert {:error, {:invalid_json, _}} = Sentry.Client.send_event(unencodable_event)
     end)
   end
 

--- a/test/mix/sentry.send_test_event_test.exs
+++ b/test/mix/sentry.send_test_event_test.exs
@@ -55,7 +55,7 @@ defmodule Mix.Tasks.Sentry.SendTestEventTest do
            """
   end
 
-  test "handles :error when Sentry server is failing" do
+  test "handles error when Sentry server is failing" do
     bypass = Bypass.open()
 
     Bypass.expect(bypass, fn conn ->
@@ -78,7 +78,7 @@ defmodule Mix.Tasks.Sentry.SendTestEventTest do
                     hackney_opts: [recv_timeout: 50]
 
                     Sending test event...
-                    Error sending event!
+                    Error sending event: "Received 500 from Sentry server: "
                     """
            end) =~ "Failed to send Sentry event"
   end

--- a/test/sentry_test.exs
+++ b/test/sentry_test.exs
@@ -55,9 +55,9 @@ defmodule SentryTest do
       dsn: "http://public:secret@localhost:#{bypass.port}/1"
     )
 
-    assert capture_log(fn ->
-             assert :error = Sentry.capture_message("error", [])
-           end) =~ "Failed to send Sentry event"
+    capture_log(fn ->
+      assert {:error, _} = Sentry.capture_message("error", [])
+    end)
 
     Bypass.pass(bypass)
   end

--- a/test/support/test_client.exs
+++ b/test/support/test_client.exs
@@ -26,7 +26,7 @@ defmodule Sentry.TestClient do
               end
             )
 
-            :error
+            {:error, error}
         end
 
       {:error, error} ->
@@ -35,7 +35,7 @@ defmodule Sentry.TestClient do
           "Error sending in Sentry.TestClient: #{inspect(error)}"
         )
 
-        :error
+        {:error, error}
     end
   end
 end


### PR DESCRIPTION
The cause of #371 is that logging from within the Sentry.LoggerBackend can deadlock Logger itself. When Logger receives a bunch of messages and can't process them fast enough, it switches into synchronous mode (default is queue length of 20). This means when Sentry.LoggerBackend tries to log while Logger is in synchronous mode, it will deadlock because Sentry.LoggerBackend is waiting for Logger to return a response while Logger is waiting for Sentry.LoggerBackend to process messages.

I started a little bit of a refactor in how Client handles errors to separate the Logger pieces from the Client to potentially make changes going forward, but the fix is relatively straightforward for now in that if the event_source on the event is the LoggerBackend, we don't log.

I'm not expecting many users to see this, especially in production, but this is dangerous behavior that should not be possible 🙂

closes #371