### PR TITLE
Update "User Feedback" URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you are in a non-Phoenix Plug application, add `Sentry.PlugCapture` at the to
 
 #### Capturing User Feedback
 
-If you would like to capture user feedback as described [here](https://docs.sentry.io/enriching-error-data/user-feedback), the `Sentry.get_last_event_id_and_source()` function can be used to see if Sentry has sent an event within the current Plug process, and the source of that event. `:plug` will be the source for events coming from `Sentry.PlugCapture`. The options described in the Sentry documentation linked above can be encoded into the response as well.
+If you would like to capture user feedback as described [here](https://docs.sentry.io/platforms/elixir/enriching-events/user-feedback/), the `Sentry.get_last_event_id_and_source()` function can be used to see if Sentry has sent an event within the current Plug process, and the source of that event. `:plug` will be the source for events coming from `Sentry.PlugCapture`. The options described in the Sentry documentation linked above can be encoded into the response as well.
 
 An example Phoenix application setup that wanted to display the user feedback form on 500 responses on requests accepting HTML could look like:
 


### PR DESCRIPTION
Hello! Tiny fix but the current link to `User Feedback` leads to a "Page not found". I believe this is the new URL?