### PR TITLE
Sentry.LoggerBackend - allow all json encodable logger metadata

### DIFF
--- a/lib/sentry/logger_backend.ex
+++ b/lib/sentry/logger_backend.ex
@@ -142,7 +142,10 @@ defmodule Sentry.LoggerBackend do
   defp build_logger_metadata(meta) do
     meta
     |> Enum.filter(fn {_key, value} ->
-      is_binary(value) || is_atom(value) || is_number(value)
+      case Jason.encode(value) do
+        {:ok, _} -> true
+        _ -> false
+      end
     end)
     |> Enum.into(%{})
   end


### PR DESCRIPTION
This change allows all json encodable values to be passed as logger metadata. 