### PR TITLE
Add url_scrubber for redacting URLs

### DIFF
--- a/test/sentry/plug_context_test.exs
+++ b/test/sentry/plug_context_test.exs
@@ -109,7 +109,7 @@ defmodule Sentry.PlugContextTest do
     assert %{"not-secret" => "not-secret"} == Sentry.Context.get_all().request.cookies
   end
 
-  test "allows configuring url scrubber" do
+  test "allows configuring URL scrubber" do
     conn = conn(:get, "/secret-token/secret")
     call(conn, url_scrubber: {__MODULE__, :url_scrubber})
 


### PR DESCRIPTION
@whatyouhide indicated [here](https://github.com/getsentry/sentry-elixir/pull/678#issuecomment-1868330165) that this PR would be welcome. 🙂 

This PR adds support for a `url_scrubber` which works just like `body_scrubber`, `header_scrubber`, and `cookie_scrubber`.

The "default scrubber" behavior is to not redact anything. (Just runs `Plug.Conn.request_url/1` as before.)