### PR TITLE
Proposal: Add before_capture_exception hook

### DIFF
--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -182,6 +182,10 @@ defmodule Sentry.Config do
     get_config(:hackney_opts, default: [], check_dsn: false)
   end
 
+  def before_capture_exception do
+    get_config(:before_capture_exception, check_dsn: false)
+  end
+
   def before_send_event do
     get_config(:before_send_event, check_dsn: false)
   end


### PR DESCRIPTION
The existing `before_send_event` hook is useful however the error has already been processed somewhat at that point.  This means there's sensitive data that could be embedded in the error string that is hard to detect and redact.  We recently had a situation where some private keys were pushed into sentry and alerted into Slack causing the need for a key rotation.

This PR has an example implementation of `before_capture_exception` which allows us to hook into things early and redact the raw error before it is processed.  If this is something that can be added to the main library I can wrap this up with documentation/tests