### PR TITLE
Use the right default environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `:report_deps` now reports all loaded applications at the time the `:sentry` application starts. This is not a compile-time configuration option anymore.
 - Add the `mix sentry.package_source_code` Mix task. See the upgrade guide for more information.
 - Add `~r"/test/"` to the default source code exclude patterns (see the `:source_code_exclude_patterns` option).
+- `:environment_name` now defaults to `production` (if it wasn't configured explicitly and if the `SENTRY_ENVIRONMENT` environment variable is not set).
 
 ## 9.1.0
 

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -22,7 +22,7 @@ defmodule Sentry.Config do
       be enabled and if events should be sent. For events to be sent, the value of
       this option must appear in the `:included_environments` list.
       If the `SENTRY_ENVIRONMENT` environment variable is set, it will
-      be used as the defaults value. Otherwise, defaults to `"dev"`.
+      be used as the defaults value. Otherwise, defaults to `"production"`.
       """
     ],
     included_environments: [
@@ -286,15 +286,12 @@ defmodule Sentry.Config do
       |> Keyword.take(@valid_keys)
       |> fill_in_from_env(:dsn, "SENTRY_DSN")
       |> fill_in_from_env(:release, "SENTRY_RELEASE")
+      |> fill_in_from_env(:environment_name, "SENTRY_ENVIRONMENT")
 
     case NimbleOptions.validate(config_opts, @opts_schema) do
       {:ok, opts} ->
         opts
-        |> Keyword.put_new_lazy(:environment_name, fn ->
-          System.get_env("SENTRY_ENVIRONMENT") ||
-            raise ArgumentError,
-                  ":environment_name must be set in the application config or the SENTRY_ENVIRONMENT env var"
-        end)
+        |> Keyword.put_new(:environment_name, "production")
         |> normalize_included_environments()
         |> normalize_environment()
         |> assert_dsn_has_no_query_params!()

--- a/pages/upgrade-10.x.md
+++ b/pages/upgrade-10.x.md
@@ -21,3 +21,7 @@ Now, packaging source code is an active step that you have to take. The [`mix se
   1. Add a call to `mix sentry.package_source_code` in your release script. This can be inside a `Dockerfile`, for example. Make sure to call this **before** `mix release`, so that the built release will include the packaged source code.
 
   1. That's all!
+
+## Make Sure You're Using the Right Environment
+
+Now, if you're not explicitly setting he `:environment_name` option in your config or setting the `SENTRY_ENVIRONMENT` environment variable, the environment will default to `production` (which is in line with the other Sentry SDKs).

--- a/test/sentry/config_test.exs
+++ b/test/sentry/config_test.exs
@@ -5,11 +5,6 @@ defmodule Sentry.ConfigTest do
 
   alias Sentry.Config
 
-  setup do
-    modify_system_env(%{"SENTRY_ENVIRONMENT" => "test"})
-    :ok
-  end
-
   describe "validate!/0" do
     test ":dsn from option" do
       dsn = "https://public:secret@app.getsentry.com/1"
@@ -98,14 +93,6 @@ defmodule Sentry.ConfigTest do
     test ":environment_name from system env" do
       modify_system_env(%{"SENTRY_ENVIRONMENT" => "my_env"})
       assert Config.validate!([])[:environment_name] == "my_env"
-    end
-
-    test ":environment_name is required" do
-      delete_system_env("SENTRY_ENVIRONMENT")
-
-      assert_raise ArgumentError, ~r/:environment_name must be set/, fn ->
-        Config.validate!([])
-      end
     end
 
     test ":sample_rate" do


### PR DESCRIPTION
Now that I’m more familiar with other Sentry SDKs, I see that many of them (Python, PHP, and more) don't require the environment to be set. Moreover, this is from the [docs on Event Payloads](https://develop.sentry.dev/sdk/event-payloads/):

> The environment name, such as `production` or `staging`. The default value should be `production`.

So, yeah, the default value **should** be `production` :wink: