### PR TITLE
Make Sentry.DefaultEventFilter public

### DIFF
--- a/lib/sentry/default_event_filter.ex
+++ b/lib/sentry/default_event_filter.ex
@@ -1,8 +1,4 @@
 defmodule Sentry.DefaultEventFilter do
-  @behaviour Sentry.EventFilter
-
-  @moduledoc false
-
   @ignored_exceptions [
     Phoenix.NotAcceptableError,
     Phoenix.Router.NoRouteError,
@@ -14,11 +10,20 @@ defmodule Sentry.DefaultEventFilter do
     Plug.Static.InvalidPathError
   ]
 
-  def exclude_exception?(%x{}, :plug) when x in @ignored_exceptions do
-    true
-  end
+  @moduledoc """
+  The default implementation of the `Sentry.EventFilter` behaviour.
 
+  This filter excludes the following exceptions:
+
+  #{Enum.map_join(@ignored_exceptions, "\n", &"  * `#{inspect(&1)}`")}
+
+  In addition, it excludes routes that do not match in plug routers.
+  """
+
+  @behaviour Sentry.EventFilter
+
+  @impl true
+  def exclude_exception?(%x{}, :plug) when x in @ignored_exceptions, do: true
   def exclude_exception?(%FunctionClauseError{function: :do_match, arity: 4}, :plug), do: true
-
   def exclude_exception?(_, _), do: false
 end

--- a/lib/sentry/event_filter.ex
+++ b/lib/sentry/event_filter.ex
@@ -1,38 +1,71 @@
 defmodule Sentry.EventFilter do
   @moduledoc """
-  This module defines a Behaviour for filtering Sentry events.
-  There is one callback to implement. The first argument will be
-  the exception reported, and the second is the source. Events
-  from `Sentry.PlugCapture` will have :plug as a source and events from
-  `Sentry.LoggerBackend` will have `:logger` as the source. A custom
-  source can also be specified by passing the `event_source` option
-  to `Sentry.capture_exception/2`.
+  A behaviour for filtering events to send to Sentry.
 
-  As an example, if you wanted to exclude any `ArithmeticError` exceptions:
+  There's only one callback to implement, `c:exclude_exception?/2`.
+
+  ## Usage
+
+  To use a custom event filter module, configure the `:filter` option
+  in the `:sentry` application. For example:
+
+      config :sentry,
+        filter: MyApp.SentryEventFilter
+
+  The default event filter is `Sentry.DefaultEventFilter`.
+
+  ## Examples
+
+  As an example, if you wanted to exclude all `ArithmeticError` exceptions
+  and nothing else:
 
       defmodule MyApp.SentryEventFilter do
         @behaviour Sentry.EventFilter
 
+        @impl true
         def exclude_exception?(%ArithmeticError{}, _source), do: true
         def exclude_exception?(_exception, _source), do: false
       end
 
-  Alternatively, if you want to skip all non-500 exceptions in a Plug app:
+  Alternatively, if you wanted to skip all non-500 exceptions in a Plug app:
 
       defmodule MyApp.SentryEventFilter do
         @behaviour Sentry.EventFilter
 
-        def exclude_exception?(exception, _) do
+        @impl true
+        def exclude_exception?(exception, _source) do
           Plug.Exception.status(exception) < 500
         end
       end
 
-  Sentry uses `Sentry.DefaultEventFilter` by default.
+  If you want to exclude some specific exceptions but then fall back to the
+  default event filter, you can do something like this:
+
+      defmodule MyApp.SentryEventFilter do
+        @behaviour Sentry.EventFilter
+
+        @impl true
+        def exclude_exception?(%ArithmeticError{}, _source) do
+          true
+        end
+
+        def exclude_exception?(exception, source) do
+          Sentry.DefaultEventFilter.exclude_exception?(exception, source)
+        end
+      end
+
   """
 
   @doc """
-  Callback that returns whether an exception should be excluded from
-  being reported
+  Should return whether the given event should be *excluded* from being
+  reported to Sentry.
+
+  `exception` is the exception that was raised.
+
+  `source` is the source of the event. Events from `Sentry.PlugCapture`
+  will have `:plug` as a source and events from `Sentry.LoggerBackend`
+  will have `:logger` as the source. A custom source can also be specified
+  by passing the `:event_source` option to `Sentry.capture_exception/2`.
   """
-  @callback exclude_exception?(Exception.t(), atom) :: boolean
+  @callback exclude_exception?(exception :: Exception.t(), source :: atom) :: boolean
 end


### PR DESCRIPTION
I think it should be public. 🙃 