### PR TITLE
Hard-deprecate :included_environments option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add the `mix sentry.package_source_code` Mix task. See the upgrade guide for more information.
 - Add `~r"/test/"` to the default source code exclude patterns (see the `:source_code_exclude_patterns` option).
 - `:environment_name` now defaults to `production` (if it wasn't configured explicitly and if the `SENTRY_ENVIRONMENT` environment variable is not set).
+- Hard-deprecate `:included_environments`. To control whether to send events to Sentry, use the `:dsn` configuration option instead. `:included_environments` now emits a warning if used, but will still work until v11.0.0 of this library.
 
 ## 9.1.0
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Sentry has a range of configuration options, but most applications will have a c
 config :sentry,
   dsn: "https://public_key@app.getsentry.com/1",
   environment_name: Mix.env(),
-  included_environments: [:prod],
   enable_source_code_context: true,
   root_source_code_paths: [File.cwd!()]
 ```
@@ -177,7 +176,6 @@ Client configuration:
 server: https://sentry.io/
 public_key: public
 secret_key: secret
-included_environments: [:prod]
 current environment_name: :dev
 
 :dev is not in [:prod] so no test event will be sent
@@ -187,7 +185,6 @@ Client configuration:
 server: https://sentry.io/
 public_key: public
 secret_key: secret
-included_environments: [:prod]
 current environment_name: :prod
 
 Sending test event!

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,7 +2,6 @@ import Config
 
 if config_env() == :test do
   config :sentry,
-    included_environments: [:test],
     environment_name: :test,
     tags: %{},
     enable_source_code_context: true,

--- a/lib/mix/tasks/sentry.send_test_event.ex
+++ b/lib/mix/tasks/sentry.send_test_event.ex
@@ -31,28 +31,28 @@ defmodule Mix.Tasks.Sentry.SendTestEvent do
         Mix.raise("Failed to start the :sentry application:\n\n#{inspect(reason)}")
     end
 
-    included_environments = Config.included_environments()
+    print_environment_info()
 
-    print_environment_info(Sentry.Transport.get_dsn(), included_environments)
-
-    env_name = to_string(Config.environment_name())
-
-    if included_environments == :all or env_name in included_environments do
+    if Config.dsn() do
       send_event()
     else
       Mix.shell().info([
         :yellow,
-        "#{inspect(env_name)} is not in #{inspect(included_environments)} so no test event will be sent"
+        "Event not sent because the :dsn option is not set (or set to nil)"
       ])
     end
   end
 
-  defp print_environment_info({endpoint, public_key, secret_key}, included_environments) do
+  defp print_environment_info do
     Mix.shell().info("Client configuration:")
-    Mix.shell().info("server: #{endpoint}")
-    Mix.shell().info("public_key: #{public_key}")
-    Mix.shell().info("secret_key: #{secret_key}")
-    Mix.shell().info("included_environments: #{inspect(included_environments)}")
+
+    if Config.dsn() do
+      {endpoint, public_key, secret_key} = Sentry.Transport.get_dsn()
+      Mix.shell().info("server: #{endpoint}")
+      Mix.shell().info("public_key: #{public_key}")
+      Mix.shell().info("secret_key: #{secret_key}")
+    end
+
     Mix.shell().info("current environment_name: #{inspect(to_string(Config.environment_name()))}")
     Mix.shell().info("hackney_opts: #{inspect(Config.hackney_opts())}\n")
   end

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -234,7 +234,7 @@ defmodule Sentry.Config do
 
   hook_opts_schema = [
     before_send_event: [
-      type: {:custom, __MODULE__, :__validate_hook__, [_arity = 1, :before_send_event]},
+      type: {:or, [{:fun, 1}, {:tuple, [:atom, :atom]}]},
       type_doc: "`t:before_send_event_callback/0`",
       doc: """
       Allows performing operations on the event *before* it is sent as
@@ -245,7 +245,7 @@ defmodule Sentry.Config do
       """
     ],
     after_send_event: [
-      type: {:custom, __MODULE__, :__validate_hook__, [_arity = 2, :after_send_event]},
+      type: {:or, [{:fun, 2}, {:tuple, [:atom, :atom]}]},
       type_doc: "`t:after_send_event_callback/0`",
       doc: """
       Callback that is called *after*
@@ -504,27 +504,6 @@ defmodule Sentry.Config do
     else
       {:error,
        "expected :sample_rate to be a float between 0.0 and 1.0 (included), got: #{inspect(float)}"}
-    end
-  end
-
-  def __validate_hook__({mod, fun} = hook, _arity, _name) when is_atom(mod) and is_atom(fun) do
-    {:ok, hook}
-  end
-
-  def __validate_hook__(fun, arity, name) do
-    cond do
-      is_function(fun, arity) ->
-        {:ok, fun}
-
-      is_function(fun) ->
-        {:arity, actual} = Function.info(fun, :arity)
-
-        {:error,
-         "expected #{inspect(name)} to be an anonymous function of arity #{arity}, but got one of arity #{actual}"}
-
-      true ->
-        {:error,
-         "expected #{inspect(name)} to be a {mod, fun} tuple or an anonymous function, got: #{inspect(fun)}"}
     end
   end
 

--- a/pages/upgrade-10.x.md
+++ b/pages/upgrade-10.x.md
@@ -25,3 +25,39 @@ Now, packaging source code is an active step that you have to take. The [`mix se
 ## Make Sure You're Using the Right Environment
 
 Now, if you're not explicitly setting he `:environment_name` option in your config or setting the `SENTRY_ENVIRONMENT` environment variable, the environment will default to `production` (which is in line with the other Sentry SDKs).
+
+## Stop Using `:included_environments`
+
+We hard-deprecated `:included_environments`. It's a bit of a confusing option that essentially no other Sentry SDKs use. To control whether to send events to Sentry, use the `:dsn` configuration instead (if set then we send events, if not set then we don't send events). `:included_environments` will be removed in v11.0.0.
+
+For example, if you had something like this in `config/config.exs`:
+
+```elixir
+# In config/config.exs
+config :sentry,
+  dsn: "...",
+  environment_name: config_env(),
+  included_environments: [:prod]
+```
+
+Move this block to `config/prod.exs`, and turn it into:
+
+```elixir
+# In config/prod.exs
+config :sentry,
+  dsn: "...",
+  environment_name: :prod
+```
+
+This way, `:dsn` will only be set in the `:prod` environment and no events will be sent in the development or testing environments.
+
+Alternatively, if you were setting `:dsn` in `config/runtime.exs` (for use with Mix releases), change it to:
+
+```elixir
+# In config/runtime.exs
+if config_env() == :prod do
+  config :sentry,
+    dsn: "...",
+    environment_name: :prod
+end
+```

