### PR TITLE
Fix incorrect gathering mix deps

### DIFF
--- a/lib/mix/tasks/sentry.send_test_event.ex
+++ b/lib/mix/tasks/sentry.send_test_event.ex
@@ -52,7 +52,7 @@ defmodule Mix.Tasks.Sentry.SendTestEvent do
       result =
         "Testing sending Sentry event"
         |> RuntimeError.exception()
-        |> Sentry.capture_exception(result: :sync)
+        |> Sentry.capture_exception(result: :sync, mix_deps: Sentry.Util.mix_deps())
 
       case result do
         {:ok, id} ->

--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -63,13 +63,6 @@ defmodule Sentry.Event do
   @source_code_context_enabled Config.enable_source_code_context()
   @source_files if(@source_code_context_enabled, do: Sentry.Sources.load_files(), else: nil)
 
-  @enable_deps_reporting Config.report_deps()
-  @deps if(
-          @enable_deps_reporting,
-          do: Util.mix_deps(),
-          else: []
-        )
-
   @doc """
   Creates an Event struct out of context collected and options
   ## Options

--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -139,6 +139,8 @@ defmodule Sentry.Event do
 
     env = Config.environment_name()
 
+    mix_deps = Keyword.get(opts, :mix_deps, [])
+
     %Event{
       culprit: culprit_from_stacktrace(stacktrace),
       message: message,
@@ -158,7 +160,7 @@ defmodule Sentry.Event do
       breadcrumbs: breadcrumbs,
       request: request,
       fingerprint: fingerprint,
-      modules: Util.mix_deps_versions(@deps),
+      modules: Util.mix_deps_versions(mix_deps),
       event_source: event_source
     }
     |> add_metadata()

--- a/lib/sentry/util.ex
+++ b/lib/sentry/util.ex
@@ -27,8 +27,11 @@ defmodule Sentry.Util do
 
   @spec mix_deps() :: list(atom())
   def mix_deps do
+    Mix.Project.get() |> IO.inspect()
+
     Mix.Project.deps_paths()
     |> Map.keys()
+    |> IO.inspect()
   end
 
   @spec mix_deps_versions(list(atom())) :: map()


### PR DESCRIPTION
The problems is the library get mix deps inside the module which it get mix deps of the library not the target project. Fixes it by:

* Attach mix deps gathering when calling `use Sentry.PlugCapture`. 
* Get mix deps when user calling `mix sentry.send_test_event`. 

Fixes #415 