### PR TITLE
Attempt to scrub all `Plug.Conn`s in `Sentry.PlugCapture`

### DIFF
--- a/lib/sentry/plug_capture.ex
+++ b/lib/sentry/plug_capture.ex
@@ -1,11 +1,14 @@
 defmodule Sentry.PlugCapture do
   @moduledoc """
-  Provides basic functionality to handle and send errors occurring within
+  Provides basic functionality to capture and send errors occurring within
   Plug applications, including Phoenix.
 
-  It is intended for usage with `Sentry.PlugContext`.
+  It is intended for usage with `Sentry.PlugContext`, which adds relevant request
+  metadata to the Sentry context before errors are captured.
 
   ## Usage
+
+  ### With Phoenix
 
   In a Phoenix application, it is important to use this module **before**
   the Phoenix endpoint itself. It should be added to your `endpoint.ex` file:
@@ -17,7 +20,9 @@ defmodule Sentry.PlugCapture do
         # ...
       end
 
-  In a Plug application, it can be added *below* your router:
+  ### With Plug
+
+  In a Plug application, you can add this module *below* your router:
 
       defmodule MyApp.PlugRouter do
         use Plug.Router
@@ -32,15 +37,58 @@ defmodule Sentry.PlugCapture do
   > and adds capturing errors and reporting to Sentry. You can still re-override
   > that callback after `use Sentry.PlugCapture` if you need to.
 
+  ## Scrubbing Sensitive Data
+
+  Like `Sentry.PlugContext`, this module also supports scrubbing sensitive data
+  out of errors. However, this module has to do some *guessing* to figure
+  out if there are `Plug.Conn` structs to scrub. Right now, the strategy we
+  use follows these steps:
+
+    1. if the error is `Phoenix.ActionClauseError`, we scrub both the
+       conn as well as the params
+
+  Otherwise, we don't perform any scrubbing. To configure scrubbing, you can
+  use similar options to `Sentry.PlugContext`:
+
+    * `:body_scrubber` for scrubbing the body (defaults to `Sentry.PlugContext.default_body_scrubber/1`)
+    * `:header_scrubber` for scrubbing the headers (defaults to `Sentry.PlugContext.default_header_scrubber/1`)
+    * `:cookie_scrubber` for scrubbing the cookies (defaults to `Sentry.PlugContext.default_cookie_scrubber/1`)
+
+  You can pass these options when you `use Sentry.PlugCapture`.
+
+      use Sentry.PlugCapture, body_scrubber: {MyApp.Scrubber, :scrub_body}
+
+  By default, the built-in scrubber does this:
+
+    * scrubs *all* cookies
+    * scrubs sensitive headers just like `Sentry.PlugContext.default_header_scrubber/1`
+    * scrubs sensitive body params just like `Sentry.PlugContext.default_body_scrubber/1`
+
   """
 
-  defmacro __using__(_opts) do
+  defmacro __using__(opts) do
     quote do
+      @sentry_plug_capture_scrubber Keyword.get(
+                                      unquote(Macro.escape(opts)),
+                                      :scrubber,
+                                      {unquote(__MODULE__), :default_scrubber, []}
+                                    )
+
+      unless match?(
+               {mod, fun, args} when is_atom(mod) and is_atom(fun) and is_list(args),
+               @sentry_plug_capture_scrubber
+             ) do
+        raise ArgumentError, """
+        expected :scrubber to be a tuple of the form {module, function, args}, got: \
+        #{inspect(@sentry_plug_capture_opts)}\
+        """
+      end
+
       @before_compile Sentry.PlugCapture
     end
   end
 
-  defmacro __before_compile__(_) do
+  defmacro __before_compile__(_env) do
     quote do
       defoverridable call: 2
 
@@ -48,14 +96,25 @@ defmodule Sentry.PlugCapture do
         try do
           super(conn, opts)
         rescue
-          e in Plug.Conn.WrapperError ->
-            exception = Exception.normalize(:error, e.reason, e.stack)
-            _ = Sentry.capture_exception(exception, stacktrace: e.stack, event_source: :plug)
-            Plug.Conn.WrapperError.reraise(e)
+          err in Plug.Conn.WrapperError ->
+            exception = Exception.normalize(:error, err.reason, err.stack)
 
