### PR TITLE
Allow users to configure maximum number of breadcrumbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ The full range of options is the following:
 | `filter` | False | | Module where the filter rules are defined (see [Filtering Exceptions](https://hexdocs.pm/sentry/Sentry.html#module-filtering-exceptions)) |
 | `json_library` | False | `Jason` | |
 | `log_level` | False | `:warn` | This sets the log level used when Sentry fails to send an event due to an invalid event or API error |
+| `max_breadcrumbs` | False | 100 | This sets the maximum number of breadcrumbs to send to Sentry when creating an event |
 
 Sentry uses the [hackney HTTP client](https://github.com/benoitc/hackney) for HTTP requests.  Sentry starts its own hackney pool named `:sentry_pool` with a default connection pool of 50, and a connection timeout of 5000 milliseconds.  The pool can be configured with the `hackney_pool_max_connections` and `hackney_pool_timeout` configuration keys.  If you need to set other [hackney configurations](https://github.com/benoitc/hackney/blob/master/doc/hackney.md#request5) for things like a proxy, using your own pool or response timeouts, the `hackney_opts` configuration is passed directly to hackney for each request.
 

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -143,6 +143,10 @@ defmodule Sentry.Config do
     get_config(:log_level, default: :warn, check_dsn: false)
   end
 
+  def max_breadcrumbs do
+    get_config(:max_breadcrumbs, default: 100, check_dsn: false)
+  end
+
   def permitted_log_level_values, do: @permitted_log_level_values
 
   defp get_config(key, opts \\ []) when is_atom(key) do

--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -126,7 +126,10 @@ defmodule Sentry.Event do
       request_context
       |> Map.merge(Keyword.get(opts, :request, %{}))
 
-    breadcrumbs = Keyword.get(opts, :breadcrumbs, []) ++ breadcrumbs_context
+    breadcrumbs =
+      Keyword.get(opts, :breadcrumbs, [])
+      |> Kernel.++(breadcrumbs_context)
+      |> Enum.take(-1 * Config.max_breadcrumbs())
 
     level = Keyword.get(opts, :level, "error")
 

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -140,6 +140,16 @@ defmodule Sentry.EventTest do
     } = Event.create_event(message: "Test message")
   end
 
+  test "respects the max_breadcrumbs configuration" do
+    breadcrumbs =
+      1..150
+      |> Enum.map(fn x -> %{message: "breadcrumb-#{x}"} end)
+
+    event = Event.create_event(message: "Test message", breadcrumbs: breadcrumbs)
+    assert length(event.breadcrumbs) == 100
+    assert event.breadcrumbs == Enum.take(breadcrumbs, -100)
+  end
+
   test "only sending fingerprint when set" do
     exception = RuntimeError.exception("error")
     event = Sentry.Event.transform_exception(exception, fingerprint: ["hello", "world"])


### PR DESCRIPTION
This configuration option allows a user to specify the maximum number of breadcrumbs when posting events to Sentry. The default value is 100.

This is helpful in situations in which long running processes can add a large number of breadcrumbs resulting in failures to create Sentry events when the message becomes too large.

Fixes #407