### PR TITLE
Use module attribute for dictionary key consistently

### DIFF
--- a/lib/sentry/context.ex
+++ b/lib/sentry/context.ex
@@ -186,7 +186,7 @@ defmodule Sentry.Context do
       %{breadcrumbs: [], extra: %{}, request: %{}, tags: %{}, user: %{}}
   """
   def clear_all do
-    :logger.update_process_metadata(%{sentry: %{}})
+    :logger.update_process_metadata(%{@logger_metadata_key => %{}})
   end
 
   defp get_sentry_context do
@@ -255,17 +255,17 @@ defmodule Sentry.Context do
         Enum.take(breadcrumbs, -1 * Sentry.Config.max_breadcrumbs())
       end)
 
-    :logger.update_process_metadata(%{sentry: sentry_metadata})
+    :logger.update_process_metadata(%{@logger_metadata_key => sentry_metadata})
   end
 
   defp set_context(key, new) when is_map(new) do
     sentry_metadata =
       case :logger.get_process_metadata() do
-        %{sentry: sentry} -> Map.update(sentry, key, new, &Map.merge(&1, new))
+        %{@logger_metadata_key => sentry} -> Map.update(sentry, key, new, &Map.merge(&1, new))
         _ -> %{key => new}
       end
 
-    :logger.update_process_metadata(%{sentry: sentry_metadata})
+    :logger.update_process_metadata(%{@logger_metadata_key => sentry_metadata})
   end
 
   @doc """


### PR DESCRIPTION
get_sentry_context/0 uses @logger_metadata_key but several other places use a hardcoded :sentry atom for access. This PR makes usage consistent.