### PR TITLE
Wrap sentry event when the sample_rate is 0

### DIFF
--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -97,7 +97,7 @@ defmodule Sentry.Client do
         :excluded
 
       {%Event{}, false} ->
-        :unsampled
+        {:unsampled, event}
 
       {%Event{}, true} ->
         encode_and_send(event, result)

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -299,7 +299,9 @@ defmodule Sentry.ClientTest do
       e ->
         {:ok, _} = Sentry.capture_exception(e, result: :sync, sample_rate: 1)
         Bypass.down(bypass)
-        :unsampled = Sentry.capture_exception(e, result: :sync, sample_rate: 0.0)
+
+        {:unsampled, %Sentry.Event{}} =
+          Sentry.capture_exception(e, result: :sync, sample_rate: 0.0)
     end
   end
 


### PR DESCRIPTION
In order to configure `sample_rate` 0 in our current project and we want to return the log before sending an event to Sentry for such environments (dev, test, staging)