-          e ->
-            _ = Sentry.capture_exception(e, stacktrace: __STACKTRACE__, event_source: :plug)
-            :erlang.raise(:error, e, __STACKTRACE__)
+            Sentry.PlugCapture.capture_exception(
+              exception,
+              err.stack,
+              @sentry_plug_capture_scrubber
+            )
+
+            Plug.Conn.WrapperError.reraise(err)
+
+          exception ->
+            Sentry.PlugCapture.capture_exception(
+              exception,
+              __STACKTRACE__,
+              @sentry_plug_capture_scrubber
+            )
+
+            :erlang.raise(:error, exception, __STACKTRACE__)
         catch
           kind, reason ->
             message = "Uncaught #{kind} - #{inspect(reason)}"
@@ -65,5 +124,38 @@ defmodule Sentry.PlugCapture do
         end
       end
     end
+  end
+
+  @doc false
+  def capture_exception(exception, stacktrace, {_mod, _fun, _args} = scrubber) do
+    # We can't pattern match here, because we're not guaranteed to have
+    # Phoenix available.
+    exception =
+      cond do
+        is_struct(exception, Phoenix.ActionClauseError) ->
+          update_in(exception, [Access.key!(:args), Access.all()], fn
+            conn when is_struct(conn, Plug.Conn) -> apply_scrubber(conn, scrubber)
+            other -> other
+          end)
+
+        true ->
+          exception
+      end
+
+    Sentry.capture_exception(exception, stacktrace: stacktrace, event_source: :plug)
+  end
+
+  @doc false
+  def default_scrubber(conn) do
+    %{
+      conn
+      | cookies: %{},
+        req_headers: Sentry.PlugContext.default_header_scrubber(conn),
+        params: Sentry.PlugContext.default_body_scrubber(conn)
+    }
+  end
+
+  defp apply_scrubber(conn, {mod, fun, args}) do
+    apply(mod, fun, [conn | args])
   end
 end

--- a/lib/sentry/plug_capture.ex
+++ b/lib/sentry/plug_capture.ex
@@ -39,50 +39,53 @@ defmodule Sentry.PlugCapture do
 
   ## Scrubbing Sensitive Data
 
+  > #### Since v9.1.0 {: .neutral}
+  >
+  > Scrubbing sensitive data in `Sentry.PlugCapture` is available since v9.1.0
+  > of this library.
+
   Like `Sentry.PlugContext`, this module also supports scrubbing sensitive data
   out of errors. However, this module has to do some *guessing* to figure
   out if there are `Plug.Conn` structs to scrub. Right now, the strategy we
   use follows these steps:
 
-    1. if the error is `Phoenix.ActionClauseError`, we scrub both the
-       conn as well as the params
+    1. if the error is `Phoenix.ActionClauseError`, we scrub the `Plug.Conn` structs
+      from the `args` field of that exception
 
-  Otherwise, we don't perform any scrubbing. To configure scrubbing, you can
-  use similar options to `Sentry.PlugContext`:
+  Otherwise, we don't perform any scrubbing. To configure scrubbing, you can use the
+  `:scrubbing` option (see below).
 
-    * `:body_scrubber` for scrubbing the body (defaults to `Sentry.PlugContext.default_body_scrubber/1`)
-    * `:header_scrubber` for scrubbing the headers (defaults to `Sentry.PlugContext.default_header_scrubber/1`)
-    * `:cookie_scrubber` for scrubbing the cookies (defaults to `Sentry.PlugContext.default_cookie_scrubber/1`)
+  ## Options
 
-  You can pass these options when you `use Sentry.PlugCapture`.
+    * `:scrubber` (since v9.1.0) - a term of type `{module, function, args}` that
+      will be invoked to scrub sensitive data from `Plug.Conn` structs. The
+      `Plug.Conn` struct is prepended to `args` before invoking the function,
+      so that the final function will be called as `apply(module, function, [conn | args])`.
+      The function must return a `Plug.Conn` struct. By default, the built-in
+      scrubber does this:
 
