### PR TITLE
Make Sentry.Util + Sentry.CrashError + Sentry.Config private

### DIFF
--- a/lib/sentry.ex
+++ b/lib/sentry.ex
@@ -27,7 +27,7 @@ defmodule Sentry do
 
       config :sentry, dsn: "https://public:secret@app.getsentry.com/1",
         included_environments: [:prod],
-        environment_name: Mix.env
+        environment_name: Mix.env()
 
   This will set the environment name to whatever the current Mix environment
   atom is, but it will only send events if the current environment is `:prod`,
@@ -47,6 +47,10 @@ defmodule Sentry do
   Now, on our servers, we can set the environment variable appropriately. On
   our local development machines, exceptions will never be sent, because the
   default value is not in the list of `included_environments`.
+
+  Sentry also supports loading config at runtime, via `{:system, "SYSTEM_ENV_KEY"}` tuples,
+  where Sentry will read `SYSTEM_ENV_KEY` to get the config value from the system
+  environment at runtime.
 
   ## Filtering Exceptions
 

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -1,9 +1,5 @@
 defmodule Sentry.Config do
-  @moduledoc """
-  This module provides the functionality for fetching configuration settings and their defaults.
-
-  Sentry supports loading config at runtime, via `{:system, "SYSTEM_ENV_KEY"}` tuples, where Sentry will read `SYSTEM_ENV_KEY` to get the config value from the system environment at runtime.
-  """
+  @moduledoc false
 
   @default_included_environments [:prod]
   @default_environment_name Mix.env()

--- a/lib/sentry/util.ex
+++ b/lib/sentry/util.ex
@@ -1,7 +1,5 @@
 defmodule Sentry.Util do
-  @moduledoc """
-    Provides basic utility functions.
-  """
+  @moduledoc false
 
   @rfc_4122_variant10 2
   @uuid_v4_identifier 4


### PR DESCRIPTION
As discussed with @sl0thentr0py, this is targeted at the 9.0.0 release we're working on.