### PR TITLE
update stale reference to Sentry.Plug module in docs

### DIFF
--- a/lib/sentry/plug_context.ex
+++ b/lib/sentry/plug_context.ex
@@ -23,7 +23,7 @@ defmodule Sentry.PlugContext do
         # and credit card information in plain text.  To also prevent sending
         # our sensitive "my_secret_field" and "other_sensitive_data" fields,
         # we simply drop those keys.
-        Sentry.Plug.default_body_scrubber(conn)
+        Sentry.PlugContext.default_body_scrubber(conn)
         |> Map.drop(["my_secret_field", "other_sensitive_data"])
       end
 


### PR DESCRIPTION
Hey folks,

I noticed a stale reference to `Sentry.Plug.default_body_scrubber/1` in the documentation, where it should now be `Sentry.PlugContext.default_body_scrubber/1`. You can [see the docs in question here](https://hexdocs.pm/sentry/Sentry.PlugContext.html#module-sending-post-body-params).

This is just a simple change to fix that. Cheers!