### PR TITLE
Make Sentry.HTTPClient.child_spec/0 optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Removed the `:async` value for the `:result` option in `Sentry.send_event/2` (and friends)
 - Removed the `Sentry.Event.sentry_exception/0` type
 
+### Improvements
+
+- Make the `Sentry.HTTPClient.child_spec/0` callback optional
+
 ## 8.1.0
 
 ### Various fixes & improvements

--- a/lib/sentry/http_client.ex
+++ b/lib/sentry/http_client.ex
@@ -10,6 +10,17 @@ defmodule Sentry.HTTPClient do
       config :sentry,
         client: MyHTTPClient
 
+  ## Child Spec
+
+  The `c:child_spec/0` callback is a callback that should be used when you want Sentry
+  to start the HTTP client *under its supervision tree*. If you want to start your own
+  HTTP client under your application's supervision tree, just don't implement the callback
+  and Sentry won't do anything to start the client.
+
+  > #### Optional Since v9.0.0 {: .warning}
+  >
+  > The `c:child_spec/0` callback is optional only since v9.0.0 of Sentry, and was required
+  > before.
   """
 
   @typedoc """
@@ -33,6 +44,8 @@ defmodule Sentry.HTTPClient do
   Should return a **child specification** to start the HTTP client.
 
   For example, this can start a pool of HTTP connections dedicated to Sentry.
+  If not provided, Sentry won't do anything to start your HTTP client. See
+  [the module documentation](#module-child-spec) for more info.
   """
   @callback child_spec() :: :supervisor.child_spec()
 
@@ -42,4 +55,6 @@ defmodule Sentry.HTTPClient do
   @callback post(url :: String.t(), request_headers :: headers(), request_body :: body()) ::
               {:ok, status(), response_headers :: headers(), response_body :: body()}
               | {:error, term()}
+
+  @optional_callbacks [child_spec: 0]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule Sentry.Mixfile do
         plt_file: {:no_warn, "priv/plts/dialyzer.plt"},
         plt_core_path: "priv/plts",
         plt_add_deps: :app_tree,
-        plt_add_apps: [:mix]
+        plt_add_apps: [:mix, :ex_unit]
       ],
       docs: [
         extra_section: "Guides",

--- a/test/support/test_gen_server.ex
+++ b/test/support/test_gen_server.ex
@@ -64,7 +64,7 @@ defmodule Sentry.TestGenServer do
   end
 
   def handle_cast(:invalid_function, state) do
-    NaiveDateTime.from_erl({}, {}, {})
+    apply(NaiveDateTime, :from_erl, [{}, {}, {}])
     {:noreply, state}
   end
 end


### PR DESCRIPTION
Closes #587.

Supersedes #589.