### PR TITLE
Check :hackney application when starting

### DIFF
--- a/lib/sentry.ex
+++ b/lib/sentry.ex
@@ -101,6 +101,21 @@ defmodule Sentry do
       Config.client().child_spec()
     ]
 
+    if Config.client() == Sentry.HackneyClient do
+      unless Code.ensure_loaded?(:hackney) do
+        raise """
+        cannot start the :sentry application because the HTTP client is set to \
+        Sentry.HackneyClient (which is the default), but the Hackney library is not loaded. \
+        Add :hackney to your dependencies to fix this.
+        """
+      end
+
+      case Application.ensure_all_started(:hackney) do
+        {:ok, _apps} -> :ok
+        {:error, reason} -> raise "failed to start the :hackney application: #{inspect(reason)}"
+      end
+    end
+
     validate_json_config!()
     validate_log_level_config!()
 

--- a/lib/sentry/hackney_client.ex
+++ b/lib/sentry/hackney_client.ex
@@ -7,18 +7,8 @@ defmodule Sentry.HackneyClient do
 
   @hackney_pool_name :sentry_pool
 
+  @impl true
   def child_spec do
-    unless Code.ensure_loaded?(:hackney) do
-      raise """
-      cannot start Sentry.HackneyClient because :hackney is not available.
-      Please make sure to add hackney as a dependency:
-
-          {:hackney, "~> 1.8"}
-      """
-    end
-
-    Application.ensure_all_started(:hackney)
-
     :hackney_pool.child_spec(
       @hackney_pool_name,
       timeout: Sentry.Config.hackney_timeout(),
@@ -26,6 +16,7 @@ defmodule Sentry.HackneyClient do
     )
   end
 
+  @impl true
   def post(url, headers, body) do
     hackney_opts =
       Sentry.Config.hackney_opts()


### PR DESCRIPTION
Supersedes https://github.com/getsentry/sentry-elixir/pull/541.

I think this is a better approach: we don't start the Sentry application if the client is `Sentry.HackneyClient` but `:hackney` is not available.