### PR TITLE
expose create_event_opts_schema

### DIFF
--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -266,6 +266,10 @@ defmodule Sentry.Event do
 
   @create_event_opts_schema NimbleOptions.new!(create_event_opts_schema)
 
+  @doc false
+  @spec create_event_opts_schema() :: NimbleOptions.t()
+  def create_event_opts_schema, do: @create_event_opts_schema
+
   @doc """
   Creates an event struct out of collected context and options.
 


### PR DESCRIPTION
We use [LoggerSentry](https://hexdocs.pm/logger_sentry) for it's rate limiting functionality. However the latest version of Sentry's Elixir library (this one) is incompatible. Specifically, we see the error:

```
[info]** (NimbleOptions.ValidationError) unknown options [:erl_level, :crash_reason, :domain, :error_logger, :file, :function, :gl, :line, :mfa, :module, :pid, :registered_name, :report_cb, :time], valid options are: [:exception, :stacktrace, :message, :extra, :user, :tags, :request, :breadcrumbs, :level, :fingerprint, :event_source, :interpolation_parameters, :handled]
[info]    (nimble_options 1.1.0) lib/nimble_options.ex:359: NimbleOptions.validate!/2
[info]    (sentry 10.3.0) lib/sentry/event.ex:303: Sentry.Event.create_event/1
[info]    (sentry 10.3.0) lib/sentry.ex:291: Sentry.capture_message/2
[info]    (logger_sentry 0.7.2) lib/logger_sentry/rate_limiter.ex:57: LoggerSentry.RateLimiter.handle_cast/2
```

without getting into too many details, the issue here is that LoggerSentry is sending the wrong opts to Sentry and it's being caught by the [NimbleOptions validate here](https://github.com/getsentry/sentry-elixir/blob/master/lib/sentry/event.ex#L303). 

So, I'd like to try and fix LoggerSentry and it would be nice if I could read the value of `@create_event_opts_schema` and use that as a source of truth rather than hardcode option names and run the risk of them changing again later.

## If there's a better way to RateLimit using Sentry Elixir's default logger...

If there's a way to use Sentry's [LoggerHandler](https://hexdocs.pm/sentry/Sentry.LoggerHandler.html) or something like that, then we'd be happy to go that route and drop LoggerSentry entirely. 

## To test in console:

```elixir
iex -S mix

=> Sentry.Event.create_event_opts_schema()
```

