### PR TITLE
Use Supervisor.child_spec for type

### DIFF
--- a/lib/sentry/http_client.ex
+++ b/lib/sentry/http_client.ex
@@ -13,7 +13,7 @@ defmodule Sentry.HTTPClient do
 
   @type headers :: [{String.t(), String.t()}]
 
-  @callback child_spec() :: :supervisor.child_spec()
+  @callback child_spec() :: Supervisor.child_spec()
 
   @callback post(url :: String.t(), headers, body :: String.t()) ::
               {:ok, status :: pos_integer, headers, body :: String.t()}


### PR DESCRIPTION
Use the typespec from Elixir, [Supervisor.child_spec/0](https://hexdocs.pm/elixir/Supervisor.html#t:child_spec/0) instead of the Erlang module type.

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
