### PR TITLE
Adds support for lists in scrubbing logic

### DIFF
--- a/test/plug_context_test.exs
+++ b/test/plug_context_test.exs
@@ -82,7 +82,10 @@ defmodule Sentry.PlugContextTest do
       "count" => 334,
       "cc" => "4197-7215-7810-8280",
       "another_cc" => "4197721578108280",
-      "user" => %{"password" => "mypassword"}
+      "user" => %{"password" => "mypassword"},
+      "payments" => [
+        %{"yet_another_cc" => "4197-7215-7810-8280"}
+      ]
     })
     |> put_req_cookie("secret", "secretvalue")
     |> put_req_cookie("regular", "value")
@@ -101,7 +104,10 @@ defmodule Sentry.PlugContextTest do
              "passwd" => "*********",
              "password" => "*********",
              "secret" => "*********",
-             "user" => %{"password" => "*********"}
+             "user" => %{"password" => "*********"},
+             "payments" => [
+               %{"yet_another_cc" => "*********"}
+             ]
            }
   end
 


### PR DESCRIPTION
The scrubbing logic in `Sentry.PlugContext` acts on keys, and so lists themselves are not a target for scrubbing. But lists can contain maps that need scrubbing. This adds support for lists in the scrubbing logic.