### PR TITLE
Send async events right away without queueing

### DIFF
--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -84,9 +84,7 @@ defmodule Sentry.Client do
   end
 
   defp encode_and_send(%Event{} = event, _result_type = :sync, request_retries) do
-    envelope = Envelope.new([event])
-
-    send_result = Transport.post_envelope(envelope, request_retries)
+    send_result = [event] |> Envelope.new() |> Transport.post_envelope(request_retries)
 
     if match?({:ok, _}, send_result) do
       Sentry.put_last_event_id_and_source(event.event_id, event.source)

--- a/test/envelope_test.exs
+++ b/test/envelope_test.exs
@@ -71,8 +71,8 @@ defmodule Sentry.EnvelopeTest do
 
       {:ok, raw_envelope} =
         [event]
-        |> Sentry.Envelope.new()
-        |> Sentry.Envelope.to_binary()
+        |> Envelope.new()
+        |> Envelope.to_binary()
 
       {:ok, envelope} = Envelope.from_binary(raw_envelope)
 

--- a/test/sentry/transport_test.exs
+++ b/test/sentry/transport_test.exs
@@ -15,9 +15,7 @@ defmodule Sentry.TransportTest do
     test "sends a POST request with the right headers and payload", %{bypass: bypass} do
       envelope =
         Envelope.new([
-          Event.create_event(message: "Hello 1"),
-          Event.create_event(message: "Hello 2"),
-          Event.create_event(message: "Hello 3")
+          Event.create_event(message: "Hello 1")
         ])
 
       Bypass.expect_once(bypass, fn conn ->


### PR DESCRIPTION
Envelopes don't support more than one event item per envelope.