### PR TITLE
Convert charlists in metadata to strings

### DIFF
--- a/test/logger_backend_test.exs
+++ b/test/logger_backend_test.exs
@@ -150,7 +150,9 @@ defmodule Sentry.LoggerBackendTest do
   end
 
   test "includes Logger metadata for keys configured to be included" do
-    Logger.configure_backend(Sentry.LoggerBackend, metadata: [:string, :number, :map, :list])
+    Logger.configure_backend(Sentry.LoggerBackend,
+      metadata: [:string, :number, :map, :list, :chardata]
+    )
 
     ref = register_before_send()
 
@@ -161,6 +163,7 @@ defmodule Sentry.LoggerBackendTest do
       Logger.metadata(number: 43)
       Logger.metadata(map: %{a: "b"})
       Logger.metadata(list: [1, 2, 3])
+      Logger.metadata(chardata: ["π's unicode is", ?\s, [?π]])
       {:noreply, state}
     end)
 
@@ -171,6 +174,7 @@ defmodule Sentry.LoggerBackendTest do
     assert event.extra.logger_metadata.map == %{a: "b"}
     assert event.extra.logger_metadata.list == [1, 2, 3]
     assert event.extra.logger_metadata.number == 43
+    assert event.extra.logger_metadata.chardata == "π's unicode is π"
   end
 
   test "does not include Logger metadata when disabled" do

--- a/test/sentry/logger_handler_test.exs
+++ b/test/sentry/logger_handler_test.exs
@@ -172,7 +172,7 @@ defmodule Sentry.LoggerHandlerTest do
       end
     end
 
-    @tag handler_config: %{metadata: [:string, :number, :map, :list]}
+    @tag handler_config: %{metadata: [:string, :number, :map, :list, :chardata]}
     test "includes Logger metadata for keys configured to be included",
          %{sender_ref: ref, test_genserver: test_genserver} do
       run_and_catch_exit(test_genserver, fn ->
@@ -180,7 +180,8 @@ defmodule Sentry.LoggerHandlerTest do
           string: "string",
           number: 43,
           map: %{a: "b"},
-          list: [1, 2, 3]
+          list: [1, 2, 3],
+          chardata: ["π's unicode is", ?\s, [?π]]
         )
 
         invalid_function()
@@ -191,6 +192,7 @@ defmodule Sentry.LoggerHandlerTest do
       assert event.extra.logger_metadata.map == %{a: "b"}
       assert event.extra.logger_metadata.list == [1, 2, 3]
       assert event.extra.logger_metadata.number == 43
+      assert event.extra.logger_metadata.chardata == "π's unicode is π"
     end
 
     @tag handler_config: %{metadata: []}


### PR DESCRIPTION
Closes #645.

Performance-wise this is not great, but after all we report errors *when they are errors*, so maybe super-duper worrying about perf is not worth it here for the improved DX.