### PR TITLE
Logger Backend improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Enhancements
   * Cache environment config in application config (#393)
+  * Allow configuring LoggerBackend to send all messages, not just exceptions (e.g. `Logger.error("I am an error message")`)
 
 * Bug Fixes
   * fix request url port in payloads for HTTPS requests  (#391)
@@ -12,10 +13,11 @@
   * Change default `included_environments` to only include `:prod` by default (#370)
   * Change default event send type to :none instead of :async (#341)
   * Make hackney an optional dependency, and simplify Sentry.HTTPClient behaviour (#400)
-  * Use Logger.metadata for Sentry.Context, no longer return metadata values on set_* functions, and rename `set_http_context` to `set_request_context`
-  * Move excluded exceptions from Sentry.Plug to Sentry.DefaultEventFilter
-  * Remove Sentry.Plug and Sentry.Phoenix.Endpoint in favor of Sentry.PlugContext and Sentry.PlugCapture
-  * Remove feedback form rendering and configuration
+  * Use Logger.metadata for Sentry.Context, no longer return metadata values on set_* functions, and rename `set_http_context` to `set_request_context` (#401)
+  * Move excluded exceptions from Sentry.Plug to Sentry.DefaultEventFilter (#402)
+  * Remove Sentry.Plug and Sentry.Phoenix.Endpoint in favor of Sentry.PlugContext and Sentry.PlugCapture (#402)
+  * Remove feedback form rendering and configuration (#402)
+  * Logger metadata is now specified by key in LoggerBackend instead of enabled/disabled
 
 ## 7.2.4 (2020-03-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   * Remove Sentry.Plug and Sentry.Phoenix.Endpoint in favor of Sentry.PlugContext and Sentry.PlugCapture (#402)
   * Remove feedback form rendering and configuration (#402)
   * Logger metadata is now specified by key in LoggerBackend instead of enabled/disabled
+  * `Sentry.capture_exception/1` now only accepts exceptions
 
 ## 7.2.4 (2020-03-09)
 

--- a/lib/sentry.ex
+++ b/lib/sentry.ex
@@ -112,7 +112,7 @@ defmodule Sentry do
   Parses and submits an exception to Sentry if current environment is in included_environments.
   `opts` argument is passed as the second argument to `Sentry.send_event/2`.
   """
-  @spec capture_exception(Exception.t() | atom() | {atom(), atom()}, Keyword.t()) :: send_result
+  @spec capture_exception(Exception.t(), Keyword.t()) :: send_result
   def capture_exception(exception, opts \\ []) do
     filter_module = Config.filter()
     event_source = Keyword.get(opts, :event_source)

--- a/lib/sentry/crash_error.ex
+++ b/lib/sentry/crash_error.ex
@@ -1,0 +1,11 @@
+defmodule Sentry.CrashError do
+  defexception [:message]
+
+  def exception({:nocatch, reason}) do
+    %Sentry.CrashError{message: Exception.format_banner(:throw, reason, [])}
+  end
+
+  def exception(reason) do
+    %Sentry.CrashError{message: Exception.format_banner(:exit, reason, [])}
+  end
+end

--- a/lib/sentry/logger_backend.ex
+++ b/lib/sentry/logger_backend.ex
@@ -127,7 +127,7 @@ defmodule Sentry.LoggerBackend do
     end
   end
 
-  defp get_sentry_from_callers([head | tail]) do
+  defp get_sentry_from_callers([head | tail]) when is_pid(head) do
     with {:dictionary, [_ | _] = dictionary} <- :erlang.process_info(head, :dictionary),
          %{sentry: sentry} <- dictionary[:"$logger_metadata$"] do
       sentry

--- a/lib/sentry/logger_backend.ex
+++ b/lib/sentry/logger_backend.ex
@@ -112,7 +112,10 @@ defmodule Sentry.LoggerBackend do
         Sentry.capture_exception(exception, [stacktrace: stacktrace] ++ opts)
 
       {other, stacktrace} when is_list(stacktrace) ->
-        Sentry.capture_exception(Sentry.CrashError.exception(other), [stacktrace: stacktrace] ++ opts)
+        Sentry.capture_exception(
+          Sentry.CrashError.exception(other),
+          [stacktrace: stacktrace] ++ opts
+        )
 
       _ ->
         if state.capture_log_messages do

--- a/lib/sentry/logger_backend.ex
+++ b/lib/sentry/logger_backend.ex
@@ -20,8 +20,8 @@ defmodule Sentry.LoggerBackend do
 
   * `:metadata` - To include non-Sentry Logger metadata in reports, the
   `:metadata` key can be set to a list of keys. Metadata under those keys will
-  be added in the `:extra` context under the `:logger_metadata` key  Defaults
-  to `[]`
+  be added in the `:extra` context under the `:logger_metadata` key. Defaults
+  to `[]`.
 
   * `:level` - The minimum [Logger level](https://hexdocs.pm/logger/Logger.html#module-levels) to send events for.
   Defaults to `:error`.

--- a/lib/sentry/logger_backend.ex
+++ b/lib/sentry/logger_backend.ex
@@ -128,7 +128,7 @@ defmodule Sentry.LoggerBackend do
   end
 
   defp get_sentry_from_callers([head | tail]) do
-    with [_ | _] = dictionary <- :erlang.process_info(head, :dictionary),
+    with {:dictionary, [_ | _] = dictionary} <- :erlang.process_info(head, :dictionary),
          %{sentry: sentry} <- dictionary[:"$logger_metadata$"] do
       sentry
     else

--- a/lib/sentry/logger_backend.ex
+++ b/lib/sentry/logger_backend.ex
@@ -108,11 +108,11 @@ defmodule Sentry.LoggerBackend do
       ] ++ Map.to_list(sentry)
 
     case meta[:crash_reason] do
-      {exception, stacktrace} when is_list(stacktrace) ->
+      {%_{__exception__: true} = exception, stacktrace} when is_list(stacktrace) ->
         Sentry.capture_exception(exception, [stacktrace: stacktrace] ++ opts)
 
-      reason when is_atom(reason) and not is_nil(reason) ->
-        Sentry.capture_exception(reason, opts)
+      {other, stacktrace} when is_list(stacktrace) ->
+        Sentry.capture_exception(Sentry.CrashError.exception(other), [stacktrace: stacktrace] ++ opts)
 
       _ ->
         if state.capture_log_messages do

--- a/lib/sentry/logger_backend.ex
+++ b/lib/sentry/logger_backend.ex
@@ -26,7 +26,7 @@ defmodule Sentry.LoggerBackend do
   * `:level` - The minimum [Logger level](https://hexdocs.pm/logger/Logger.html#module-levels) to send events for.
   Defaults to `:error`.
 
-  * `:send_all_messages` - When `true`, this module will send all Logger
+  * `:capture_log_messages` - When `true`, this module will send all Logger
   messages. Defaults to `false`, which will only send messages with metadata
   that has the shape of an exception and stacktrace.
 
@@ -40,11 +40,11 @@ defmodule Sentry.LoggerBackend do
         # Include metadata added with `Logger.metadata([foo_bar: "value"])`
         metadata: [:foo_bar],
         # Send messages like `Logger.error("error")` to Sentry
-        send_all_messages: true
+        capture_log_messages: true
   """
   @behaviour :gen_event
 
-  defstruct level: :error, metadata: [], excluded_domains: [:cowboy], send_all_messages: false
+  defstruct level: :error, metadata: [], excluded_domains: [:cowboy], capture_log_messages: false
 
   def init(__MODULE__) do
     config = Application.get_env(:logger, __MODULE__, [])
@@ -115,7 +115,7 @@ defmodule Sentry.LoggerBackend do
         Sentry.capture_exception(reason, opts)
 
       _ ->
-        if state.send_all_messages do
+        if state.capture_log_messages do
           try do
             if is_binary(msg), do: msg, else: :unicode.characters_to_binary(msg)
           rescue

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Sentry.Mixfile do
     [
       app: :sentry,
       version: "7.2.4",
-      elixir: "~> 1.7",
+      elixir: "~> 1.10",
       description: "The Official Elixir client for Sentry",
       package: package(),
       deps: deps(),
@@ -31,7 +31,7 @@ defmodule Sentry.Mixfile do
       {:hackney, "~> 1.8 or 1.6.5", optional: true},
       {:jason, "~> 1.1", optional: true},
       {:plug, "~> 1.6", optional: true},
-      {:plug_cowboy, "~> 1.0 or ~> 2.0", optional: true},
+      {:plug_cowboy, "~> 2.3", optional: true},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
       {:ex_doc, "~> 0.21.0", only: :dev},
       {:bypass, "~> 1.0", only: [:test]},

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -32,7 +32,7 @@ defmodule Sentry.EventTest do
     assert event.level == "error"
 
     assert event.message ==
-             "(UndefinedFunctionError) function Sentry.Event.not_a_function/3 is undefined or private"
+             "(UndefinedFunctionError function Sentry.Event.not_a_function/3 is undefined or private)"
 
     assert is_binary(event.server_name)
 

--- a/test/logger_backend_test.exs
+++ b/test/logger_backend_test.exs
@@ -345,8 +345,9 @@ defmodule Sentry.LoggerBackendTest do
     Logger.configure_backend(Sentry.LoggerBackend, level: :error, send_all_messages: false)
   end
 
-  @tag :skip
+  # TODO: update for Elixir 1.10.4 to not manually set :callers and replace with Task
   test "sentry metadata is retrieved from callers" do
+    Logger.configure_backend(Sentry.LoggerBackend, send_all_messages: true)
     bypass = Bypass.open()
     modify_env(:sentry, dsn: "http://public:secret@localhost:#{bypass.port}/1")
     pid = self()
@@ -355,15 +356,17 @@ defmodule Sentry.LoggerBackendTest do
       {:ok, body, conn} = Plug.Conn.read_body(conn)
       json = Jason.decode!(body)
       assert json["user"]["user_id"] == 3
+      assert json["message"] == "error"
       send(pid, "API called")
       Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
     end)
 
     capture_log(fn ->
       Sentry.Context.set_user_context(%{user_id: 3})
+      parent = self()
 
       Task.start(fn ->
-        raise "Error"
+        Logger.error("error", callers: [parent])
       end)
 
       assert_receive("API called")

--- a/test/logger_backend_test.exs
+++ b/test/logger_backend_test.exs
@@ -299,8 +299,8 @@ defmodule Sentry.LoggerBackendTest do
     end)
   end
 
-  test "sends all messages if send_all_messages is true" do
-    Logger.configure_backend(Sentry.LoggerBackend, send_all_messages: true)
+  test "sends all messages if capture_log_messages is true" do
+    Logger.configure_backend(Sentry.LoggerBackend, capture_log_messages: true)
     bypass = Bypass.open()
     modify_env(:sentry, dsn: "http://public:secret@localhost:#{bypass.port}/1")
     pid = self()
@@ -318,11 +318,11 @@ defmodule Sentry.LoggerBackendTest do
       assert_receive("API called")
     end)
   after
-    Logger.configure_backend(Sentry.LoggerBackend, send_all_messages: false)
+    Logger.configure_backend(Sentry.LoggerBackend, capture_log_messages: false)
   end
 
   test "sends warning messages when configured to :warn" do
-    Logger.configure_backend(Sentry.LoggerBackend, level: :warn, send_all_messages: true)
+    Logger.configure_backend(Sentry.LoggerBackend, level: :warn, capture_log_messages: true)
     bypass = Bypass.open()
     modify_env(:sentry, dsn: "http://public:secret@localhost:#{bypass.port}/1")
     pid = self()
@@ -342,12 +342,12 @@ defmodule Sentry.LoggerBackendTest do
       assert_receive("API called")
     end)
   after
-    Logger.configure_backend(Sentry.LoggerBackend, level: :error, send_all_messages: false)
+    Logger.configure_backend(Sentry.LoggerBackend, level: :error, capture_log_messages: false)
   end
 
   # TODO: update for Elixir 1.10.4 to not manually set :callers and replace with Task
   test "sentry metadata is retrieved from callers" do
-    Logger.configure_backend(Sentry.LoggerBackend, send_all_messages: true)
+    Logger.configure_backend(Sentry.LoggerBackend, capture_log_messages: true)
     bypass = Bypass.open()
     modify_env(:sentry, dsn: "http://public:secret@localhost:#{bypass.port}/1")
     pid = self()

--- a/test/plug_capture_test.exs
+++ b/test/plug_capture_test.exs
@@ -100,7 +100,7 @@ defmodule Sentry.PlugCaptureTest do
       {:ok, body, conn} = Plug.Conn.read_body(conn)
       json = Jason.decode!(body)
       assert json["culprit"] == "Sentry.PlugCaptureTest.PhoenixController.error/2"
-      assert json["message"] == "(RuntimeError) PhoenixError"
+      assert json["message"] == "(RuntimeError PhoenixError)"
       Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
     end)
 

--- a/test/plug_capture_test.exs
+++ b/test/plug_capture_test.exs
@@ -208,9 +208,8 @@ defmodule Sentry.PlugCaptureTest do
       Sentry.ExamplePlugApplication.call(conn, [])
     end)
 
-    {event_id, _} = Sentry.get_last_event_id_and_source()
-
     assert_received {:plug_conn, :sent}
+    {event_id, _} = Sentry.get_last_event_id_and_source()
     assert {500, _headers, body} = sent_resp(conn)
     assert body =~ "sentry-cdn"
     assert body =~ event_id

--- a/test/sentry_test.exs
+++ b/test/sentry_test.exs
@@ -61,37 +61,6 @@ defmodule SentryTest do
     Bypass.pass(bypass)
   end
 
-  test "handles three element tuple as stacktrace" do
-    bypass = Bypass.open()
-
-    Bypass.expect(bypass, fn conn ->
-      assert conn.request_path == "/api/1/store/"
-      assert conn.method == "POST"
-      {:ok, body, conn} = Plug.Conn.read_body(conn)
-      {:ok, json} = Jason.decode(body)
-      assert json["culprit"] == "GenServer.call/3"
-      assert List.first(json["exception"])["value"] == "Erlang error: :timeout"
-      Plug.Conn.send_resp(conn, 200, ~s<{"id": "340"}>)
-    end)
-
-    modify_env(
-      :sentry,
-      dsn: "http://public:secret@localhost:#{bypass.port}/1"
-    )
-
-    Process.flag(:trap_exit, true)
-
-    {:ok, pid} = Sentry.TestGenServer.start_link(self())
-    spawn_pid = spawn_link(fn -> GenServer.call(pid, {:sleep, 100}, 0) end)
-
-    receive do
-      {:EXIT, ^spawn_pid, {reason, stack}} ->
-        Sentry.capture_exception(reason, stacktrace: stack)
-    end
-
-    Bypass.pass(bypass)
-  end
-
   test "sets last_event_id_and_source when an event is sent" do
     bypass = Bypass.open()
 

--- a/test/support/test_gen_server.exs
+++ b/test/support/test_gen_server.exs
@@ -15,6 +15,10 @@ defmodule Sentry.TestGenServer do
     send(pid, {:logger_metadata, key, value})
   end
 
+  def add_sentry_breadcrumb(pid, value) do
+    send(pid, {:sentry_breadcrumb, value})
+  end
+
   def invalid_function(pid) do
     send(pid, :invalid_function)
   end
@@ -38,6 +42,11 @@ defmodule Sentry.TestGenServer do
 
   def handle_info({:logger_metadata, key, value}, state) do
     Logger.metadata([{key, value}])
+    {:noreply, state}
+  end
+
+  def handle_info({:sentry_breadcrumb, value}, state) do
+    Sentry.Context.add_breadcrumb(value)
     {:noreply, state}
   end
 


### PR DESCRIPTION
With significant initial work from @josevalim 

- Ignores Plug/Cowboy process crashes by excluding by Logger `:domain`
- Allows sending all messages received by Logger
- Non-Sentry metadata to be included in reports is now specified by a list of keys

closes #383, closes #397 