### PR TITLE
Add `Sentry.Payloads` and all the public payload structs

### DIFF
--- a/lib/sentry/payloads.ex
+++ b/lib/sentry/payloads.ex
@@ -2,9 +2,15 @@ defmodule Sentry.Payloads do
   @moduledoc false
 
   defmodule Event do
-    @moduledoc false
-    # https://develop.sentry.dev/sdk/event-payloads/
+    @moduledoc """
+    The struct for the top-level Sentry event payload.
 
+    See <https://develop.sentry.dev/sdk/event-payloads>.
+    """
+
+    @moduledoc since: "9.0.0"
+
+    @typedoc since: "9.0.0"
     @type t() :: %__MODULE__{
             # Required
             event_id: <<_::128>>,
@@ -19,10 +25,11 @@ defmodule Sentry.Payloads do
             release: String.t() | nil,
             dist: String.t() | nil,
             tags: %{optional(String.t()) => String.t()},
-            environment: String.t(),
+            environment: String.t() | nil,
             modules: %{optional(String.t()) => String.t()},
             extra: map(),
             fingerprint: [String.t()],
+            sdk: Sentry.Payloads.SDK.t() | nil,
 
             # Possible payloads.
             exception: [Sentry.Payloads.Exception.t(), ...] | nil
@@ -47,6 +54,7 @@ defmodule Sentry.Payloads do
       :release,
       :dist,
       :exception,
+      :sdk,
 
       # Required. Has to be "elixir".
       platform: :elixir,
@@ -60,10 +68,37 @@ defmodule Sentry.Payloads do
     ]
   end
 
