### PR TITLE
fix request url port in payloads for HTTPS requests

### DIFF
--- a/lib/sentry/plug.ex
+++ b/lib/sentry/plug.ex
@@ -230,7 +230,7 @@ if Code.ensure_loaded?(Plug) do
         |> Plug.Conn.fetch_query_params()
 
       %{
-        url: "#{conn.scheme}://#{conn.host}:#{conn.port}#{conn.request_path}",
+        url: Plug.Conn.request_url(conn),
         method: conn.method,
         data: handle_data(conn, body_scrubber),
         query_string: conn.query_string,

--- a/test/plug_test.exs
+++ b/test/plug_test.exs
@@ -198,6 +198,26 @@ defmodule Sentry.PlugTest do
     assert body =~ ~s{"title":"abc-123"}
   end
 
+  test "request url" do
+    # Default ports
+    conn = conn(:get, "http://www.example.com:80/error_route")
+    %{url: url} = Sentry.Plug.build_request_interface_data(conn, [])
+    assert url == "http://www.example.com/error_route"
+
+    conn = conn(:get, "https://www.example.com:443/error_route")
+    %{url: url} = Sentry.Plug.build_request_interface_data(conn, [])
+    assert url == "https://www.example.com/error_route"
+
+    # Custom ports
+    conn = conn(:get, "http://www.example.com:1234/error_route")
+    %{url: url} = Sentry.Plug.build_request_interface_data(conn, [])
+    assert url == "http://www.example.com:1234/error_route"
+
+    conn = conn(:get, "https://www.example.com:1234/error_route")
+    %{url: url} = Sentry.Plug.build_request_interface_data(conn, [])
+    assert url == "https://www.example.com:1234/error_route"
+  end
+
   defp update_req_cookie(conn, name, value) do
     req_headers =
       conn.req_headers


### PR DESCRIPTION
We have noticed invalid request urls for HTTPS requests (like https://mysite.com:80)
This is because request URLs are built from conn properties like
"#{conn.scheme}://#{conn.host}:#{conn.port}#{conn.request_path}"

Plug.Conn does not allow to configure port for HTTPS requests (conn.port is always 80 and ignored) when using Plug.SSL. https://hexdocs.pm/plug/Plug.SSL.html

It is better to use Plug.Conn.request_url() instead of building request URL manually