### PR TITLE
Send Sentry reports on uncaught throws/exits

### DIFF
--- a/lib/sentry/plug_capture.ex
+++ b/lib/sentry/plug_capture.ex
@@ -45,6 +45,12 @@ defmodule Sentry.PlugCapture do
           e ->
             _ = Sentry.capture_exception(e, stacktrace: __STACKTRACE__, event_source: :plug)
             :erlang.raise(:error, e, __STACKTRACE__)
+        catch
+          kind, reason ->
+            message = "Uncaught #{kind} - #{inspect(reason)}"
+            stack = __STACKTRACE__
+            Sentry.capture_message(message, stacktrace: stack, event_source: :plug)
+            :erlang.raise(kind, reason, stack)
         end
       end
     end

--- a/test/sources_test.exs
+++ b/test/sources_test.exs
@@ -55,7 +55,7 @@ defmodule Sentry.SourcesTest do
   test "exception makes call to Sentry API" do
     correct_context = %{
       "context_line" => "    raise RuntimeError, \"Error\"",
-      "post_context" => ["  end", "", "  post \"/error_route\" do"],
+      "post_context" => ["  end", "", "  get \"/exit_route\" do"],
       "pre_context" => ["", "  get \"/error_route\" do", "    _ = conn"]
     }
 

--- a/test/support/example_plug_application.ex
+++ b/test/support/example_plug_application.ex
@@ -13,6 +13,16 @@ defmodule Sentry.ExamplePlugApplication do
     raise RuntimeError, "Error"
   end
 
+  get "/exit_route" do
+    _ = conn
+    exit(:test)
+  end
+
+  get "/throw_route" do
+    _ = conn
+    throw(:test)
+  end
+
   post "/error_route" do
     _ = conn
     raise RuntimeError, "Error"


### PR DESCRIPTION
Fix #446

Previously PlugCapture would only catch exceptions. If there was an uncaught exit or throw, this would be ignored and Plug/Phoenix would end up send a 500 Internal Server Error to the clients with no notification to Sentry.