### PR TITLE
Align Sentry event levels with Elixir logging levels

### DIFF
--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -16,7 +16,7 @@ defmodule Sentry.Config do
   @default_send_result :none
   @default_send_max_attempts 4
 
-  @permitted_log_level_values ~w(debug info warn error)a
+  @permitted_log_level_values ~w(debug info warning warn error)a
 
   def validate_config! do
   end

--- a/lib/sentry/logger_backend.ex
+++ b/lib/sentry/logger_backend.ex
@@ -103,7 +103,7 @@ defmodule Sentry.LoggerBackend do
     opts =
       [
         event_source: :logger,
-        level: "#{level}",
+        level: elixir_logger_level_to_sentry_level(level),
         extra: %{logger_metadata: logger_metadata(meta, state), logger_level: level},
         result: :none
       ] ++ Map.to_list(sentry)
@@ -150,5 +150,37 @@ defmodule Sentry.LoggerBackend do
         value = meta[key],
         do: {key, value},
         into: %{}
+  end
+
+  @spec elixir_logger_level_to_sentry_level(Logger.level()) :: String.t()
+  defp elixir_logger_level_to_sentry_level(level) do
+    case level do
+      :emergency ->
+        "fatal"
+
+      :alert ->
+        "fatal"
+
+      :critical ->
+        "fatal"
+
+      :error ->
+        "error"
+
+      :warning ->
+        "warning"
+
+      :warn ->
+        "warning"
+
+      :notice ->
+        "info"
+
+      :info ->
+        "info"
+
+      :debug ->
+        "debug"
+    end
   end
 end

--- a/test/logger_backend_test.exs
+++ b/test/logger_backend_test.exs
@@ -425,7 +425,7 @@ defmodule Sentry.LoggerBackendTest do
       {:ok, body, conn} = Plug.Conn.read_body(conn)
       json = Jason.decode!(body)
       assert json["message"] == "warn"
-      assert json["level"] == "warn"
+      assert json["level"] == "warning"
       send(pid, "API called")
       Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
     end)


### PR DESCRIPTION
Fixes issue mentioned here: https://github.com/getsentry/sentry-elixir/issues/428#issuecomment-688014316

This also adds translation of the other Elixir Logger levels to Sentry event levels, including those added in `1.11.0`

Sentry levels: https://github.com/getsentry/sentry/blob/master/src/sentry/constants.py#L186-L190

Elixir levels: https://hexdocs.pm/logger/Logger.html#module-levels