### PR TITLE
Fix example configuration on Sentry.Sources

### DIFF
--- a/lib/sentry/sources.ex
+++ b/lib/sentry/sources.ex
@@ -23,14 +23,14 @@ defmodule Sentry.Sources do
     should not be stored or referenced when reporting exceptions.  Defaults to
     `[~r"/_build/", ~r"/deps/", ~r"/priv/"]`.
   * `:source_code_path_pattern` - a glob that is expanded to select files from the
-    `:root_source_code_path`.  Defaults to `"**/*.ex"`.
+    `:root_source_code_paths`.  Defaults to `"**/*.ex"`.
 
   An example configuration:
 
       config :sentry,
         dsn: "https://public:secret@app.getsentry.com/1",
         enable_source_code_context: true,
-        root_source_code_path: [File.cwd!()],
+        root_source_code_paths: [File.cwd!()],
         context_lines: 5
 
   ### Source code storage


### PR DESCRIPTION
Hello there, this PR aims to fix and improve the example on `Sentry.Sources`.

If I understood correctly:
* `root_source_code_path` is deprecated  and expects a single path
* `root_source_code_paths` expects a list of paths.

Based on that there are 2 issues:
1. The example sets `root_source_code_path` with a list of paths. That seems an incorrect value.
2. `root_source_code_paths` should be preferred over the deprecated `root_source_code_path` config.

Thanks for your time.