### PR TITLE
Speed up tests by ~450%

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -6,7 +6,6 @@ if config_env() == :test do
     tags: %{},
     enable_source_code_context: true,
     root_source_code_paths: [File.cwd!()],
-    source_code_exclude_patterns: [],
     hackney_opts: [recv_timeout: 50, pool: :sentry_pool],
     send_result: :sync,
     send_max_attempts: 1,

--- a/lib/sentry/sources.ex
+++ b/lib/sentry/sources.ex
@@ -10,6 +10,7 @@ defmodule Sentry.Sources do
         }
 
   @source_code_map_key {:sentry, :source_code_map}
+  @compression_level if Mix.env() == :test, do: 0, else: 9
 
   # Default argument is here for testing.
   @spec load_source_code_map_if_present(Path.t()) :: {:loaded, source_map()} | {:error, term()}
@@ -51,7 +52,7 @@ defmodule Sentry.Sources do
   def encode_source_code_map(%{} = source_map) do
     # This term contains no atoms, so that it can be decoded with binary_to_term(bin, [:safe]).
     term_to_encode = %{"version" => 1, "files_map" => source_map}
-    :erlang.term_to_binary(term_to_encode, compressed: 9)
+    :erlang.term_to_binary(term_to_encode, compressed: @compression_level)
   end
 
   defp decode_source_code_map(binary) when is_binary(binary) do

--- a/test/context_test.exs
+++ b/test/context_test.exs
@@ -77,7 +77,6 @@ defmodule Sentry.ContextTest do
     assert event.user == %{}
   end
 
-  @tag start_app: false
   test "passing in tags context as option overrides Context and Application config" do
     Context.set_tags_context(%{"key" => "345", "key1" => "123"})
     put_test_config(tags: %{"key" => "overridden", "key2" => "1234", "key3" => "12345"})

--- a/test/logger_backend_test.exs
+++ b/test/logger_backend_test.exs
@@ -126,12 +126,9 @@ defmodule Sentry.LoggerBackendTest do
 
     ref = register_before_send()
 
-    {:ok, _plug_pid} = Plug.Cowboy.http(Sentry.ExamplePlugApplication, [], port: 8003)
-
     :hackney.get("http://127.0.0.1:8003/error_route", [], "", [])
     assert_receive {^ref, _event}, 1000
   after
-    :ok = Plug.Cowboy.shutdown(Sentry.ExamplePlugApplication.HTTP)
     Logger.configure_backend(Sentry.LoggerBackend, excluded_domains: [:cowboy])
   end
 
@@ -312,7 +309,7 @@ defmodule Sentry.LoggerBackendTest do
 
     Logger.error("Error", domain: [:sentry])
 
-    refute_receive {^ref, _event}
+    refute_received {^ref, _event}
   end
 
   test "sets event level to Logger message level" do

--- a/test/mix/sentry.package_source_code_test.exs
+++ b/test/mix/sentry.package_source_code_test.exs
@@ -32,6 +32,16 @@ defmodule Mix.Tasks.Sentry.PackageSourceCodeTest do
   end
 
   test "supports the --debug option" do
+    # Use a path pattern that doesn't match any files, to make this test as fast as
+    # possible.
+    old_root_source_code_paths = Application.get_env(:sentry, :root_source_code_paths)
+
+    on_exit(fn ->
+      Application.put_env(:sentry, :root_source_code_paths, old_root_source_code_paths)
+    end)
+
+    Application.put_env(:sentry, :root_source_code_paths, [])
+
     assert :ok = Mix.Task.rerun("sentry.package_source_code", ["--debug"])
 
     assert {:messages,

--- a/test/sentry/dedupe_test.exs
+++ b/test/sentry/dedupe_test.exs
@@ -5,8 +5,6 @@ defmodule Sentry.DedupeTest do
   alias Sentry.Dedupe
   alias Sentry.Event
 
-  @ttl_millisec 25
-
   describe "insert/1" do
     test "works correctly" do
       event = %Event{
@@ -25,8 +23,8 @@ defmodule Sentry.DedupeTest do
       # Now, we trigger a sweep after waiting for the TTL interval.
       # To ensure the :sweep message is processed, we use the trick
       # of asking the GenServer for its state (which is a sync call).
-      Process.sleep(@ttl_millisec * 2)
-      send(Dedupe, {:sweep, @ttl_millisec})
+      Process.sleep(5)
+      send(Dedupe, {:sweep, 0})
       _ = :sys.get_state(Dedupe)
 
       # Now, it's :new again.

--- a/test/sentry/logger_handler_test.exs
+++ b/test/sentry/logger_handler_test.exs
@@ -91,12 +91,8 @@ defmodule Sentry.LoggerHandlerTest do
     @tag handler_config: %{excluded_domains: []}
     test "sends two errors when a Plug process crashes if cowboy domain is not excluded",
          %{sender_ref: ref} do
-      {:ok, _plug_pid} = Plug.Cowboy.http(Sentry.ExamplePlugApplication, [], port: 8003)
-
       :hackney.get("http://127.0.0.1:8003/error_route", [], "", [])
       assert_receive {^ref, _event}, 1000
-    after
-      :ok = Plug.Cowboy.shutdown(Sentry.ExamplePlugApplication.HTTP)
     end
   end
 
@@ -109,7 +105,7 @@ defmodule Sentry.LoggerHandlerTest do
       assert_receive {^ref, event}
       assert event.message.formatted == "Testing error"
 
-      refute_receive {^ref, _event}, 100
+      refute_received {^ref, _event}, 100
     end
 
     @tag handler_config: %{capture_log_messages: true, level: :warning}
@@ -122,7 +118,7 @@ defmodule Sentry.LoggerHandlerTest do
       assert event.message.formatted == "Testing warning"
       assert event.level == :warning
 
-      refute_receive {^ref, _event}, 100
+      refute_received {^ref, _event}
     end
 
     @tag handler_config: %{capture_log_messages: true}
@@ -147,7 +143,7 @@ defmodule Sentry.LoggerHandlerTest do
     @tag handler_config: %{capture_log_messages: true}
     test "ignores log messages that are logged by Sentry itself", %{sender_ref: ref} do
       Logger.error("Sentry had an error", domain: [:sentry])
-      refute_receive {^ref, _event}
+      refute_received {^ref, _event}
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,3 +5,5 @@ File.rm_rf!(Sentry.Sources.path_of_packaged_source_code())
 ExUnit.after_suite(fn _ ->
   File.rm_rf!(Sentry.Sources.path_of_packaged_source_code())
 end)
+
+{:ok, _} = Plug.Cowboy.http(Sentry.ExamplePlugApplication, [], port: 8003)


### PR DESCRIPTION
Before:

```
Finished in 4.4 seconds (0.6s async, 3.8s sync)
12 doctests, 159 tests, 0 failures
```

After:

```
Finished in 0.9 seconds (0.4s async, 0.4s sync)
12 doctests, 159 tests, 0 failures
```