### PR TITLE
Use Logger.add_backend/1

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,13 @@ defmodule MyAppWeb.ErrorView do
 
 ### Capture Crashed Process Exceptions
 
-This library comes with an extension to capture all error messages that the Plug handler might not.  This is based on [Logger.Backend](https://hexdocs.pm/logger/Logger.html#module-backends).
+This library comes with an extension to capture all error messages that the Plug handler might not.  This is based on [Logger.Backend](https://hexdocs.pm/logger/Logger.html#module-backends). You can add it as a backend when your application starts:
 
 ```diff
-# config/config.exs
+# lib/my_app/application.ex
 
-+ config :logger,
-+  backends: [:console, Sentry.LoggerBackend]
++   def start(_type, _args) do
++     Logger.add_backend(Sentry.LoggerBackend)
 ```
 
 The backend can also be configured to capture Logger metadata, which is detailed [here](https://hexdocs.pm/sentry/Sentry.LoggerBackend.html).

--- a/lib/sentry/logger_backend.ex
+++ b/lib/sentry/logger_backend.ex
@@ -1,10 +1,11 @@
 defmodule Sentry.LoggerBackend do
   @moduledoc """
   Report Logger events like crashed processes to Sentry. To include in your
-  application, add this module to your Logger backends:
+  application, start this backend in your application `start/2` callback:
 
-      config :logger,
-        backends: [:console, Sentry.LoggerBackend]
+      # lib/my_app/application.ex
+      def start(_type, _args) do
+        Logger.add_backend(Sentry.LoggerBackend)
 
   Sentry context will be included in metadata in reported events. Example:
 


### PR DESCRIPTION
Configuring the backend on config/config.exs may be too early
and cause issues if trying to loading logger config before Sentry
is compiled.

Or it can be an issue in umbrella projects when only some of them
depend on Sentry.