### PR TITLE
Fix `mix.sentry_recompile` typo in moduledoc

### DIFF
--- a/lib/sentry/sources.ex
+++ b/lib/sentry/sources.ex
@@ -42,7 +42,7 @@ defmodule Sentry.Sources do
   The best way to ensure source code is up to date is to recompile Sentry
   itself via `mix deps.compile sentry --force`.  It's possible to create a Mix
   Task alias in `mix.exs` to do this.  The example below would allow one to
-  run `mix.sentry_recompile && mix compile` which will force recompilation of Sentry so
+  run `mix sentry_recompile && mix compile` which will force recompilation of Sentry so
   it has the newest source and then compile the project. The second `mix compile`
   is required due to Mix only invoking the same task once in an alias.
 


### PR DESCRIPTION
```bash
> mix.sentry_recompile
command not found

> mix sentry_recompile
==> sentry
Compiling 16 files (.ex)
...
```