### PR TITLE
Update badges in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # sentry
 
-[![Build Status](https://img.shields.io/travis/getsentry/sentry-elixir.svg?style=flat)](https://travis-ci.org/getsentry/sentry-elixir)
-[![hex.pm version](https://img.shields.io/hexpm/v/sentry.svg?style=flat)](https://hex.pm/packages/sentry)
-[Documentation](https://hexdocs.pm/sentry/readme.html)
+![Build Status](https://github.com/getsentry/sentry-elixir/actions/workflows/main.yml/badge.svg)
+[![Hex Package](https://img.shields.io/hexpm/v/sentry.svg)](https://hex.pm/packages/sentry)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-blue.svg)](https://hexdocs.pm/sentry)
 
 The Official Sentry Client for Elixir which provides a simple API to capture exceptions, automatically handle Plug Exceptions and provides a backend for the Elixir Logger. This documentation represents unreleased features, for documentation on the current release, see [here](https://hexdocs.pm/sentry/readme.html).
 


### PR DESCRIPTION
This PR replaces "Build Status" Travis-CI badge with Github Actions one.

https://github.com/ruslandoga/sentry-elixir/blob/update-badges/README.md