### PR TITLE
Add plug parsing errors to list of default excluded params

### DIFF
--- a/lib/sentry/default_event_filter.ex
+++ b/lib/sentry/default_event_filter.ex
@@ -3,7 +3,15 @@ defmodule Sentry.DefaultEventFilter do
 
   @moduledoc false
 
-  def exclude_exception?(%x{}, :plug) when x in [Phoenix.Router.NoRouteError] do
+  @ignored_exceptions [
+    Phoenix.Router.NoRouteError,
+    Plug.Parsers.RequestTooLarge,
+    Plug.Parsers.BadEncodingError,
+    Plug.Parsers.ParseError,
+    Plug.Parsers.UnsupportedMediaTypeError
+  ]
+
+  def exclude_exception?(%x{}, :plug) when x in @ignored_exceptions do
     true
   end
 


### PR DESCRIPTION
Phoenix handles these errors by default. In addition, these
errors are not really actionable by the application author, so
they just contribute noise to the Sentry exception list.

This addresses #413 