### PR TITLE
Updates Sentry.Sources to support multiple source code root paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ config :sentry,
   environment_name: Mix.env(),
   included_environments: [:prod],
   enable_source_code_context: true,
-  root_source_code_path: File.cwd!()
+  root_source_code_paths: [File.cwd!()]
 ```
 
 The `environment_name` and `included_environments` work together to determine
@@ -169,7 +169,7 @@ The full range of options is the following:
 | `in_app_module_whitelist` | False | `[]` | |
 | `report_deps` | False | True | Will attempt to load Mix dependencies at compile time to report alongside events |
 | `enable_source_code_context` | False | False | |
-| `root_source_code_path` | Required if `enable_source_code_context` is enabled | | Should generally be set to `File.cwd!()`|
+| `root_source_code_paths` | Required if `enable_source_code_context` is enabled | | Should usually be set to `[File.cwd!()]`. For umbrella applications you should list all your applications paths in this list (e.g. `["#{File.cwd!()}/apps/app_1", "#{File.cwd!()}/apps/app_2"]`. |
 | `context_lines` | False  | 3 | |
 | `source_code_exclude_patterns` | False  | `[~r"/_build/", ~r"/deps/", ~r"/priv/"]` | |
 | `source_code_path_pattern` | False  | `"**/*.ex"` | |

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,6 +5,6 @@ config :sentry,
   environment_name: :dev,
   tags: %{},
   enable_source_code_context: true,
-  root_source_code_path: File.cwd!()
+  root_source_code_paths: [File.cwd!()]
 
 import_config "#{Mix.env()}.exs"

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -77,6 +77,17 @@ defmodule Sentry.Config do
     get_config(:enable_source_code_context, default: false, check_dsn: false)
   end
 
+  @deprecated "Use root_source_code_paths/0 instead"
+  def root_source_code_path do
+    path = get_config(:root_source_code_path)
+
+    if path do
+      path
+    else
+      raise ArgumentError.exception(":root_source_code_path must be configured")
+    end
+  end
+
   # :root_source_code_path (single path) was replaced by :root_source_code_paths (list of
   # paths).
   #

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -77,13 +77,27 @@ defmodule Sentry.Config do
     get_config(:enable_source_code_context, default: false, check_dsn: false)
   end
 
-  def root_source_code_path do
+  # :root_source_code_path (single path) was replaced by :root_source_code_paths (list of
+  # paths).
+  #
+  # In order for this to not be a breaking change we still accept the old
+  # :root_source_code_path as a fallback.
+  #
+  # We should deprecate this the :root_source_code_path completely in the next major
+  # release.
+  def root_source_code_paths do
+    paths = get_config(:root_source_code_paths)
     path = get_config(:root_source_code_path)
 
-    if path do
-      path
-    else
-      raise ArgumentError.exception(":root_source_code_path must be configured")
+    cond do
+      not is_nil(paths) ->
+        paths
+
+      not is_nil(path) ->
+        [path]
+
+      true ->
+        raise ArgumentError.exception(":root_source_code_paths must be configured")
     end
   end
 

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -90,6 +90,14 @@ defmodule Sentry.Config do
     path = get_config(:root_source_code_path)
 
     cond do
+      not is_nil(path) and not is_nil(paths) ->
+        raise ArgumentError, """
+        :root_source_code_path and :root_source_code_paths can't be configured at the \
+        same time.
+
+        :root_source_code_path is deprecated. Set :root_source_code_paths instead.
+        """
+
       not is_nil(paths) ->
         paths
 

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -72,4 +72,46 @@ defmodule Sentry.ConfigTest do
       assert ["test", "dev"] == Config.included_environments()
     end
   end
+
+  describe "root_source_code_paths" do
+    test "raises error if :root_source_code_path and :root_source_code_paths are set" do
+      modify_env(:sentry, root_source_code_path: "/test")
+      modify_env(:sentry, root_source_code_paths: ["/test"])
+
+      expected_error_message = """
+      :root_source_code_path and :root_source_code_paths can't be configured at the \
+      same time.
+
+      :root_source_code_path is deprecated. Set :root_source_code_paths instead.
+      """
+
+      assert_raise ArgumentError, expected_error_message, fn ->
+        Config.root_source_code_paths()
+      end
+    end
+
+    test "raises error if :root_source_code_path and :root_source_code_paths are not set" do
+      delete_env(:sentry, [:root_source_code_path, :root_source_code_paths])
+
+      expected_error_message = ":root_source_code_paths must be configured"
+
+      assert_raise ArgumentError, expected_error_message, fn ->
+        Config.root_source_code_paths()
+      end
+    end
+
+    test "returns :root_source_code_path if it's set" do
+      modify_env(:sentry, root_source_code_path: "/test")
+      modify_env(:sentry, root_source_code_paths: nil)
+
+      assert Config.root_source_code_paths() == ["/test"]
+    end
+
+    test "returns :root_source_code_paths if it's set" do
+      modify_env(:sentry, root_source_code_path: nil)
+      modify_env(:sentry, root_source_code_paths: ["/test"])
+
+      assert Config.root_source_code_paths() == ["/test"]
+    end
+  end
 end

--- a/test/sources_test.exs
+++ b/test/sources_test.exs
@@ -5,7 +5,7 @@ defmodule Sentry.SourcesTest do
 
   describe "load_files/0" do
     test "loads files" do
-      Application.put_env(:sentry, :root_source_code_paths, [
+      modify_env(:sentry, root_source_code_paths: [
         File.cwd!() <> "/test/support/example-umbrella-app/apps/app_a",
         File.cwd!() <> "/test/support/example-umbrella-app/apps/app_b"
       ])
@@ -29,7 +29,7 @@ defmodule Sentry.SourcesTest do
     end
 
     test "raises error when two files have the same relative path" do
-      Application.put_env(:sentry, :root_source_code_paths, [
+      modify_env(:sentry, root_source_code_paths: [
         File.cwd!() <> "/test/support/example-umbrella-app-with-conflict/apps/app_a",
         File.cwd!() <> "/test/support/example-umbrella-app-with-conflict/apps/app_b"
       ])

--- a/test/sources_test.exs
+++ b/test/sources_test.exs
@@ -27,6 +27,25 @@ defmodule Sentry.SourcesTest do
                }
              } = Sentry.Sources.load_files()
     end
+
+    test "raises error when two files have the same relative path" do
+      Application.put_env(:sentry, :root_source_code_paths, [
+        File.cwd!() <> "/test/support/example-umbrella-app-with-conflict/apps/app_a",
+        File.cwd!() <> "/test/support/example-umbrella-app-with-conflict/apps/app_b"
+      ])
+
+      expected_error_message = """
+      Found two source files in different source root paths with the same relative \
+      path: lib/module_a.ex
+
+      This means that both source files would be reported to Sentry as the same \
+      file. Please rename one of them to avoid this.
+      """
+
+      assert_raise RuntimeError, expected_error_message, fn ->
+        Sentry.Sources.load_files()
+      end
+    end
   end
 
   test "exception makes call to Sentry API" do

--- a/test/sources_test.exs
+++ b/test/sources_test.exs
@@ -3,6 +3,32 @@ defmodule Sentry.SourcesTest do
   use Plug.Test
   import Sentry.TestEnvironmentHelper
 
+  describe "load_files/0" do
+    test "loads files" do
+      Application.put_env(:sentry, :root_source_code_paths, [
+        File.cwd!() <> "/test/support/example-umbrella-app/apps/app_a",
+        File.cwd!() <> "/test/support/example-umbrella-app/apps/app_b"
+      ])
+
+      assert %{
+               "lib/module_a.ex" => %{
+                 1 => "defmodule ModuleA do",
+                 2 => "  def test do",
+                 3 => "    \"test a\"",
+                 4 => "  end",
+                 5 => "end"
+               },
+               "lib/module_b.ex" => %{
+                 1 => "defmodule ModuleB do",
+                 2 => "  def test do",
+                 3 => "    \"test b\"",
+                 4 => "  end",
+                 5 => "end"
+               }
+             } = Sentry.Sources.load_files()
+    end
+  end
+
   test "exception makes call to Sentry API" do
     correct_context = %{
       "context_line" => "    raise RuntimeError, \"Error\"",

--- a/test/support/example-umbrella-app-with-conflict/apps/app_a/lib/module_a.ex
+++ b/test/support/example-umbrella-app-with-conflict/apps/app_a/lib/module_a.ex
@@ -1,0 +1,5 @@
+defmodule ModuleA do
+  def test do
+    "test a"
+  end
+end

--- a/test/support/example-umbrella-app-with-conflict/apps/app_b/lib/module_a.ex
+++ b/test/support/example-umbrella-app-with-conflict/apps/app_b/lib/module_a.ex
@@ -1,0 +1,5 @@
+defmodule ModuleB do
+  def test do
+    "test b"
+  end
+end

--- a/test/support/example-umbrella-app/apps/app_a/lib/module_a.ex
+++ b/test/support/example-umbrella-app/apps/app_a/lib/module_a.ex
@@ -1,0 +1,5 @@
+defmodule ModuleA do
+  def test do
+    "test a"
+  end
+end

--- a/test/support/example-umbrella-app/apps/app_b/lib/module_b.ex
+++ b/test/support/example-umbrella-app/apps/app_b/lib/module_b.ex
@@ -1,0 +1,5 @@
+defmodule ModuleB do
+  def test do
+    "test b"
+  end
+end


### PR DESCRIPTION
Before the changes in this commit Sentry.Sources only looked for source
code files in one root path, the `:root_source_code_path`.

With the changes in this commit this module will now be able to look for
source code in multiple paths. The paths can be configured in the
`:root_source_code_paths` config key.

This change is specially important for umbrella applications [1], that
have their code nested in the `apps` path. If we don't specify the root
path for each individual application (which isn't possible without the
changes in this commit), and instead just use `File.cwd!()` as the root
path, the source code files of each umbrella app will be loaded with
`apps/<app name>` prefix in their name. This is a problem because these
names will never match the file names in the stacktrace, which means
that Sentry won't be able to attach source code context.

To avoid a configuration breaking change, the changes in this commit
still support the `:root_source_code_path` configuration key, but "soft
deprecate" it by removing it from documentation. This config key should
be fully deprecated in the next major Sentry release.

[1] https://elixir-lang.org/getting-started/mix-otp/dependencies-and-umbrella-projects.html