### PR TITLE
Fix dialyzer warning

### DIFF
--- a/lib/sentry/logger_backend.ex
+++ b/lib/sentry/logger_backend.ex
@@ -93,7 +93,8 @@ defmodule Sentry.LoggerBackend do
 
     if Logger.compare_levels(level, state.level) != :lt and
          not LoggerUtils.excluded_domain?(meta[:domain] || [], state.excluded_domains) do
-      log(level, msg, meta, state)
+      _ = log(level, msg, meta, state)
+      :ok
     end
 
     {:ok, state}


### PR DESCRIPTION
When dialyzer is run on this project with the `:unmatched_returns` setting, a warning is generated for this piece of code. Here is one attempt at fixing the warning, but it should be noted that this fix will cause a change in behavior: If the call to `log` does not return `:ok`, an error will occur. I couldn't really tell what the desired outcome was here, perhaps you'd rather we match on `_`?

Fixes #647