### PR TITLE
Exclude `~r"/test/"` from source code by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `:report_deps` now reports all loaded applications at the time the `:sentry` application starts. This is not a compile-time configuration option anymore.
 - Add the `mix sentry.package_source_code` Mix task. See the upgrade guide for more information.
+- Add `~r"/test/"` to the default source code exclude patterns (see the `:source_code_exclude_patterns` option).
 
 ## 9.1.0
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,6 +7,7 @@ if config_env() == :test do
     tags: %{},
     enable_source_code_context: true,
     root_source_code_paths: [File.cwd!()],
+    source_code_exclude_patterns: [],
     hackney_opts: [recv_timeout: 50],
     send_result: :sync,
     send_max_attempts: 1

--- a/lib/sentry.ex
+++ b/lib/sentry.ex
@@ -1,5 +1,5 @@
 defmodule Sentry do
-  @moduledoc ~S"""
+  @moduledoc """
   Provides the functionality to submit events to [Sentry](https://sentry.io).
 
   This library can be used to submit events to Sentry from any Elixir application.
@@ -198,7 +198,7 @@ defmodule Sentry do
 
     * `:source_code_exclude_patterns` (list of `t:Regex.t/0`) - a list of regular
       expressions used to determine which files to exclude from source code
-      context. Defaults to `[~r"/_build/", ~r"/deps/", ~r"/priv/"]`.
+      context. Defaults to `#{inspect(Sentry.Config.default_source_code_exclude_patterns())}`.
 
     * `:context_lines` (`t:integer/0`) - the number of lines of source code
       before and after the line that caused the exception to report. Defaults to `5`.
@@ -252,7 +252,7 @@ defmodule Sentry do
               Logger.info("Successfully sent event!")
 
             {:error, _reason} ->
-              Logger.info(fn -> "Did not successfully send event! #{inspect(event)}" end)
+              Logger.info(fn -> "Did not successfully send event! \#{inspect(event)}" end)
           end
         end
       end

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -3,13 +3,17 @@ defmodule Sentry.Config do
 
   @default_max_hackney_connections 50
   @default_hackney_timeout 5000
-  @default_exclude_patterns [~r"/_build/", ~r"/deps/", ~r"/priv/"]
+  @default_exclude_patterns [~r"/_build/", ~r"/deps/", ~r"/priv/", ~r"/test/"]
   @default_path_pattern "**/*.ex"
   @default_context_lines 3
   @default_sample_rate 1.0
   @default_send_result :none
   @default_send_max_attempts 4
   @default_log_level :warning
+
+  # Also exposed as a function to be used in docs in the Sentry module.
+  @spec default_source_code_exclude_patterns() :: [Regex.t(), ...]
+  def default_source_code_exclude_patterns, do: @default_exclude_patterns
 
   @spec validate_log_level!() :: :ok
   def validate_log_level! do


### PR DESCRIPTION
Closes #617.