### PR TITLE
Fix ArgumentError when using custom scrubber with PlugCapture

### DIFF
--- a/lib/sentry/plug_capture.ex
+++ b/lib/sentry/plug_capture.ex
@@ -72,7 +72,7 @@ defmodule Sentry.PlugCapture do
 
   defmacro __using__(opts) do
     quote do
-      opts = unquote(Macro.escape(opts))
+      opts = unquote(opts)
       default_scrubber = {unquote(__MODULE__), :default_scrubber, []}
 
       scrubber =


### PR DESCRIPTION
[The docs for Sentry.PlugCapture](https://hexdocs.pm/sentry/10.1.0/Sentry.PlugCapture.html#module-scrubbing-sensitive-data) reference the custom `:scrubber` option for `use Sentry.PlugCapture`:

> a term of type `{module, function, args}` that will be invoked to scrub sensitive data from [Plug.Conn](https://hexdocs.pm/plug/1.11.1/Plug.Conn.html) structs.

However, when you provide `{module, function, args}` as instructed:

```elixir
use Sentry.PlugCapture, scrubber: {MyModule, :scrub_conn, []}
```

You get this compilation error:

```
== Compilation error in file my_endpoint.ex ==
** (ArgumentError) expected :scrubber to be a {module, function, args} tuple, got: {:{}, [line: 4], [MyModule, :scrub_conn, []]}
```

This PR removes the `Macro.escape` that was causing this.