### PR TITLE
Fix error when using process_info/2 on remote PIDs

### DIFF
--- a/lib/sentry/logger_backend.ex
+++ b/lib/sentry/logger_backend.ex
@@ -123,7 +123,8 @@ defmodule Sentry.LoggerBackend do
   end
 
   defp get_sentry_from_callers([head | tail]) when is_pid(head) do
-    with {:dictionary, [_ | _] = dictionary} <- :erlang.process_info(head, :dictionary),
+    with {:current_node, true} <- {:current_node, node(head) == Node.self()},
+         {:dictionary, [_ | _] = dictionary} <- :erlang.process_info(head, :dictionary),
          %{sentry: sentry} <- dictionary[:"$logger_metadata$"] do
       sentry
     else


### PR DESCRIPTION
Small patch to not throw when parsing stacktraces. 

This function currently throws right now when you have a remote pid in your call chain, which may happen if you are passing module/function/arguments from one node to another, since `:erlang.process_info` throws a `badarg` when it's pass a pid from a remote machine (https://www.erlang.org/doc/man/erlang#process_info-2).

Since this function is private I didn't add any tests, but this can be tested in iex by manually making this function public and:

```
# Open one iex Session
iex --name node1@127.0.0.1 -S mix
> pid = spawn(fn -> :timer.sleep(:infinity) end)
> :global.register_name(:test_process, pid)

# Open second iex session
iex --name node2@127.0.0.1 -S mix
> remote_pid = :global.whereis_name(:test_process)
> Sentry.LoggerBackend.get_sentry_from_callers([remote_pid])
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not a local pid

    :erlang.process_info(#PID<21647.324.0>, :dictionary)
    (sentry 8.1.0) iex:128: Sentry.LoggerBackend.get_sentry_from_callers/1
    iex:6: (file)
```