### PR TITLE
feat(source packaging): allow custom output path in task

### DIFF
--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -61,6 +61,15 @@ defmodule Sentry.Config do
       The name of the server running the application. Not used by default.
       """
     ],
+    source_code_map_path: [
+      type: {:custom, __MODULE__, :__validate_path__, []},
+      default: nil,
+      type_doc: "`t:Path.t/0` or `nil`",
+      doc: """
+      The path to the map file when mix task `sentry.package_source_code` was invoked with
+      `--output path/to/file.map`
+      """
+    ],
     sample_rate: [
       type: {:custom, __MODULE__, :__validate_sample_rate__, []},
       default: 1.0,
@@ -399,6 +408,9 @@ defmodule Sentry.Config do
   @spec server_name() :: String.t() | nil
   def server_name, do: get(:server_name)
 
+  @spec source_code_map_path() :: Path.t() | nil
+  def source_code_map_path, do: get(:source_code_map_path)
+
   @spec filter() :: module()
   def filter, do: fetch!(:filter)
 
@@ -526,6 +538,16 @@ defmodule Sentry.Config do
   @compile {:inline, fetch!: 1}
   defp get(key) do
     :persistent_term.get({:sentry_config, key}, nil)
+  end
+
+  def __validate_path__(nil), do: {:ok, nil}
+
+  def __validate_path__(path) when is_binary(path) do
+    if File.exists?(path) do
+      {:ok, path}
+    else
+      {:error, "path does not exist"}
+    end
   end
 
   def __validate_sample_rate__(float) do

--- a/lib/sentry/sources.ex
+++ b/lib/sentry/sources.ex
@@ -14,7 +14,9 @@ defmodule Sentry.Sources do
 
   # Default argument is here for testing.
   @spec load_source_code_map_if_present(Path.t()) :: {:loaded, source_map()} | {:error, term()}
-  def load_source_code_map_if_present(path \\ path_of_packaged_source_code()) do
+  def load_source_code_map_if_present(
+        path \\ Config.source_code_map_path() || path_of_packaged_source_code()
+      ) do
     path = Path.relative_to_cwd(path)
 
     with {:ok, contents} <- File.read(path),

--- a/test/mix/sentry.package_source_code_test.exs
+++ b/test/mix/sentry.package_source_code_test.exs
@@ -20,15 +20,24 @@ defmodule Mix.Tasks.Sentry.PackageSourceCodeTest do
 
     assert :ok = Mix.Task.rerun("sentry.package_source_code")
 
-    assert_receive {:mix_shell, :info, ["Wrote " <> _ = message]}
-    assert message =~ expected_path
+    validate_map_file!(expected_path)
+  end
 
-    assert {:ok, contents} = File.read(expected_path)
+  @tag :tmp_dir
+  test "packages source code into custom path", %{tmp_dir: tmp_dir} do
+    put_test_config(
+      root_source_code_paths: [File.cwd!()],
+      enable_source_code_context: true
+    )
 
-    assert %{"version" => 1, "files_map" => source_map} =
-             :erlang.binary_to_term(contents, [:safe])
+    expected_path =
+      [tmp_dir, "sentry.map"]
+      |> Path.join()
+      |> Path.relative_to_cwd()
 
-    assert Map.has_key?(source_map, "lib/mix/tasks/sentry.package_source_code.ex")
+    assert :ok = Mix.Task.rerun("sentry.package_source_code", ["--output", expected_path])
+
+    validate_map_file!(expected_path)
   end
 
   test "supports the --debug option" do
@@ -50,5 +59,17 @@ defmodule Mix.Tasks.Sentry.PackageSourceCodeTest do
               {:mix_shell, :info, ["Encoded source code map" <> _]},
               {:mix_shell, :info, ["Wrote " <> _]}
             ]} = Process.info(self(), :messages)
+  end
+
+  defp validate_map_file!(path) do
+    assert_receive {:mix_shell, :info, ["Wrote " <> _ = message]}
+    assert message =~ path
+
+    assert {:ok, contents} = File.read(path)
+
+    assert %{"version" => 1, "files_map" => source_map} =
+             :erlang.binary_to_term(contents, [:safe])
+
+    assert Map.has_key?(source_map, "lib/mix/tasks/sentry.package_source_code.ex")
   end
 end

--- a/test/sentry/config_test.exs
+++ b/test/sentry/config_test.exs
@@ -50,6 +50,22 @@ defmodule Sentry.ConfigTest do
       end
     end
 
+    @tag :tmp_dir
+    test ":source_code_map_path from option", %{tmp_dir: tmp_dir} do
+      source_code_map_path = Path.join([tmp_dir, "test.map"])
+
+      assert Config.validate!(source_code_map_path: nil)[:source_code_map_path] == nil
+
+      assert_raise ArgumentError, ~r/path does not exist/, fn ->
+        assert Config.validate!(source_code_map_path: source_code_map_path)
+      end
+
+      File.touch!(source_code_map_path)
+
+      assert Config.validate!(source_code_map_path: source_code_map_path)[:source_code_map_path] ==
+               source_code_map_path
+    end
+
     test ":release from option" do
       assert Config.validate!(release: "1.0.0")[:release] == "1.0.0"
     end


### PR DESCRIPTION
This fixes packaging an app's source code for Sentry v10 when building in highly reproducible environments (like nix), where the deps' sources are read-only (i.e. cannot write to Sentry's `priv` dir).
I've added an example to the docs.