### PR TITLE
Support :all in Sentry.LoggerBackend's :metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Improvements
 
 - Make the `Sentry.HTTPClient.child_spec/0` callback optional
+- Add `:all` as a possible value of the `:metadata` configuration option for `Sentry.LoggerBackend`
 
 ## 8.1.0
 

--- a/lib/sentry/logger_backend.ex
+++ b/lib/sentry/logger_backend.ex
@@ -22,10 +22,11 @@ defmodule Sentry.LoggerBackend do
   * `:metadata` - To include non-Sentry Logger metadata in reports, the
   `:metadata` key can be set to a list of keys. Metadata under those keys will
   be added in the `:extra` context under the `:logger_metadata` key. Defaults
-  to `[]`.
+  to `[]`. If set to `:all`, all metadata will be included. `:all` is available
+  since v9.0.0 of this library.
 
-  * `:level` - The minimum [Logger level](https://hexdocs.pm/logger/Logger.html#module-levels) to send events for.
-  Defaults to `:error`.
+  * `:level` - The minimum [Logger level](https://hexdocs.pm/logger/Logger.html#module-levels
+    to send events for. Defaults to `:error`.
 
   * `:capture_log_messages` - When `true`, this module will send all Logger
   messages. Defaults to `false`, which will only send messages with metadata
@@ -42,6 +43,7 @@ defmodule Sentry.LoggerBackend do
         metadata: [:foo_bar],
         # Send messages like `Logger.error("error")` to Sentry
         capture_log_messages: true
+
   """
 
   @behaviour :gen_event
@@ -166,6 +168,10 @@ defmodule Sentry.LoggerBackend do
   end
 
   defp excluded_domain?(_, _), do: false
+
+  defp logger_metadata(meta, %__MODULE__{metadata: :all}) do
+    Map.new(meta)
+  end
 
   defp logger_metadata(meta, state) do
     for key <- state.metadata,

--- a/test/logger_backend_test.exs
+++ b/test/logger_backend_test.exs
@@ -191,7 +191,6 @@ defmodule Sentry.LoggerBackendTest do
     assert event.extra.logger_metadata.domain == [:otp]
     assert event.extra.logger_metadata.module == :gen_server
     assert event.extra.logger_metadata.file == "gen_server.erl"
-    assert event.extra.logger_metadata.function == "error_info/8"
     assert is_integer(event.extra.logger_metadata.time)
     assert is_pid(event.extra.logger_metadata.pid)
     assert {%FunctionClauseError{}, _stacktrace} = event.extra.logger_metadata.crash_reason


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-elixir/issues/522.

For now, we can start with all metadata since now everything is serializable (#602). We could skip some keys by default in the future, but if you're using `:all`, I believe your intention is to include *all* keys 😉 