### PR TITLE
Handle :unsampled events in sentry.send_test_event

### DIFF
--- a/lib/mix/tasks/sentry.send_test_event.ex
+++ b/lib/mix/tasks/sentry.send_test_event.ex
@@ -63,6 +63,11 @@ defmodule Mix.Tasks.Sentry.SendTestEvent do
 
         :excluded ->
           Mix.shell().info("No test event was sent because the event was excluded by a filter")
+
+        :unsampled ->
+          Mix.shell().info(
+            "No test event was sent because the event was excluded according to the sample_rate"
+          )
       end
     else
       Mix.shell().info(


### PR DESCRIPTION
Hey there!

I tried to send a test event and got:
```
Sending test event...
** (CaseClauseError) no case clause matching: :unsampled
    (sentry 8.0.5) lib/mix/tasks/sentry.send_test_event.ex:57: Mix.Tasks.Sentry.SendTestEvent.maybe_send_event/0
    (mix 1.11.4) lib/mix/task.ex:394: Mix.Task.run_task/3
    (mix 1.11.4) lib/mix/cli.ex:84: Mix.CLI.run_task/2
    (elixir 1.11.4) lib/code.ex:931: Code.require_file/2
```

So I propose a clause be added to handle this case.