### PR TITLE
Add threads interface and fix messages with stacktraces

### DIFF
--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -154,10 +154,19 @@ defmodule Sentry.Client do
     |> update_if_present(:user, &sanitize_non_jsonable_values(&1, json_library))
     |> update_if_present(:tags, &sanitize_non_jsonable_values(&1, json_library))
     |> update_if_present(:exception, fn list -> Enum.map(list, &render_exception/1) end)
+    |> update_if_present(:threads, fn list -> Enum.map(list, &render_thread/1) end)
   end
 
   defp render_exception(%Interfaces.Exception{} = exception) do
     exception
+    |> Map.from_struct()
+    |> update_if_present(:stacktrace, fn %Interfaces.Stacktrace{frames: frames} ->
+      %{frames: Enum.map(frames, &Map.from_struct/1)}
+    end)
+  end
+
+  defp render_thread(%Interfaces.Thread{} = thread) do
+    thread
     |> Map.from_struct()
     |> update_if_present(:stacktrace, fn %Interfaces.Stacktrace{frames: frames} ->
       %{frames: Enum.map(frames, &Map.from_struct/1)}

--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -293,21 +293,11 @@ defmodule Sentry.Event do
     end
   end
 
-  defp coerce_exception(_exception = nil, _stacktrace = nil, _message) do
+  # If we have a message with a stacktrace, but no exceptions, for now we store the stacktrace in
+  # the "threads" interface and we don't fill in the "exception" interface altogether. This might
+  # be eventually fixed in Sentry itself: https://github.com/getsentry/sentry/issues/61239
+  defp coerce_exception(_exception = nil, _stacktrace_or_nil, message) when is_binary(message) do
     nil
-  end
-
-  defp coerce_exception(_exception = nil, stacktrace_or_nil, message) when is_binary(message) do
-    stacktrace =
-      if is_list(stacktrace_or_nil) do
-        %Interfaces.Stacktrace{frames: stacktrace_to_frames(stacktrace_or_nil)}
-      end
-
-    %Interfaces.Exception{
-      type: "message",
-      value: message,
-      stacktrace: stacktrace
-    }
   end
 
   defp coerce_exception(exception, stacktrace_or_nil, _message) when is_exception(exception) do

--- a/lib/sentry/interfaces.ex
+++ b/lib/sentry/interfaces.ex
@@ -190,4 +190,38 @@ defmodule Sentry.Interfaces do
 
     defstruct [:type, :category, :message, :data, :level, :timestamp]
   end
+
+  defmodule Thread do
+    @moduledoc """
+    The struct for the **thread** interface.
+
+    See <https://develop.sentry.dev/sdk/event-payloads/threads>.
+    """
+
+    @moduledoc since: "10.1.0"
+
+    @typedoc since: "10.1.0"
+    @type t() :: %__MODULE__{
+            id: term(),
+            crashed: boolean() | nil,
+            current: boolean() | nil,
+            main: boolean() | nil,
+            name: String.t() | nil,
+            state: term(),
+            held_locks: [term()],
+            stacktrace: Sentry.Interfaces.Stacktrace.t() | nil
+          }
+
+    @enforce_keys [:id]
+    defstruct [
+      :id,
+      :crashed,
+      :current,
+      :main,
+      :name,
+      :state,
+      :held_locks,
+      :stacktrace
+    ]
+  end
 end

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -210,6 +210,49 @@ defmodule Sentry.EventTest do
              } = Event.create_event(message: "Test message")
     end
 
+    test "fills in the message and threads interfaces when passing the :message option with :stacktrace" do
+      {:current_stacktrace, stacktrace} = Process.info(self(), :current_stacktrace)
+      put_test_config(environment_name: "my_env")
+
+      assert %Event{
+               breadcrumbs: [],
+               environment: "my_env",
+               exception: [
+                 %Interfaces.Exception{
+                   type: "message",
+                   value: "Test message",
+                   stacktrace: exception_stacktrace
+                 }
+               ],
+               extra: %{},
+               level: :error,
+               message: "Test message",
+               platform: :elixir,
+               release: nil,
+               request: %{},
+               tags: %{},
+               user: %{},
+               contexts: %{os: %{name: _, version: _}, runtime: %{name: _, version: _}},
+               threads: [%Interfaces.Thread{id: thread_id, stacktrace: thread_stacktrace}]
+             } = Event.create_event(message: "Test message", stacktrace: stacktrace)
+
+      assert exception_stacktrace == thread_stacktrace
+
+      assert is_binary(thread_id) and byte_size(thread_id) > 0
+
+      assert [
+               %Interfaces.Stacktrace.Frame{
+                 context_line: nil,
+                 in_app: false,
+                 lineno: _,
+                 post_context: [],
+                 pre_context: [],
+                 vars: %{}
+               }
+               | _rest
+             ] = thread_stacktrace.frames
+    end
+
     test "fills in private (:__...__) fields" do
       exception = %RuntimeError{message: "foo"}
 

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -217,13 +217,7 @@ defmodule Sentry.EventTest do
       assert %Event{
                breadcrumbs: [],
                environment: "my_env",
-               exception: [
-                 %Interfaces.Exception{
-                   type: "message",
-                   value: "Test message",
-                   stacktrace: exception_stacktrace
-                 }
-               ],
+               exception: [],
                extra: %{},
                level: :error,
                message: "Test message",
@@ -235,8 +229,6 @@ defmodule Sentry.EventTest do
                contexts: %{os: %{name: _, version: _}, runtime: %{name: _, version: _}},
                threads: [%Interfaces.Thread{id: thread_id, stacktrace: thread_stacktrace}]
              } = Event.create_event(message: "Test message", stacktrace: stacktrace)
-
-      assert exception_stacktrace == thread_stacktrace
 
       assert is_binary(thread_id) and byte_size(thread_id) > 0
 

--- a/test/sentry/logger_handler_test.exs
+++ b/test/sentry/logger_handler_test.exs
@@ -175,7 +175,8 @@ defmodule Sentry.LoggerHandlerTest do
       assert event.message =~ "** (stop) :bad_exit"
 
       if System.otp_release() >= "26" do
-        assert hd(event.exception).type == "message"
+        assert [] = event.exception
+        assert [_thread] = event.threads
       end
     end
 
@@ -273,13 +274,12 @@ defmodule Sentry.LoggerHandlerTest do
 
       assert_receive {^ref, event}
 
-      assert [exception] = event.exception
+      assert [] = event.exception
+      assert [thread] = event.threads
 
-      assert exception.type == "message"
-
-      assert exception.value =~ "** (stop) exited in: GenServer.call("
-      assert exception.value =~ "** (EXIT) time out"
-      assert length(exception.stacktrace.frames) > 0
+      assert event.message =~ "** (stop) exited in: GenServer.call("
+      assert event.message =~ "** (EXIT) time out"
+      assert length(thread.stacktrace.frames) > 0
     end
 
     test "reports crashes on c:GenServer.init/1", %{sender_ref: ref} do


### PR DESCRIPTION
This fixes the issue that was moved to the Sentry repo: https://github.com/getsentry/sentry/issues/61239

This PR:

  * adds a **threads** interface (we should release a minor version, not a patch version because of this)
  * fill in the threads interface when there is a report of a message without exception but with a stacktrace

The reported message + stacktrace now look like this (before, the title was just `message`):

![CleanShot 2023-12-09 at 09 51 05@2x](https://github.com/getsentry/sentry-elixir/assets/3890250/1e5e5f51-1bb8-49d2-902f-564430723b48)
