### PR TITLE
Move all the config docs to the Sentry module

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,44 +73,6 @@ config :sentry,
   root_source_code_paths: [File.cwd!()]
 ```
 
-The `environment_name` and `included_environments` work together to determine
-if and when Sentry should send events to the server. If the currently configured
-`:environment_name` is in the configured list of `:included_environments`, the
-event will be sent.
-
-The full range of options is the following:
-
-| Key           | Required         | Default      | Notes |
-| ------------- | -----------------|--------------|-------|
-| `dsn` | True  | n/a | |
-| `environment_name` | False  | :prod | |
-| `included_environments` | False  | `[:test, :dev, :prod]` | If you need non-standard mix env names you *need* to include it here |
-| `tags` | False  | `%{}` | |
-| `release` | False  | None | |
-| `server_name` | False  | None | |
-| `client` | False  | `Sentry.HackneyClient` | If you need different functionality for the HTTP client, you can define your own module that implements the `Sentry.HTTPClient` behaviour and set `client` to that module |
-| `hackney_opts` | False  | `[pool: :sentry_pool]` | |
-| `hackney_pool_max_connections` | False  | 50 | |
-| `hackney_pool_timeout` | False  | 5000 | |
-| `before_send_event` | False | | |
-| `after_send_event` | False | | |
-| `sample_rate` | False | 1.0 | |
-| `send_result` | False | `:none` | You may want to set it to `:sync` if testing your Sentry integration. See "Testing with Sentry" |
-| `send_max_attempts` | False | 4 | |
-| `in_app_module_allow_list` | False | `[]` | |
-| `report_deps` | False | True | Will attempt to load Mix dependencies at compile time to report alongside events |
-| `enable_source_code_context` | False | False | |
-| `root_source_code_paths` | Required if `enable_source_code_context` is enabled | | Should usually be set to `[File.cwd!()]`. For umbrella applications you should list all your applications paths in this list (e.g. `["#{File.cwd!()}/apps/app_1", "#{File.cwd!()}/apps/app_2"]`. |
-| `context_lines` | False  | 3 | |
-| `source_code_exclude_patterns` | False  | `[~r"/_build/", ~r"/deps/", ~r"/priv/"]` | |
-| `source_code_path_pattern` | False  | `"**/*.ex"` | |
-| `filter` | False | | Module where the filter rules are defined (see [Filtering Exceptions](https://hexdocs.pm/sentry/Sentry.html#module-filtering-exceptions)) |
-| `json_library` | False | `Jason` | |
-| `log_level` | False | `:warning` | This sets the log level used when Sentry fails to send an event due to an invalid event or API error |
-| `max_breadcrumbs` | False | 100 | This sets the maximum number of breadcrumbs to send to Sentry when creating an event |
-
-Sentry uses the [hackney HTTP client](https://github.com/benoitc/hackney) for HTTP requests.  Sentry starts its own hackney pool named `:sentry_pool` with a default connection pool of 50, and a connection timeout of 5000 milliseconds.  The pool can be configured with the `hackney_pool_max_connections` and `hackney_pool_timeout` configuration keys.  If you need to set other [hackney configurations](https://github.com/benoitc/hackney/blob/master/doc/hackney.md#request5) for things like a proxy, using your own pool or response timeouts, the `hackney_opts` configuration is passed directly to hackney for each request.
-
 ### Context and Breadcrumbs
 
 Sentry has multiple options for including contextual information. They are organized into "Tags", "User", and "Extra", and Sentry's documentation on them is [here](https://docs.sentry.io/learn/context/).  Breadcrumbs are a similar concept and Sentry's documentation covers them [here](https://docs.sentry.io/learn/breadcrumbs/).

--- a/lib/sentry.ex
+++ b/lib/sentry.ex
@@ -3,7 +3,7 @@ defmodule Sentry do
   alias Sentry.{Config, Event}
   require Logger
 
-  @moduledoc """
+  @moduledoc ~S"""
   Provides the functionality to submit events to [Sentry](https://sentry.io).
 
   This library can be used to submit events to Sentry from any Elixir application.
@@ -17,10 +17,11 @@ defmodule Sentry do
       [*Setup with Plug and Phoenix* guide](setup-with-plug-and-phoenix.html), and the
       `Sentry.PlugCapture` and `Sentry.PlugContext` modules.
 
-  ## Configuration
+  ## Usage
 
-  Add the following to your production config
+  Add the following to your production configuration:
 
+      # In config/prod.exs
       config :sentry, dsn: "https://public:secret@app.getsentry.com/1",
         included_environments: [:prod],
         environment_name: :prod,
@@ -28,36 +29,183 @@ defmodule Sentry do
           env: "production"
         }
 
-  The `environment_name` and `included_environments` work together to determine
-  if and when Sentry should record exceptions. The `environment_name` is the
+  The `:environment_name` and `:included_environments` options work together to determine
+  if and when Sentry should record exceptions. The `en:vironment_name` is the
   name of the current environment. In the example above, we have explicitly set
   the environment to `:prod` which works well if you are inside an environment
   specific configuration `config/prod.exs`.
 
-  An alternative is to use `Mix.env` in your general configuration file:
+  An alternative is to use `Config.config_env/0` in your general configuration file:
 
       config :sentry, dsn: "https://public:secret@app.getsentry.com/1",
         included_environments: [:prod],
-        environment_name: Mix.env()
+        environment_name: config_env()
 
-  This will set the environment name to whatever the current Mix environment
-  atom is, but it will only send events if the current environment is `:prod`,
-  since that is the only entry in the `included_environments` key.
+  This will set the environment name to whatever the current environment
+  is, but it will only send events if the current environment is `:prod`,
+  since that is the only entry in the `:included_environments` key.
 
-  You can even rely on more custom determinations of the environment name. It's
+  You can even rely on more specific logic to determine the environment name. It's
   not uncommmon for most applications to have a "staging" environment. In order
   to handle this without adding an additional Mix environment, you can set an
-  environment variable that determines the release level.
+  environment variable that determines the release level. By default, Sentry
+  picks up the `SENTRY_ENVIRONMENT` variable. Otherwise, you can read the
+  variable at runtime. Do this only in `config/runtime.exs` so that it will
+  work both for local development as well as Mix releases.
 
+      # In config/runtime.exs
       config :sentry, dsn: "https://public:secret@app.getsentry.com/1",
         included_environments: ~w(production staging),
-        environment_name: System.get_env("RELEASE_LEVEL") || "development"
+        environment_name: System.get_env("RELEASE_LEVEL", "development")
 
   In this example, we are getting the environment name from the `RELEASE_LEVEL`
   environment variable. If that variable does not exist, we default to `"development"`.
   Now, on our servers, we can set the environment variable appropriately. On
   our local development machines, exceptions will never be sent, because the
-  default value is not in the list of `included_environments`.
+  default value is not in the list of `:included_environments`.
+
+  Sentry supports many configuration options. See the [*Configuration*
+  section](#module-configuration) for complete documentation.
+
+  ## Configuration
+
+  You can configure Sentry through the application environment. Configure
+  the following keys under the `:sentry` application. For example, you can
+  do this in `config/config.exs`:
+
+      # config/config.exs
+      config :sentry,
+        # ...
+
+  The basic configuration options are:
+
+    * `:dsn` (`t:String.t/0`) - the DSN for your Sentry project.
+      If this is not set, Sentry will not be enabled. If the `SENTRY_DSN`
+      environment variable is set, it will be used as the default value.
+
+    * `:release` (`t:String.t/0`) - the release version of your application.
+      This is used to correlate events with source code. If the `SENTRY_RELEASE`
+      environment variable is set, it will be used as the default value.
+
+    * `:environment_name` (`t:atom/0` or `t:String.t/0`) - the current
+      environment name. This is used to determine if Sentry should be enabled
+      and if events should be sent. For events to be sent, the value of
+      this option must appear in the `:included_environments` list.
+      If the `SENTRY_ENVIRONMENT` environment variable is set, it will
+      be used as the defaults value. Otherwise, defaults to `"dev"`.
+
+    * `:included_environments` (list of `t:atom/0` or `t:String.t/0`) -
+      the environments in which Sentry can report events. `:environment_name`
+      needs to be in this list for events to be reported. Defaults to `[:prod]`.
+
+    * `:tags` (`t:map/0`) - a map of tags to be sent with every event.
+      Defaults to `%{}`.
+
+    * `:server_name` (`t:String.t/0`) - the name of the server running the
+      application. Not used by default.
+
+    * `:filter` (`t:module/0`) - a module that implements the `Sentry.Filter`
+      behaviour. Defaults to `Sentry.DefaultEventFilter`. See the
+      [*Filtering Exceptions* section](#module-filtering-exceptions) below.
+
+    * `:json_library` (`t:module/0`) - a module that implements the "standard"
+      Elixir JSON behaviour, that is, exports the `encode/1` and `decode/1`
+      functions. Defaults to `Jason`, which requires [`:jason`](https://hex.pm/packages/jason)
+      to be a dependency of your application.
+
+    * `:log_level` (`t:Logger.level/0`) - the level to use when Sentry fails to
+      send an event due to an API failure or other reasons. Defaults to `:warning`.
+
+  To customize what happens when sending an event, you can use these options:
+
+    * `:sample_rate` (`t:float/0` between `0.0` and `1.0`) - the percentage
+      of events to send to Sentry. Defaults to `1.0` (100% of events).
+
+    * `:send_result` (`t:atom/0`) - controls what to return when reporting exceptions
+      to Sentry. Defaults to `:none`.
+
+    * `:send_max_attempts` (`t:integer/0`) - the maximum number of attempts to
+      send an event to Sentry. Defaults to `4`.
+
+    * `:max_breadcrumbs` (`t:integer/0`) - the maximum number of breadcrumbs
+      to keep. Defaults to `100`. See `Sentry.Context.add_breadcrumb/1`.
+
+    * `:before_send_event` (`t:before_send_event_callback/0`) - allows performing operations
+      on the event *before* it is sent. If the callback returns `nil` or `false`,
+      the event is not reported. If it returns an updated `Sentry.Event`, then
+      the updated event is used instead. See the [*Event Callbacks*
+      section](#module-event-callbacks) below for more information.
+
+    * `:after_send_event` (`t:after_send_event_callback/0`) - callback that is called *after*
+      attempting to send an event.  The result of the HTTP call as well as the event will
+      be passed as arguments. The return value of the callback is not returned. See the
+      [*Event Callbacks* section](#module-event-callbacks) below for more information.
+
+    * `:in_app_module_allow_list` (list of `t:module/0`) - a list of modules that is used
+      to distinguish among stacktrace frames that belong to your app and ones that are
+      part of libraries or core Elixir. This is used to better display the significant part
+      of stacktraces. The logic is "greedy", so if your app's root module is `MyApp` and
+      you configure this option to `[MyApp]`, `MyApp` as well as any submodules
+      (like `MyApp.Submodule`) would be considered part of your app. Defaults to `[]`.
+
+  To customize the behaviour of the HTTP client used by Sentry, you can
+  use these options:
+
+    * `:client` (`t:module/0`) - a module that implements the `Sentry.HTTPClient`
+      behaviour. Defaults to `Sentry.HackneyClient`, which uses
+      [hackney](https://github.com/benoitc/hackney) as the HTTP client.
+
+    * `:hackney_opts` (`t:keyword/0`) - options to be passed to `hackney`. Only
+      applied if `:client` is set to `Sentry.HackneyClient`. Defaults to
+      `[pool: :sentry_pool]`.
+
+    * `:hackney_pool_max_connections` (`t:integer/0`) - the maximum number of
+      connections to keep in the pool. Only applied if `:client` is set to
+      `Sentry.HackneyClient`. Defaults to `50`.
+
+    * `:hackney_pool_timeout` (`t:integer/0`) - the maximum time to wait for a
+      connection to become available. Only applied if `:client` is set to
+      `Sentry.HackneyClient`. Defaults to `5000`.
+
+  To customize options related to reporting source code context, you can use these
+  options:
+
+    * `:report_deps` (`t:boolean/0`) - whether to report Mix dependencies of your
+      application alongside events. If `true`, this attempts to load dependencies
+      *at compile time*. Defaults to `true`.
+
+    * `:enable_source_code_context` (`t:boolean/0`) - whether to report source
+      code context alongside events. Defaults to `false`.
+
+    * `:root_source_code_paths` (list of `t:Path.t/0`) - a list of paths to the root of
+      your application's source code. This is used to determine the relative
+      path of files in stack traces. Usually, you'll want to set this to
+      `[File.cwd!()]`. For umbrella apps, you should set this to all the application
+      paths in your umbrella (such as `[Path.join(File.cwd!(), "apps/app1"), ...]`).
+      **Required** if `:enabled_source_code_context` is `true`.
+
+    * `:source_code_path_pattern` (`t:String.t/0`) - a glob pattern used to
+      determine which files to report source code context for. The glon "starts"
+      from `:root_source_code_paths`. Defaults to `"**/*.ex"`.
+
+    * `:source_code_exclude_patterns` (list of `t:Regex.t/0`) - a list of regular
+      expressions used to determine which files to exclude from source code
+      context. Defaults to `[~r"/_build/", ~r"/deps/", ~r"/priv/"]`.
+
+    * `:context_lines` (`t:integer/0`) - the number of lines of source code
+      before and after the line that caused the exception to report. Defaults to `3`.
+
+  > #### Compile-time Configuration {: .tip}
+  >
+  > These options are only available at compile-time:
+  >   * `:enable_source_code_context`
+  >   * `:root_source_code_paths`
+  >   * `:report_deps`
+  >   * `:source_code_path_pattern`
+  >   * `:source_code_exclude_patterns`
+  >
+  > If you change the value of any of these, you'll need to recompile Sentry itself.
+  > You can run `mix deps.compile sentry` to do that.
 
   ### Configuration Through System Environment
 
@@ -78,48 +226,83 @@ defmodule Sentry do
 
   ## Filtering Exceptions
 
-  If you would like to prevent certain exceptions, the `:filter` configuration option
-  allows you to implement the `Sentry.EventFilter` behaviour.  The first argument is the
-  exception to be sent, and the second is the source of the event.  `Sentry.Plug`
-  will have a source of `:plug`, `Sentry.LoggerBackend` will have a source of `:logger`, and `Sentry.Phoenix.Endpoint` will have a source of `:endpoint`.
-  If an exception does not come from either of those sources, the source will be nil
-  unless the `:event_source` option is passed to `Sentry.capture_exception/2`
+  If you would like to prevent Sentry from sending certain exceptions, you can
+  use the `:filter` configuration option. It must be configured to be a module
+  that implements the `Sentry.EventFilter` behaviour.
 
-  A configuration like below will prevent sending `Phoenix.Router.NoRouteError` from `Sentry.Plug`, but
-  allows other exceptions to be sent.
+  A configuration like the one below prevents sending `Phoenix.Router.NoRouteError`
+  exceptions coming from `Sentry.Plug`, but allows other exceptions to be sent.
 
-      # sentry_event_filter.ex
       defmodule MyApp.SentryEventFilter do
         @behaviour Sentry.EventFilter
 
-        def exclude_exception?(%Elixir.Phoenix.Router.NoRouteError{}, :plug), do: true
+        @impl true
+        def exclude_exception?(%Phoenix.Router.NoRouteError{}, :plug), do: true
         def exclude_exception?(_exception, _source), do: false
       end
 
-      # config.exs
-      config :sentry, filter: MyApp.SentryEventFilter,
-        included_environments: ~w(production staging),
-        environment_name: System.get_env("RELEASE_LEVEL") || "development"
+      # In config/config.exs
+      config :sentry,
+        filter: MyApp.SentryEventFilter,
+        # other config...
 
-  ## Capturing Exceptions
 
-  Simply calling `capture_exception/2` will send the event. By default, the event
-  is sent asynchronously and the result can be awaited upon.  The `:result` option
-  can be used to change this behavior.  See `Sentry.Client.send_event/2` for more
-  information.
+  ## Event Callbacks
 
-      {:ok, task} = Sentry.capture_exception(my_exception)
-      {:ok, event_id} = Task.await(task)
-      {:ok, another_event_id} = Sentry.capture_exception(other_exception, [event_source: :my_source, result: :sync])
+  You can configure the `:before_send_event` and `:after_send_event` options to
+  customize what happens before and/or after sending an event. For example, you
+  can set:
 
-  ### Options
+      config :sentry,
+        before_send_event: {MyModule, :before_send},
+        before_send_event: {MyModule, :after_send}
 
-    * `:event_source` - The source passed as the first argument to `c:Sentry.EventFilter.exclude_exception?/2`
+  `MyModule` could look like this:
 
-  ## Configuring The `Logger` Backend
+      defmodule MyModule do
+        def before_send(event) do
+          metadata = Map.new(Logger.metadata())
+          %{event | extra: Map.merge(event.extra, metadata)}
+        end
 
-  See `Sentry.LoggerBackend`
+        def after_send_event(event, result) do
+          case result do
+            {:ok, id} ->
+              Logger.info("Successfully sent event!")
+
+            _ ->
+              Logger.info(fn -> "Did not successfully send event! #{inspect(event)}" end)
+          end
+        end
+      end
+
   """
+
+  @typedoc """
+  A callback to use with the `:before_send_event` configuration option.
+  configuration options.k
+
+  If this is `{module, function_name}`, then `module.function_name(event)` will
+  be called, where `event` is of type `t:Sentry.Event.t/0`.
+
+  See the [*Configuration* section](#module-configuration) in the module documentation
+  for more information on configuration.
+  """
+  @typedoc since: "9.0.0"
+  @type before_send_event_callback() ::
+          (Sentry.Event.t() -> as_boolean(Sentry.Event.t()))
+          | {module(), function_name :: atom()}
+
+  @typedoc """
+  A callback to use with the `:after_send_event` configuration option.
+
+  If this is `{module, function_name}`, then `module.function_name(event, result)` will
+  be called, where `event` is of type `t:Sentry.Event.t/0`.
+  """
+  @typedoc since: "9.0.0"
+  @type after_send_event_callback() ::
+          (Sentry.Event.t(), result :: term() -> term())
+          | {module(), function_name :: atom()}
 
   @type send_result :: Sentry.Client.send_event_result() | :excluded | :ignored
 
@@ -155,8 +338,13 @@ defmodule Sentry do
   end
 
   @doc """
-  Parses and submits an exception to Sentry if current environment is in included_environments.
-  `opts` argument is passed as the second argument to `Sentry.send_event/2`.
+  Parses and submits an exception to Sentry
+
+  This only sends the exception if the current Sentry environment is in
+  the `:included_environments`. See the [*Configuration* section](#module-configuration)
+  in the module documentation.
+
+  The `opts` argument is passed as the second argument to `send_event/2`.
   """
   @spec capture_exception(Exception.t(), Keyword.t()) :: send_result
   def capture_exception(exception, opts \\ []) do

--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -1,5 +1,5 @@
 defmodule Sentry.Client do
-  @moduledoc ~S"""
+  @moduledoc """
   This module interfaces directly with Sentry via HTTP.
 
   The client itself can be configured via the :client
@@ -9,41 +9,6 @@ defmodule Sentry.Client do
   It makes use of `Task.Supervisor` to allow sending tasks
   synchronously or asynchronously, and defaulting to asynchronous.
   See `send_event/2` for more information.
-
-  ### Configuration
-
-    * `:before_send_event` - allows performing operations on the event before
-      it is sent. Accepts an anonymous function or a `{module, function}` tuple,
-      and the event will be passed as the only argument.
-
-    * `:after_send_event` - callback that is called after attempting to send an event.
-      Accepts an anonymous function or a `{module, function}` tuple. The result of the
-      HTTP call as well as the event will be passed as arguments. The return value of
-      the callback is not returned.
-
-  Example configuration of putting Logger metadata in the extra context:
-
-      config :sentry,
-        before_send_event: {MyModule, :before_send},
-        before_send_event: {MyModule, :after_send}
-
-  where:
-
-      defmodule MyModule do
-        def before_send(event) do
-          metadata = Map.new(Logger.metadata)
-          %{event | extra: Map.merge(event.extra, metadata)}
-        end
-
-        def after_send_event(event, result) do
-          case result do
-            {:ok, id} ->
-              Logger.info("Successfully sent event!")
-            _ ->
-              Logger.info(fn -> "Did not successfully send event! #{inspect(event)}" end)
-          end
-        end
-      end
   """
 
   alias Sentry.{Config, Event}

--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -1,13 +1,7 @@
 defmodule Sentry.Event do
   @moduledoc """
-    Provides an Event Struct as well as transformation of Logger
-    entries into Sentry Events.
-
-  ### Configuration
-
-  * `:in_app_module_allow_list` - Expects a list of modules that is used to distinguish among stacktrace frames that belong to your app and ones that are part of libraries or core Elixir.  This is used to better display the significant part of stacktraces.  The logic is greedy, so if your app's root module is `MyApp` and your setting is `[MyApp]`, that module as well as any submodules like `MyApp.Submodule` would be considered part of your app.  Defaults to `[]`.
-  * `:report_deps` - Flag for whether to include the loaded dependencies when reporting an error. Defaults to true.
-
+  Provides an Event Struct as well as transformation of Logger
+  entries into Sentry Events.
   """
 
   defstruct event_id: nil,

--- a/lib/sentry/hackney_client.ex
+++ b/lib/sentry/hackney_client.ex
@@ -10,6 +10,12 @@ defmodule Sentry.HackneyClient do
   which is an *optional dependency* of this library. If you wish to use another
   HTTP client, you'll have to implement your own `Sentry.HTTPClient`. See the
   documentation for `Sentry.HTTPClient` for more information.
+
+  Sentry starts its own hackney pool called `:sentry_pool`. If you need to set other
+  [hackney configuration options](https://github.com/benoitc/hackney/blob/master/doc/hackney.md#request5)
+  for things such as proxies, using your own pool, or response timeouts, the `:hackney_opts`
+  configuration is passed directly to hackney for each request. See the configuration
+  documentation in the `Sentry` module.
   """
 
   @hackney_pool_name :sentry_pool

--- a/lib/sentry/sources.ex
+++ b/lib/sentry/sources.ex
@@ -6,25 +6,6 @@ defmodule Sentry.Sources do
   the text of source files during compilation for displaying the
   source code that caused an exception.
 
-  ### Configuration
-  There is configuration required to set up this functionality.  The options
-  include `:enable_source_code_context`, `:root_source_code_paths`, `:context_lines`,
-  `:source_code_exclude_patterns`, and `:source_code_path_pattern`. The options must
-  be set at compile-time.
-
-  * `:enable_source_code_context` - when `true`, enables reporting source code
-    alongside exceptions.
-  * `:root_source_code_paths` - List of paths from which to start recursively reading files from.
-    Should usually be set to `[File.cwd!()]`. For umbrella applications you should list all your
-    applications paths in this list (e.g. `["#{File.cwd!()}/apps/app_1", "#{File.cwd!()}/apps/app_2"]`.
-  * `:context_lines` - The number of lines of source code before and after the line that
-    caused the exception to be included.  Defaults to `3`.
-  * `:source_code_exclude_patterns` - a list of Regex expressions used to exclude file paths that
-    should not be stored or referenced when reporting exceptions.  Defaults to
-    `[~r"/_build/", ~r"/deps/", ~r"/priv/"]`.
-  * `:source_code_path_pattern` - a glob that is expanded to select files from the
-    `:root_source_code_paths`.  Defaults to `"**/*.ex"`.
-
   An example configuration:
 
       config :sentry,


### PR DESCRIPTION
This was a lot of work, but I removed docs from the README and moved them to a new section in the `Sentry` module. Some of these were spread out, some were outdated, so I think this is a good change!