### PR TITLE
Not reading dsn config at compile time

### DIFF
--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -79,7 +79,7 @@ defmodule Sentry.Config do
 
   @deprecated "Use root_source_code_paths/0 instead"
   def root_source_code_path do
-    path = get_config(:root_source_code_path)
+    path = get_config(:root_source_code_path, check_dsn: false)
 
     if path do
       path
@@ -97,8 +97,8 @@ defmodule Sentry.Config do
   # We should deprecate this the :root_source_code_path completely in the next major
   # release.
   def root_source_code_paths do
-    paths = get_config(:root_source_code_paths)
-    path = get_config(:root_source_code_path)
+    paths = get_config(:root_source_code_paths, check_dsn: false)
+    path = get_config(:root_source_code_path, check_dsn: false)
 
     cond do
       not is_nil(path) and not is_nil(paths) ->

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -113,5 +113,11 @@ defmodule Sentry.ConfigTest do
 
       assert Config.root_source_code_paths() == ["/test"]
     end
+
+    test "call to :root_source_code_paths does not read dsn env" do
+      modify_env(:sentry, dsn: {:system, "DSN", required: true})
+
+      Config.root_source_code_paths()
+    end
   end
 end


### PR DESCRIPTION
This PR attempts to fix #440.

As described in the bug report, the `:dsn` config value got read at compile time, failing if something else then a value that can be parsed by `URI.parse/1` is present.

I added a test as well but I'm not 100% happy as it does not confirm that `Sentry.config.dsn/0` is not called at compile time but rather that a call to `root_source_code_paths` does not evaluate the `dsn` config variable. Calling `get_config` without the `check_dsn: false` option at compile time somewhere else will result in the same error and is not catched by my test. I'm currently not sure on how to test this.