### PR TITLE
async_nolink -> start_child

### DIFF
--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -109,7 +109,7 @@ defmodule Sentry.Client do
     case get_headers_and_endpoint() do
       {endpoint, auth_headers} when is_binary(endpoint) ->
         {:ok,
-         Task.Supervisor.async_nolink(Sentry.TaskSupervisor, fn ->
+         Task.Supervisor.start_child(Sentry.TaskSupervisor, fn ->
            try_request(endpoint, auth_headers, {event, body})
            |> maybe_call_after_send_event(event)
          end)}


### PR DESCRIPTION
Since we don't await, it is not necessary to use an async function.