### PR TITLE
Ignore unknown request fields

### DIFF
--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -346,7 +346,7 @@ defmodule Sentry.Event do
       modules: :persistent_term.get({:sentry, :loaded_applications}),
       original_exception: exception,
       release: Config.release(),
-      request: coerce_request(request),
+      request: struct(%Interfaces.Request{}, request),
       sdk: @sdk,
       server_name: Config.server_name() || to_string(:net_adm.localhost()),
       source: source,
@@ -425,18 +425,6 @@ defmodule Sentry.Event do
       raise ArgumentError,
             "cannot provide a :stacktrace option without an exception or a message, got: #{inspect(stacktrace)}"
     end
-  end
-
-  @request_fields %Interfaces.Request{} |> Map.from_struct() |> Map.keys() |> MapSet.new()
-
-  defp coerce_request(request) do
-    Enum.reduce(request, %Interfaces.Request{}, fn {key, value}, acc ->
-      if key in @request_fields do
-        Map.replace!(acc, key, value)
-      else
-        raise ArgumentError, "unknown field for the request interface: #{inspect(key)}"
-      end
-    end)
   end
 
   defp add_thread_with_stacktrace(%__MODULE__{} = event, stacktrace) when is_list(stacktrace) do

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -292,10 +292,9 @@ defmodule Sentry.EventTest do
       assert event.original_exception == exception
     end
 
-    test "raises if the :request option contains non-request fields" do
-      assert_raise ArgumentError, ~r/unknown field for the request interface: :bad_key/, fn ->
-        Event.create_event(request: %{method: "GET", bad_key: :indeed})
-      end
+    test "ignores unknown fields in :request" do
+      assert %Event{} = event = Event.create_event(request: %{method: "GET", bad_key: :indeed})
+      assert event.request == %Interfaces.Request{method: "GET"}
     end
   end
 


### PR DESCRIPTION
Closes #663.

If the goal of Sentry is to never get in the way and never cause issues itself, then maybe a better strategy here is to ignore unknown request keys instead of raising. I did some testing and it turns out that Sentry itself ignores unknown keys in the request interface, so this strategy seems solid.