### PR TITLE
 allow setting all as metadata for Logger.Backend config

### DIFF
--- a/lib/sentry/logger_backend.ex
+++ b/lib/sentry/logger_backend.ex
@@ -21,7 +21,7 @@ defmodule Sentry.LoggerBackend do
   * `:metadata` - To include non-Sentry Logger metadata in reports, the
   `:metadata` key can be set to a list of keys. Metadata under those keys will
   be added in the `:extra` context under the `:logger_metadata` key. Defaults
-  to `[]`.
+  to `[]`. Setting :metadata to :all prints all metadata, same as the behaviour for Logger.Backends.Console
 
   * `:level` - The minimum [Logger level](https://hexdocs.pm/logger/Logger.html#module-levels) to send events for.
   Defaults to `:error`.
@@ -143,6 +143,24 @@ defmodule Sentry.LoggerBackend do
 
   defp excluded_domain?([head | _], state), do: head in state.excluded_domains
   defp excluded_domain?(_, _), do: false
+
+  defp logger_metadata(meta, %{metadata: :all}) do
+    # exclude unserialazble default key value set by Logger
+    meta
+    |> Enum.reject(
+      &(elem(&1, 0) in [
+          :pid,
+          :gl,
+          :crash_reason,
+          :function,
+          :mfa,
+          :report_cb,
+          :error_logger,
+          :sentry
+        ])
+    )
+    |> Enum.into(%{})
+  end
 
   defp logger_metadata(meta, state) do
     for key <- state.metadata,


### PR DESCRIPTION
I branched off from 8.0.0 but it looks like some change from 8.0.0 is not merged to master HEAD yet so this PR also contains some of those change

This PR is to allow use set metadata: :all in config, same as the current behaviour for Logger.Backend.Console(https://hexdocs.pm/logger/Logger.html#module-console-backend).

Currently, I hard-coded list of key to be excluded when metadata set as all. I am not sure if you find this approach too dirty.
Another approach similar as Logger.console is to just exclude field that cannot be serialized in meaningful way like pid, func. But that will require changing more code in Sentry.Client.encode_and_send. So I decided to make a small PR first to see what you guys think.

Thank you.