### PR TITLE
Add os and runtime info to events

### DIFF
--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -333,6 +333,7 @@ defmodule Sentry.Client do
       user: event.user,
       breadcrumbs: event.breadcrumbs,
       fingerprint: event.fingerprint,
+      contexts: event.contexts,
       modules: event.modules
     }
 

--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -31,6 +31,7 @@ defmodule Sentry.Event do
             breadcrumbs: [],
             fingerprint: [],
             modules: %{},
+            contexts: %{},
             event_source: nil
 
   @type sentry_exception :: %{type: String.t(), value: String.t(), module: any()}
@@ -56,6 +57,7 @@ defmodule Sentry.Event do
           breadcrumbs: list(),
           fingerprint: list(),
           modules: map(),
+          contexts: map(),
           event_source: any()
         }
 
@@ -159,6 +161,7 @@ defmodule Sentry.Event do
       request: request,
       fingerprint: fingerprint,
       modules: Util.mix_deps_versions(@deps),
+      contexts: generate_contexts(),
       event_source: event_source
     }
     |> add_metadata()
@@ -307,4 +310,19 @@ defmodule Sentry.Event do
 
   defp coerce_stacktrace({m, f, a}), do: [{m, f, a, []}]
   defp coerce_stacktrace(stacktrace), do: stacktrace
+
+  defp generate_contexts do
+    {_, os_name} = :os.type()
+
+    os_version =
+      case :os.version() do
+        {major, minor, release} -> "#{major}.#{minor}.#{release}"
+        version_string -> version_string
+      end
+
+    %{
+      os: %{name: Atom.to_string(os_name), version: os_version},
+      runtime: %{name: "elixir", version: System.build_info().build}
+    }
+  end
 end

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -109,6 +109,10 @@ defmodule Sentry.EventTest do
 
     assert event.tags == %{}
     assert event.timestamp =~ ~r/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
+    assert is_binary(event.contexts.os.name)
+    assert is_binary(event.contexts.os.version)
+    assert is_binary(event.contexts.runtime.name)
+    assert is_binary(event.contexts.runtime.version)
   end
 
   test "respects tags in config" do
@@ -136,7 +140,8 @@ defmodule Sentry.EventTest do
       request: %{},
       stacktrace: %{frames: []},
       tags: %{},
-      user: %{}
+      user: %{},
+      contexts: %{os: %{name: _, version: _}, runtime: %{name: _, version: _}}
     } = Event.create_event(message: "Test message")
   end
 


### PR DESCRIPTION
This collects the OS and runtime's name and version from :os and System module,
and send them as contexts metadata to Sentry. 

These information will be displayed in the TAGS section with the corresponding icons:
<img width="974" alt="tags" src="https://user-images.githubusercontent.com/26372128/153337651-a56be051-a379-4610-a267-f0d40c0f1b65.png">

Closes #496 
