### PR TITLE
Fix dialyzer reporting unmatched_return for Sentry.PlugCapture

### DIFF
--- a/lib/sentry/plug_capture.ex
+++ b/lib/sentry/plug_capture.ex
@@ -39,11 +39,11 @@ defmodule Sentry.PlugCapture do
         rescue
           e in Plug.Conn.WrapperError ->
             exception = Exception.normalize(:error, e.reason, e.stack)
-            Sentry.capture_exception(exception, stacktrace: e.stack, event_source: :plug)
+            _ = Sentry.capture_exception(exception, stacktrace: e.stack, event_source: :plug)
             Plug.Conn.WrapperError.reraise(e)
 
           e ->
-            Sentry.capture_exception(e, stacktrace: __STACKTRACE__, event_source: :plug)
+            _ = Sentry.capture_exception(e, stacktrace: __STACKTRACE__, event_source: :plug)
             :erlang.raise(:error, e, __STACKTRACE__)
         end
       end


### PR DESCRIPTION
Hello

I've got a project with stricter dialyzer settings:
```
dialyzer: [
        ...
        flags: [
          :error_handling,
          :race_conditions,
          :underspecs,
          :unmatched_returns
        ]
      ],
```
and for Phoenix Endpoint module I've got warning:
```
lib/app_web/endpoint.ex:1:unmatched_return
The expression produces a value of type:

  :excluded
  | :ignored
  | :unsampled
  | {:error, :invalid_dsn | {:invalid_json, _}}
  | {:ok, <<>> | %Task{:owner => pid(), :pid => nil | pid(), :ref => reference()}}

but this value is unmatched.
```

I cannot silence `use Sentry.PlugCapture` for dialyzer the usual way with `_ =`, only `dialyzer.ignore-warnings` can shut it.
That happens because Sentry.capture_exception is returning multiple values.

Would you accept fix like that? 
Another approach would be to have capture_exception function that returns just single atom but I'm not sure what would be a right name for it. 