### PR TITLE
Don't report events if DSN is not configured

### DIFF
--- a/lib/mix/tasks/sentry.send_test_event.ex
+++ b/lib/mix/tasks/sentry.send_test_event.ex
@@ -47,7 +47,7 @@ defmodule Mix.Tasks.Sentry.SendTestEvent do
     Mix.shell().info("Client configuration:")
 
     if Config.dsn() do
-      {endpoint, public_key, secret_key} = Sentry.Transport.get_dsn()
+      {endpoint, public_key, secret_key} = Config.dsn()
       Mix.shell().info("server: #{endpoint}")
       Mix.shell().info("public_key: #{public_key}")
       Mix.shell().info("secret_key: #{secret_key}")

--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -224,9 +224,6 @@ defmodule Sentry.Client do
   defp maybe_log_send_result(send_result, %Event{}) do
     message =
       case send_result do
-        {:error, :invalid_dsn} ->
-          "Cannot send Sentry event because of invalid DSN"
-
         {:error, {:invalid_json, error}} ->
           "Unable to encode JSON Sentry error - #{inspect(error)}"
 

--- a/lib/sentry/transport/sender.ex
+++ b/lib/sentry/transport/sender.ex
@@ -54,9 +54,6 @@ defmodule Sentry.Transport.Sender do
     else
       message =
         case send_result do
-          {:error, :invalid_dsn} ->
-            "Cannot send Sentry event because of invalid DSN"
-
           {:error, {:invalid_json, error}} ->
             "Unable to encode JSON Sentry error - #{inspect(error)}"
 

--- a/test/logger_backend_test.exs
+++ b/test/logger_backend_test.exs
@@ -343,7 +343,8 @@ defmodule Sentry.LoggerBackendTest do
       before_send: fn event ->
         send(pid, {ref, event})
         false
-      end
+      end,
+      dsn: "http://public:secret@localhost:9392/1"
     )
 
     ref

--- a/test/sentry/logger_handler_test.exs
+++ b/test/sentry/logger_handler_test.exs
@@ -332,7 +332,8 @@ defmodule Sentry.LoggerHandlerTest do
       before_send: fn event ->
         send(pid, {ref, event})
         false
-      end
+      end,
+      dsn: "http://public:secret@localhost:9392/1"
     )
 
     %{sender_ref: ref}

--- a/test/sentry/transport_test.exs
+++ b/test/sentry/transport_test.exs
@@ -192,26 +192,4 @@ defmodule Sentry.TransportTest do
       assert_received {:request, ^ref}
     end
   end
-
-  describe "get_dsn/0" do
-    test "parses correct DSNs" do
-      put_test_config(dsn: "http://public:secret@localhost:3000/1")
-      assert {"http://localhost:3000/api/1/envelope/", "public", "secret"} = Transport.get_dsn()
-    end
-
-    test "errors on bad public keys" do
-      put_test_config(dsn: "https://app.getsentry.com/1")
-      assert {:error, :invalid_dsn} = Transport.get_dsn()
-    end
-
-    test "errors on non-integer project_id" do
-      put_test_config(dsn: "https://public:secret@app.getsentry.com/Mitchell")
-      assert {:error, :invalid_dsn} = Transport.get_dsn()
-    end
-
-    test "errors on no project_id" do
-      put_test_config(dsn: "https://public:secret@app.getsentry.com")
-      assert {:error, :invalid_dsn} = Transport.get_dsn()
-    end
-  end
 end

--- a/test/sentry_test.exs
+++ b/test/sentry_test.exs
@@ -78,4 +78,10 @@ defmodule SentryTest do
 
     assert log =~ "Sentry: unable to parse exception"
   end
+
+  test "does not send events if :dsn is not configured or nil" do
+    put_test_config(dsn: nil)
+    event = Sentry.Event.transform_exception(%RuntimeError{message: "oops"}, [])
+    assert :ignored = Sentry.send_event(event)
+  end
 end

--- a/test/support/example_plug_application.ex
+++ b/test/support/example_plug_application.ex
@@ -52,7 +52,7 @@ defmodule Sentry.ExamplePlugApplication do
           """
           <script src="https://browser.sentry-cdn.com/5.9.1/bundle.min.js" integrity="sha384-/x1aHz0nKRd6zVUazsV6CbQvjJvr6zQL2CHbQZf3yoLkezyEtZUpqUNnOLW9Nt3v" crossorigin="anonymous"></script>
           <script>
-          Sentry.init({ dsn: '#{Sentry.Config.dsn()}' });
+          Sentry.init({ dsn: '#{inspect(Sentry.Config.dsn())}' });
           Sentry.showReportDialog(#{opts})
           </script>
           """

--- a/test/support/test_error_view.ex
+++ b/test/support/test_error_view.ex
@@ -11,7 +11,7 @@ defmodule Sentry.ErrorView do
         ~E"""
         <script src="https://browser.sentry-cdn.com/5.9.1/bundle.min.js" integrity="sha384-/x1aHz0nKRd6zVUazsV6CbQvjJvr6zQL2CHbQZf3yoLkezyEtZUpqUNnOLW9Nt3v" crossorigin="anonymous"></script>
         <script>
-        Sentry.init({ dsn: '<%= Sentry.Config.dsn() %>' });
+        Sentry.init({ dsn: '<%= inspect(Sentry.Config.dsn()) %>' });
         Sentry.showReportDialog(<%= raw opts %>)
         </script>
         """

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -22,7 +22,7 @@ defmodule Sentry.TestHelpers do
           end
 
         current_val = :persistent_term.get({:sentry_config, renamed_key}, :__not_set__)
-        :persistent_term.put({:sentry_config, renamed_key}, val)
+        Sentry.put_config(renamed_key, val)
         {renamed_key, current_val}
       end
 


### PR DESCRIPTION
I was sure I did this, but apparently I only did it for `mix sentry.send_test_event`. We need this because this new behavior is what's documented in the 10.x upgrade guide. I will release 10.0.2 once we merge this in.

This PR also does something great, which is validating the DSN **at start time** instead of the first time reporting an event. This can help with discovering bad config earlier on, which is instrumental IMO.