-      use Sentry.PlugCapture, body_scrubber: {MyApp.Scrubber, :scrub_body}
-
-  By default, the built-in scrubber does this:
-
-    * scrubs *all* cookies
-    * scrubs sensitive headers just like `Sentry.PlugContext.default_header_scrubber/1`
-    * scrubs sensitive body params just like `Sentry.PlugContext.default_body_scrubber/1`
+      * scrubs *all* cookies
+      * scrubs sensitive headers just like `Sentry.PlugContext.default_header_scrubber/1`
+      * scrubs sensitive body params just like `Sentry.PlugContext.default_body_scrubber/1`
 
   """
 
   defmacro __using__(opts) do
     quote do
-      @sentry_plug_capture_scrubber Keyword.get(
-                                      unquote(Macro.escape(opts)),
-                                      :scrubber,
-                                      {unquote(__MODULE__), :default_scrubber, []}
-                                    )
+      opts = unquote(Macro.escape(opts))
+      default_scrubber = {unquote(__MODULE__), :default_scrubber, []}
 
-      unless match?(
-               {mod, fun, args} when is_atom(mod) and is_atom(fun) and is_list(args),
-               @sentry_plug_capture_scrubber
-             ) do
-        raise ArgumentError, """
-        expected :scrubber to be a tuple of the form {module, function, args}, got: \
-        #{inspect(@sentry_plug_capture_opts)}\
-        """
-      end
+      scrubber =
+        case Keyword.get(opts, :scrubber, default_scrubber) do
+          {mod, fun, args} = scrubber when is_atom(mod) and is_atom(fun) and is_list(args) ->
+            scrubber
+
+          other ->
+            raise ArgumentError,
+                  "expected :scrubber to be a {module, function, args} tuple, got: #{inspect(other)}"
+        end
+
+      @__sentry_scrubber scrubber
 
       @before_compile Sentry.PlugCapture
     end
@@ -98,23 +101,12 @@ defmodule Sentry.PlugCapture do
         rescue
           err in Plug.Conn.WrapperError ->
             exception = Exception.normalize(:error, err.reason, err.stack)
-
-            Sentry.PlugCapture.capture_exception(
-              exception,
-              err.stack,
-              @sentry_plug_capture_scrubber
-            )
-
+            Sentry.PlugCapture.__capture_exception__(exception, err.stack, @__sentry_scrubber)
             Plug.Conn.WrapperError.reraise(err)
 
-          exception ->
-            Sentry.PlugCapture.capture_exception(
-              exception,
-              __STACKTRACE__,
-              @sentry_plug_capture_scrubber
-            )
-
-            :erlang.raise(:error, exception, __STACKTRACE__)
+          exc ->
+            Sentry.PlugCapture.__capture_exception__(exc, __STACKTRACE__, @__sentry_scrubber)
+            :erlang.raise(:error, exc, __STACKTRACE__)
         catch
           kind, reason ->
             message = "Uncaught #{kind} - #{inspect(reason)}"
@@ -127,19 +119,17 @@ defmodule Sentry.PlugCapture do
   end
 
   @doc false
-  def capture_exception(exception, stacktrace, {_mod, _fun, _args} = scrubber) do
+  def __capture_exception__(exception, stacktrace, scrubber) do
     # We can't pattern match here, because we're not guaranteed to have
     # Phoenix available.
     exception =
-      cond do
-        is_struct(exception, Phoenix.ActionClauseError) ->
-          update_in(exception, [Access.key!(:args), Access.all()], fn
-            conn when is_struct(conn, Plug.Conn) -> apply_scrubber(conn, scrubber)
-            other -> other
-          end)
-
-        true ->
-          exception
+      if is_struct(exception, Phoenix.ActionClauseError) do
+        update_in(exception, [Access.key!(:args), Access.all()], fn
+          conn when is_struct(conn, Plug.Conn) -> apply_scrubber(conn, scrubber)
+          other -> other
+        end)
+      else
+        exception
       end
 
     Sentry.capture_exception(exception, stacktrace: stacktrace, event_source: :plug)
@@ -155,7 +145,10 @@ defmodule Sentry.PlugCapture do
     }
   end
 
-  defp apply_scrubber(conn, {mod, fun, args}) do
-    apply(mod, fun, [conn | args])
+  defp apply_scrubber(conn, {mod, fun, args} = _scrubber) do
+    case apply(mod, fun, [conn | args]) do
+      conn when is_struct(conn, Plug.Conn) -> conn
+      other -> raise ":scrubber function must return a Plug.Conn struct, got: #{inspect(other)}"
+    end
   end
 end


### PR DESCRIPTION
Closes #477.

This is not foolproof, but I think it's pretty effective.