### PR TITLE
Fix excluding domains

### DIFF
--- a/lib/sentry/logger_backend.ex
+++ b/lib/sentry/logger_backend.ex
@@ -145,7 +145,7 @@ defmodule Sentry.LoggerBackend do
     ] ++ Map.to_list(sentry)
   end
 
-  defp excluded_domain?(domains, state) when is_list(domains), do: Enum.any?(domains, &Enum.member?(&1, state.excluded_domains))
+  defp excluded_domain?(domains, state) when is_list(domains), do: Enum.any?(domains, &Enum.member?(state.excluded_domains, &1))
   defp excluded_domain?(_, _), do: false
 
   defp logger_metadata(meta, state) do

--- a/lib/sentry/logger_backend.ex
+++ b/lib/sentry/logger_backend.ex
@@ -145,7 +145,7 @@ defmodule Sentry.LoggerBackend do
     ] ++ Map.to_list(sentry)
   end
 
-  defp excluded_domain?([head | _], state), do: head in state.excluded_domains
+  defp excluded_domain?(domains, state) when is_list(domains), do: Enum.any?(domains, &Enum.member?(&1, state.excluded_domains))
   defp excluded_domain?(_, _), do: false
 
   defp logger_metadata(meta, state) do


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-elixir/issues/527

Using elixir and specifying a domain when logging, it doesn't exclude, because elixir uses `:elixir` domain as first key always, and sentry package only checks the first key versus the list specified in config

![image](https://user-images.githubusercontent.com/4070466/207591044-bd4822e5-92e0-4c8c-9030-ed9e80dffbc2.png)


This pr is to check all domains specified in the meta `:domain` key

I'll appreciate if you make a release with this