### PR TITLE
Bump Elixir requirement to 1.11+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,6 @@ jobs:
           - elixir: '1.15.x'
             otp: '23.3.x'
         include:
-          - elixir: '1.10.x'
-            otp: '22.3.x'
           - elixir: '1.11.x'
             otp: '23.3.x'
           # - elixir: 'master'

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -11,12 +11,9 @@ defmodule Sentry.Config do
   @default_sample_rate 1.0
   @default_send_result :none
   @default_send_max_attempts 4
+  @default_log_level :warning
 
   @permitted_log_level_values ~w(debug info warning warn error)a
-
-  @warning_log_level if Version.compare(System.version(), "1.11.0") != :lt,
-                       do: :warning,
-                       else: :warn
 
   def validate_config! do
   end
@@ -201,7 +198,7 @@ defmodule Sentry.Config do
   end
 
   def log_level do
-    get_config(:log_level, default: @warning_log_level, check_dsn: false)
+    get_config(:log_level, default: @default_log_level, check_dsn: false)
   end
 
   def max_breadcrumbs do

--- a/lib/sentry/logger_backend.ex
+++ b/lib/sentry/logger_backend.ex
@@ -192,9 +192,6 @@ defmodule Sentry.LoggerBackend do
     end
   end
 
-  if Version.compare(System.version(), "1.11.0") != :lt do
-    defp maybe_ensure_warning_level(:warn), do: :warning
-  end
-
+  defp maybe_ensure_warning_level(:warn), do: :warning
   defp maybe_ensure_warning_level(level), do: level
 end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Sentry.Mixfile do
     [
       app: :sentry,
       version: @version,
-      elixir: "~> 1.10",
+      elixir: "~> 1.11",
       description: "The Official Elixir client for Sentry",
       package: package(),
       deps: deps(),

--- a/test/logger_backend_test.exs
+++ b/test/logger_backend_test.exs
@@ -6,10 +6,6 @@ defmodule Sentry.LoggerBackendTest do
 
   alias Sentry.Envelope
 
-  @warning_log_level if Version.compare(System.version(), "1.11.0") != :lt,
-                       do: :warning,
-                       else: :warn
-
   setup do
     {:ok, _} = Logger.add_backend(Sentry.LoggerBackend)
 
@@ -403,9 +399,9 @@ defmodule Sentry.LoggerBackendTest do
     Logger.configure_backend(Sentry.LoggerBackend, capture_log_messages: false)
   end
 
-  test "sends warning messages when configured to #{@warning_log_level}" do
+  test "sends warning messages when configured to :warning" do
     Logger.configure_backend(Sentry.LoggerBackend,
-      level: @warning_log_level,
+      level: :warning,
       capture_log_messages: true
     )
 
@@ -429,7 +425,7 @@ defmodule Sentry.LoggerBackendTest do
 
     capture_log(fn ->
       Sentry.Context.set_user_context(%{user_id: 3})
-      Logger.log(@warning_log_level, "testing")
+      Logger.log(:warning, "testing")
       assert_receive("API called")
     end)
   after
@@ -555,7 +551,7 @@ defmodule Sentry.LoggerBackendTest do
 
   test "sets event level to Logger message level" do
     Logger.configure_backend(Sentry.LoggerBackend,
-      level: @warning_log_level,
+      level: :warning,
       capture_log_messages: true
     )
 
@@ -578,7 +574,7 @@ defmodule Sentry.LoggerBackendTest do
     end)
 
     capture_log(fn ->
-      Logger.log(@warning_log_level, "warn")
+      Logger.log(:warning, "warn")
       assert_receive("API called")
     end)
   after


### PR DESCRIPTION
We can do this now that we're aiming at a 9.0.0 release.