### PR TITLE
Fix dialyzer reporting unmatched_return for Sentry.PlugCapture

### DIFF
--- a/lib/sentry/plug_capture.ex
+++ b/lib/sentry/plug_capture.ex
@@ -49,7 +49,7 @@ defmodule Sentry.PlugCapture do
           kind, reason ->
             message = "Uncaught #{kind} - #{inspect(reason)}"
             stack = __STACKTRACE__
-            Sentry.capture_message(message, stacktrace: stack, event_source: :plug)
+            _ = Sentry.capture_message(message, stacktrace: stack, event_source: :plug)
             :erlang.raise(kind, reason, stack)
         end
       end


### PR DESCRIPTION
This issue is similar to https://github.com/getsentry/sentry-elixir/pull/436. Basically the return type of `Sentry.capture_message/2` is `{:ok, Task.t() | String.t() | pid()} | {:error, any()} | :unsampled | :excluded | :ignored` which is not handled, causing Dialyzer to complain about unmatched returns. Adding a `_ =` as was done in the aforementioned PR silenced it. My Dialyzer configuration is below in case it's of any interest.
```
dialyzer: [
  flags: [
    :unmatched_returns,
    :error_handling,
    :race_conditions,
    :no_opaque,
    :underspecs
  ],
  plt_file: {:no_warn, "priv/plts/dialyzer.plt"}
],
```