--- a/test/mix/sentry.send_test_event_test.exs
+++ b/test/mix/sentry.send_test_event_test.exs
@@ -4,8 +4,8 @@ defmodule Mix.Tasks.Sentry.SendTestEventTest do
   import ExUnit.CaptureIO
   import Sentry.TestEnvironmentHelper
 
-  test "prints if environment_name is not in included_environments" do
-    modify_env(:sentry, dsn: "http://public:secret@localhost:43/1", included_environments: [])
+  test "prints if :dsn is not set" do
+    modify_env(:sentry, dsn: nil)
 
     output =
       capture_io(fn ->
@@ -14,15 +14,11 @@ defmodule Mix.Tasks.Sentry.SendTestEventTest do
 
     assert output =~ """
            Client configuration:
-           server: http://localhost:43/api/1/envelope/
-           public_key: public
-           secret_key: secret
-           included_environments: []
            current environment_name: "test"
            hackney_opts: [recv_timeout: 50]
            """
 
-    assert output =~ ~s("test" is not in [] so no test event will be sent)
+    assert output =~ ~s(Event not sent because the :dsn option is not set)
   end
 
   test "sends event successfully when configured to" do
@@ -36,11 +32,7 @@ defmodule Mix.Tasks.Sentry.SendTestEventTest do
       Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
     end)
 
-    modify_env(
-      :sentry,
-      dsn: "http://public:secret@localhost:#{bypass.port}/1",
-      included_environments: :all
-    )
+    modify_env(:sentry, dsn: "http://public:secret@localhost:#{bypass.port}/1")
 
     output =
       capture_io(fn ->
@@ -52,7 +44,6 @@ defmodule Mix.Tasks.Sentry.SendTestEventTest do
            server: http://localhost:#{bypass.port}/api/1/envelope/
            public_key: public
            secret_key: secret
-           included_environments: :all
            current environment_name: "test"
            hackney_opts: [recv_timeout: 50]
            """

--- a/test/sentry/config_test.exs
+++ b/test/sentry/config_test.exs
@@ -75,15 +75,21 @@ defmodule Sentry.ConfigTest do
       end
     end
 
+    # TODO: remove me on v11.0.0. :included_environments has been deprecated in v10.0.0.
     test ":included_environments" do
-      assert Config.validate!(included_environments: [:test, "dev"])[:included_environments] ==
-               ["test", "dev"]
+      output =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          assert Config.validate!(included_environments: [:test, "dev"])[:included_environments] ==
+                   ["test", "dev"]
 
-      assert Config.validate!([])[:included_environments] == :all
+          assert Config.validate!([])[:included_environments] == :all
 
-      assert_raise ArgumentError, ~r/invalid value for :included_environments/, fn ->
-        Config.validate!(included_environments: "not a list")
-      end
+          assert_raise ArgumentError, ~r/invalid value for :included_environments/, fn ->
+            Config.validate!(included_environments: "not a list")
+          end
+        end)
+
+      assert output =~ ":included_environments option is deprecated"
     end
 
     test ":environment_name from option" do


### PR DESCRIPTION
We planned on deprecating this. This is in line with all other SDKs.