### PR TITLE
Update default value of included_environments in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The full range of options is the following:
 | ------------- | -----------------|--------------|-------|
 | `dsn` | True  | n/a | |
 | `environment_name` | False  | :prod | |
-| `included_environments` | False  | `[:test, :dev, :prod]` | If you need non-standard mix env names you *need* to include it here |
+| `included_environments` | False  | `[:prod]` | If you need non-standard mix env names you *need* to include it here |
 | `tags` | False  | `%{}` | |
 | `release` | False  | None | |
 | `server_name` | False  | None | |


### PR DESCRIPTION
Hi 👋 

I've seen that the default value of `included_environments` is incorrect in README.
That might confuse people, as it confused me. So I wanted to fix it. :D

---

Or was it actually supposed to include all the envs mentioned in the README? 🤔
I can create a PR for that as well, if that's the way to go.
In my opinion it would be better so people wouldn't have to mention all those separately in their configs.