### PR TITLE
Accept anything that is "stringable" when interpolating

### DIFF
--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -248,7 +248,7 @@ defmodule Sentry.Event do
       """
     ],
     interpolation_parameters: [
-      type: {:list, :string},
+      type: {:list, :any},
       doc: """
       The parameters to use for message interpolation. This is only used if the
       `:message` option is present. This is not present by default. See

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -230,14 +230,14 @@ defmodule Sentry.EventTest do
                contexts: %{os: %{name: _, version: _}, runtime: %{name: _, version: _}}
              } =
                Event.create_event(
-                 message: "Interpolated string like %s",
-                 interpolation_parameters: ["this"]
+                 message: "Interpolated string like %s and %s and '%s'",
+                 interpolation_parameters: ["this", 123, nil]
                )
 
       assert message == %Interfaces.Message{
-               formatted: "Interpolated string like this",
+               formatted: "Interpolated string like this and 123 and ''",
                params: ["this"],
-               message: "Interpolated string like %s"
+               message: "Interpolated string like %s and %s and '%s'"
              }
     end
 

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -236,7 +236,7 @@ defmodule Sentry.EventTest do
 
       assert message == %Interfaces.Message{
                formatted: "Interpolated string like this and 123 and ''",
-               params: ["this"],
+               params: ["this", 123, nil],
                message: "Interpolated string like %s and %s and '%s'"
              }
     end


### PR DESCRIPTION
Before this commit, we were forcing interpolation parameters to be strings. However, in other places we generally rely on `to_string/1` for this type of stuff. In this case, Sentry itself says that non-strings will be coerced to strings (https://develop.sentry.dev/sdk/event-payloads/message/).