### PR TITLE
Fix :crash_reason metadata handling

### DIFF
--- a/lib/sentry/logger_backend.ex
+++ b/lib/sentry/logger_backend.ex
@@ -95,9 +95,10 @@ defmodule Sentry.LoggerBackend do
   end
 
   defp log(level, msg, meta, state) do
+    {crash_reason, meta} = Keyword.pop(meta, :crash_reason)
     opts = build_opts(level, meta, state)
 
-    case meta[:crash_reason] do
+    case crash_reason do
       {%_{__exception__: true} = exception, stacktrace} when is_list(stacktrace) ->
         Sentry.capture_exception(exception, [stacktrace: stacktrace] ++ opts)
 


### PR DESCRIPTION
- [x] mix format
- [x] mix test
---

### Use case

This PR fixes following use case with `config :logger, Sentry.LoggerBackend, metadata: [:crash_reason]`.

```
  def test_with_exception() do
    try do
      raise RuntimeError
    rescue
      exception ->
        Logger.error("sentry test with exception", crash_reason: {exception, __STACKTRACE__})
    end
  end
```

Currently we cannot log for other backends and Sentry.LoggerBackend at the same time with one line.
So we need to write like following,

```
  def test_with_exception() do
    try do
      raise RuntimeError
    rescue
      exception ->
        Logger.error("sentry test with exception") # ex. for console
        Sentry.capture_exception(error, stacktrace: __STACKTRACE__)
    end
  end
```

### Why cannot currently

The following code in the current master branch cannot work because it fails to encode JSON.
Because the :crash_reason value is a tuple.

https://github.com/getsentry/sentry-elixir/blob/0e238fed32bab527c9e88c86e1ef004c737e29dd/lib/sentry/logger_backend.ex#L101-L102

[:crash_reason](https://hexdocs.pm/logger/1.14.3/Logger.html#module-metadata) is special metadata, so I think we don't need to use it for `:logger_metadata` in `:extra`.