### PR TITLE
Remove support for DSN query params

### DIFF
--- a/lib/sentry.ex
+++ b/lib/sentry.ex
@@ -137,6 +137,7 @@ defmodule Sentry do
     validate_json_config!()
     Config.validate_log_level!()
     Config.validate_included_environments!()
+    Config.assert_dsn_has_no_query_params!()
 
     opts = [strategy: :one_for_one, name: Sentry.Supervisor]
     Supervisor.start_link(children, opts)

--- a/pages/upgrade-9.x.md
+++ b/pages/upgrade-9.x.md
@@ -5,3 +5,27 @@ This guide contains information on how to upgrade from Sentry 8.x to Sentry 9.x.
 ## Check Your Elixir Version
 
 Sentry 9.0.0 requires Elixir 1.11+. If you're still running on Elixir 1.10 or lower, use Sentry 8.x or lower.
+
+## Remove DSN Query Params
+
+Before 9.0.0, the Sentry Elixir library supported one way of passing configuration through **query parameters** in the configured Sentry DSN. This is **not supported** anymore in 9.0.0.
+
+To upgrade:
+
+  1. Remove query parameters from your configured Sentry DSN.
+  1. Set the values for those parameters as normal configuration, either via the application environment, or via environment variables.
+
+For example:
+
+```elixir
+# In config/config.exs
+
+# Replace this:
+config :sentry,
+  dsn: "https://public:secret@app.getsentry.com/1?server_name=my-server"
+
+# with this:
+config :sentry,
+  dsn: "https://public:secret@app.getsentry.com/1",
+  server_name: "my-server"
+```

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -24,25 +24,6 @@ defmodule Sentry.ConfigTest do
     assert Application.get_env(:sentry, :dsn) == dsn
   end
 
-  test "retrieves from DSN query string" do
-    modify_env(
-      :sentry,
-      dsn: "https://public:super_secret@app.getsentry.com/2?server_name=my_server"
-    )
-
-    assert "my_server" == Config.server_name()
-  end
-
-  test "sets application env if found in DSN query string" do
-    modify_env(
-      :sentry,
-      dsn: "https://public:super_secret@app.getsentry.com/2?server_name=my_server"
-    )
-
-    assert "my_server" == Config.server_name()
-    assert Application.get_env(:sentry, :server_name) == "my_server"
-  end
-
   describe "source_code_path_pattern" do
     test "retrieves from environment" do
       modify_env(:sentry, source_code_path_pattern: "**/*test.ex")


### PR DESCRIPTION
As discussed on Discord with @sl0thentr0py. This is non-standard across the Sentry SDKs.