### PR TITLE
Filter more exceptions in the default filter

### DIFF
--- a/lib/sentry/default_event_filter.ex
+++ b/lib/sentry/default_event_filter.ex
@@ -4,11 +4,14 @@ defmodule Sentry.DefaultEventFilter do
   @moduledoc false
 
   @ignored_exceptions [
+    Phoenix.NotAcceptableError,
     Phoenix.Router.NoRouteError,
-    Plug.Parsers.RequestTooLargeError,
+    Plug.Conn.InvalidQueryError,
     Plug.Parsers.BadEncodingError,
     Plug.Parsers.ParseError,
-    Plug.Parsers.UnsupportedMediaTypeError
+    Plug.Parsers.RequestTooLarge,
+    Plug.Parsers.UnsupportedMediaTypeError,
+    Plug.Static.InvalidPathError
   ]
 
   def exclude_exception?(%x{}, :plug) when x in @ignored_exceptions do


### PR DESCRIPTION
We've noticed the following exceptions are perfectly handled by Phoenix and are just noise-generator for Sentry.

In the context of attack attempts or bots scanning, it can generate a lot of noise for your application.

We therefore propose to filter them out by default. cc @StephaneRob