### PR TITLE
Remove `:async` result type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### Breaking changes
 
+- Removed `Sentry.Sources`
 - Removed the `Sentry.Event.sentry_exception/0` type
 - Removed `Sentry.Event.add_metadata/1`
 - Removed `Sentry.Event.culprit_from_stacktrace/1`
+- Removed the `:async` value for the `:result` option in `Sentry.Client.send_event/2` (and friends)
 
 ## 8.1.0
 


### PR DESCRIPTION
This will make it significantly harder to implement a "sender pool" as discussed on Discord. I think it's so easy to implement this yourself, and the use case of people caring about the result is so tiny, that we can probably get away with removing this!