-  defmodule Exception do
-    @moduledoc false
-    # https://develop.sentry.dev/sdk/event-payloads/exception/
+  defmodule SDK do
+    @moduledoc """
+    The struct for the **SDK** interface.
 
+    This is usually filled in by the SDK itself.
+
+    See <https://develop.sentry.dev/sdk/event-payloads/sdk>.
+    """
+
+    @moduledoc since: "9.0.0"
+
+    @typedoc since: "9.0.0"
+    @type t() :: %__MODULE__{
+            name: String.t(),
+            version: String.t()
+          }
+
+    @enforce_keys [:name, :version]
+    defstruct [:name, :version]
+  end
+
+  defmodule Exception do
+    @moduledoc """
+    The struct for the **exception** interface.
+
+    See <https://develop.sentry.dev/sdk/event-payloads/exception>.
+    """
+
+    @moduledoc since: "9.0.0"
+
+    @typedoc since: "9.0.0"
     @type t() :: %__MODULE__{
             type: String.t(),
             value: String.t(),
@@ -76,9 +111,15 @@ defmodule Sentry.Payloads do
   end
 
   defmodule Stacktrace.Frame do
-    @moduledoc false
-    # https://develop.sentry.dev/sdk/event-payloads/stacktrace/
+    @moduledoc """
+    The struct for the **stacktrace frame** to be used within exceptions.
 
+    See `Sentry.Payloads.Stacktrace`.
+    """
+
+    @moduledoc since: "9.0.0"
+
+    @typedoc since: "9.0.0"
     @type t() :: %__MODULE__{
             filename: Path.t(),
             function: String.t(),
@@ -97,9 +138,15 @@ defmodule Sentry.Payloads do
   end
 
   defmodule Stacktrace do
-    @moduledoc false
-    # https://develop.sentry.dev/sdk/event-payloads/stacktrace/
+    @moduledoc """
+    The struct for the **stacktrace** interface.
 
+    See <https://develop.sentry.dev/sdk/event-payloads/stacktrace>.
+    """
+
+    @moduledoc since: "9.0.0"
+
+    @typedoc since: "9.0.0"
     @type t() :: %__MODULE__{
             frames: [Sentry.Payloads.Stacktrace.Frame.t()]
           }

--- a/lib/sentry/payloads.ex
+++ b/lib/sentry/payloads.ex
@@ -1,6 +1,10 @@
 defmodule Sentry.Payloads do
   @moduledoc false
 
+  # The schemas in this module are taken from the Sentry documentation, but also
+  # from the JSONSchema definitions at:
+  # https://github.com/getsentry/sentry-data-schemas/blob/ebc77d3cb2f3ef288913cce80a292ca0389a08e7/relay/event.schema.json
+
   defmodule Event do
     @moduledoc """
     The struct for the top-level Sentry event payload.

--- a/lib/sentry/payloads.ex
+++ b/lib/sentry/payloads.ex
@@ -1,0 +1,110 @@
+defmodule Sentry.Payloads do
+  @moduledoc false
+
+  defmodule Event do
+    @moduledoc false
+    # https://develop.sentry.dev/sdk/event-payloads/
+
+    @type t() :: %__MODULE__{
+            # Required
+            event_id: <<_::128>>,
+            timestamp: String.t() | number(),
+            platform: :elixir,
+
+            # Optional
+            level: :fatal | :error | :warning | :info | :debug | nil,
+            logger: String.t() | nil,
+            transaction: String.t() | nil,
+            server_name: String.t() | nil,
+            release: String.t() | nil,
+            dist: String.t() | nil,
+            tags: %{optional(String.t()) => String.t()},
+            environment: String.t(),
+            modules: %{optional(String.t()) => String.t()},
+            extra: map(),
+            fingerprint: [String.t()],
+
+            # Possible payloads.
+            exception: [Sentry.Payloads.Exception.t(), ...] | nil
+          }
+
+    @enforce_keys [:event_id, :timestamp]
+    defstruct [
+      # Required. Hexadecimal string representing a uuid4 value. The length is exactly 32
+      # characters. Dashes are not allowed. Has to be lowercase.
+      :event_id,
+
+      # Required. Indicates when the event was created in the Sentry SDK. The format is either a
+      # string as defined in RFC 3339 or a numeric (integer or float) value representing the number
+      # of seconds that have elapsed since the Unix epoch.
+      :timestamp,
+
+      # Optional fields without defaults.
+      :level,
+      :logger,
+      :transaction,
+      :server_name,
+      :release,
+      :dist,
+      :exception,
+
+      # Required. Has to be "elixir".
+      platform: :elixir,
+
+      # Optional fields with defaults.
+      tags: %{},
+      modules: %{},
+      extra: %{},
+      fingerprint: [],
+      environment: "production"
+    ]
+  end
+
+  defmodule Exception do
+    @moduledoc false
+    # https://develop.sentry.dev/sdk/event-payloads/exception/
+
+    @type t() :: %__MODULE__{
+            type: String.t(),
+            value: String.t(),
+            module: String.t() | nil,
+            stacktrace: Sentry.Payloads.Stacktrace.t() | nil
+          }
+
+    @enforce_keys [:type, :value]
+    defstruct [:type, :value, :module, :stacktrace]
+  end
+
+  defmodule Stacktrace.Frame do
+    @moduledoc false
+    # https://develop.sentry.dev/sdk/event-payloads/stacktrace/
+
+    @type t() :: %__MODULE__{
+            filename: Path.t(),
+            function: String.t(),
+            lineno: pos_integer(),
+            colno: pos_integer(),
+            abs_path: Path.t()
+          }
+
+    defstruct [
+      :filename,
+      :function,
+      :lineno,
+      :colno,
+      :abs_path
+    ]
+  end
+
+  defmodule Stacktrace do
+    @moduledoc false
+    # https://develop.sentry.dev/sdk/event-payloads/stacktrace/
+
+    @type t() :: %__MODULE__{
+            frames: [Sentry.Payloads.Stacktrace.Frame.t()]
+          }
+
+    @enforce_keys [:frames]
+    defstruct [:frames]
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -33,6 +33,11 @@ defmodule Sentry.Mixfile do
             "pages/upgrade-9.x.md"
           ]
         ],
+        groups_for_modules: [
+          "Payload Structs": [
+            ~r/^Sentry\.Payloads/
+          ]
+        ],
         source_ref: "#{@version}",
         source_url: @source_url,
         main: "readme",


### PR DESCRIPTION
This first PR introduces the data definitions (that is, `defstruct`s) for all the payloads we need to use against Sentry v7.

I scoped all of these under `Sentry.Payloads` because they're mostly not gonna be used by end users, but I’m happy to change these to go under `Sentry.Event`, `Sentry.Stacktrace`, and so on. For example, we can fix the existing `Sentry.Event` to be compliant with Sentry v7. However, I’m afraid that would make a mess of existing structs and make the top-level `Sentry.` module scope a bit crowded.

The grouping in the docs section in `mix.exs` makes it so that these modules are grouped together in the docs:

<img width="286" alt="CleanShot 2023-08-20 at 08 02 15@2x" src="https://github.com/getsentry/sentry-elixir/assets/3890250/15bbe564-4ec2-4e5b-a1ff-8bba3a8c8c2e">

For reference, see:

  * [Event payloads docs](https://develop.sentry.dev/sdk/event-payloads/)
  * [JSONSchema definitions](https://github.com/getsentry/sentry-data-schemas/blob/ebc77d3cb2f3ef288913cce80a292ca0389a08e7/relay/event.schema.json) from https://github.com/getsentry/sentry-data-schemas