### PR TITLE
Kafai  allow setting all as metadata for backend config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,19 @@
 # Changelog
 
+## 8.0.0 (2020-07-13)
+[https://gist.github.com/mitchellhenke/dce120a5515565076b13962ee0be749b](7.x -> 8.0 Upgrade Guide)
+
+* Bug Fixes
+  * Fix documentation for `Sentry.PlugContext` (#410)
+
 ## 8.0.0-rc.2 (2020-07-01)
-Fix trying to transform erlang error coming from PlugCapture (#406)
+* Bug Fixes
+  * Fix trying to transform erlang error coming from PlugCapture (#406)
 
 ## 8.0.0-rc.1 (2020-06-29)
 
-Remove changes that were unintentionally included in build
+* Bug Fixes
+  * Remove changes that were unintentionally included in build
 
 ## 8.0.0-rc.0 (2020-06-24)
 

--- a/lib/sentry/logger_backend.ex
+++ b/lib/sentry/logger_backend.ex
@@ -21,7 +21,7 @@ defmodule Sentry.LoggerBackend do
   * `:metadata` - To include non-Sentry Logger metadata in reports, the
   `:metadata` key can be set to a list of keys. Metadata under those keys will
   be added in the `:extra` context under the `:logger_metadata` key. Defaults
-  to `[]`.
+  to `[]`. Setting :metadata to :all prints all metadata, same as the behaviour for Logger.Backends.Console
 
   * `:level` - The minimum [Logger level](https://hexdocs.pm/logger/Logger.html#module-levels) to send events for.
   Defaults to `:error`.
@@ -143,6 +143,15 @@ defmodule Sentry.LoggerBackend do
 
   defp excluded_domain?([head | _], state), do: head in state.excluded_domains
   defp excluded_domain?(_, _), do: false
+
+  defp logger_metadata(meta, %{metadata: :all}) do
+    # exclude unserialazble default key value set by Logger
+    meta
+    |> Enum.reject(
+      &(elem(&1, 0) in [:pid, :gl, :crash_reason, :function, :mfa, :report_cb, :error_logger, :sentry])
+    )
+    |> Enum.into(%{})
+  end
 
   defp logger_metadata(meta, state) do
     for key <- state.metadata,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Sentry.Mixfile do
   def project do
     [
       app: :sentry,
-      version: "8.0.0-rc.2",
+      version: "8.0.0",
       elixir: "~> 1.10",
       description: "The Official Elixir client for Sentry",
       package: package(),


### PR DESCRIPTION
I branched off from 8.0.0 but it looks like some change from 8.0.0 is not merged to master HEAD yet so this PR also contains some of those change

This PR is to allow use set `metadata: :all` in config, same as the current behaviour for Logger.Backend.Console(https://hexdocs.pm/logger/Logger.html#module-console-backend).

Currently, I hard-coded list of key to be excluded when metadata set as all. I am not sure if you find this approach too dirty.
Another approach similar as Logger.console is to just exclude field that cannot be serialized in meaningful way like pid, func. But that will require changing more code in `Sentry.Client.encode_and_send`. So I decided to make a small PR first to see what you guys think.

Thank you.
