### PR TITLE
Improve "GenServer terminating" reports

### DIFF
--- a/test/sentry/logger_handler_test.exs
+++ b/test/sentry/logger_handler_test.exs
@@ -180,14 +180,18 @@ defmodule Sentry.LoggerHandlerTest do
 
       assert_receive {^ref, event}
 
-      assert event.message.formatted =~ "** (stop) :bad_exit"
+      assert event.message.message == "GenServer %s terminating: ** (stop) :bad_exit"
+      assert event.message.params == [inspect(test_genserver)]
 
       if System.otp_release() >= "26" do
         assert [] = event.exception
         assert [thread] = event.threads
         assert thread.stacktrace == nil
         assert event.extra.genserver_state == ":no_state"
-        assert event.extra.last_message =~ "{:run, #Function"
+        assert event.extra.last_message =~ ~r/^\{:run, .*/
+        assert event.extra.pid_which_sent_last_message == inspect(self())
+        assert event.extra.genserver_state == ":no_state"
+        assert event.extra.crash_reason == ":bad_exit"
       end
     end
 


### PR DESCRIPTION
We've got this error recently:

![CleanShot 2024-04-21 at 12 05 11@2x](https://github.com/getsentry/sentry-elixir/assets/3890250/e485d7ef-b3c8-4d7e-b28f-677eddf9976b)

We can do a lot better! This PR improves things significantly. Errors will be grouped better (by reason only, not by which PID crashes).