### PR TITLE
Make Sentry.send_event/1,2 private

### DIFF
--- a/lib/sentry.ex
+++ b/lib/sentry.ex
@@ -341,7 +341,7 @@ defmodule Sentry do
   the `:included_environments`. See the [*Configuration* section](#module-configuration)
   in the module documentation.
 
-  The `opts` argument is passed as the second argument to `send_event/2`.
+  The `opts` argument is passed as the second argument to `Sentry.Client.send_event/2`.
   """
   @spec capture_exception(Exception.t(), Keyword.t()) :: send_result
   def capture_exception(exception, opts \\ []) do
@@ -379,7 +379,7 @@ defmodule Sentry do
   @doc """
   Reports a message to Sentry.
 
-  `opts` argument is passed as the second argument to `Sentry.send_event/2`.
+  `opts` argument is passed as the second argument to `Sentry.Client.send_event/2`.
   """
   @spec capture_message(String.t(), Keyword.t()) :: send_result
   def capture_message(message, opts \\ []) when is_binary(message) do

--- a/lib/sentry.ex
+++ b/lib/sentry.ex
@@ -389,21 +389,13 @@ defmodule Sentry do
     |> send_event(opts)
   end
 
-  @doc """
-  Sends a `Sentry.Event`
-
-  `opts` argument is passed as the second argument to `send_event/2` of the configured `Sentry.HTTPClient`.  See `Sentry.Client.send_event/2` for more information.
-  """
-  @spec send_event(Event.t(), Keyword.t()) :: send_result
-  def send_event(event, opts \\ [])
-
-  def send_event(%Event{message: nil, exception: nil}, _opts) do
+  defp send_event(%Event{message: nil, exception: nil}, _opts) do
     Logger.log(Config.log_level(), "Sentry: unable to parse exception")
 
     :ignored
   end
 
-  def send_event(%Event{} = event, opts) do
+  defp send_event(%Event{} = event, opts) do
     included_environments = Config.included_environments()
     environment_name = Config.environment_name()
 

--- a/pages/upgrade-9.x.md
+++ b/pages/upgrade-9.x.md
@@ -68,7 +68,7 @@ Sentry used to support setting configuration options to `{:system, var}` in orde
 
 With Mix releases, you can use `config/runtime.exs` to have runtime configuration that works both within releases and using Mix (like during local development).
 
-To fix this, remove all the `{:system, var}` values from the Sentry configuration, move those options to `config/runtime.exs`, and use normal `System` functions to read the environment (such as `System.fetch_env!/2`).
+To fix this, remove all the `{:system, var}` values from the Sentry configuration, move those options to `config/runtime.exs`, and use normal `System` functions to read the environment (such as `System.fetch_env!/1`).
 
 ```elixir
 # Before, in config/config.exs ❌
@@ -97,3 +97,11 @@ The settings that are now *compile-time settings* are:
   * `:report_deps`
   * `:source_code_path_pattern`
   * `:source_code_exclude_patterns`
+
+## Stop Using API That Is Now Private
+
+Some public-facing APIs have been removed. These were more internal than public, and hopefully not many folks are relying on these.
+
+These are the things to patch up:
+
+  * `Sentry.send_event/1,2` - This function doesn't exist anymore. Building events manually is not public API anymore, since Sentry's event format can change and evolve and we want this library to be able to stay on top of things without introducing breaking changes. Replace `Sentry.send_event/1,2` calls with `Sentry.capture_exception/1,2` or `Sentry.capture_message/1,2`.


### PR DESCRIPTION
This is in preparation of making the Sentry event struct(s) private, since they changed in Sentry's API and we want to be able to modify these flexibly.