### PR TITLE
Add :bandit to list of ignored logger domains

### DIFF
--- a/lib/sentry/logger_backend.ex
+++ b/lib/sentry/logger_backend.ex
@@ -33,7 +33,7 @@ defmodule Sentry.LoggerBackend do
   ## Configuration
 
   * `:excluded_domains` - Any messages with a domain in the configured
-  list will not be sent. Defaults to `[:cowboy]` to avoid double reporting
+  list will not be sent. Defaults to `[:cowboy, :bandit]` to avoid double reporting
   events from `Sentry.PlugCapture`.
 
   * `:metadata` - To include non-Sentry Logger metadata in reports, the
@@ -70,7 +70,7 @@ defmodule Sentry.LoggerBackend do
 
   ## State
 
-  defstruct level: :error, metadata: [], excluded_domains: [:cowboy], capture_log_messages: false
+  defstruct level: :error, metadata: [], excluded_domains: [:cowboy, :bandit], capture_log_messages: false
 
   ## Callbacks
 

--- a/lib/sentry/logger_handler.ex
+++ b/lib/sentry/logger_handler.ex
@@ -26,7 +26,7 @@ defmodule Sentry.LoggerHandler do
     ],
     excluded_domains: [
       type: {:list, :atom},
-      default: [:cowboy],
+      default: [:cowboy, :bandit],
       type_doc: "list of `t:atom/0`",
       doc: """
       Any messages with a domain in the configured list will not be sent. The default is so as

--- a/test/logger_backend_test.exs
+++ b/test/logger_backend_test.exs
@@ -139,7 +139,7 @@ defmodule Sentry.LoggerBackendTest do
     :hackney.get("http://127.0.0.1:8003/error_route", [], "", [])
     assert_receive {^ref, _event}, 1000
   after
-    Logger.configure_backend(Sentry.LoggerBackend, excluded_domains: [:cowboy])
+    Logger.configure_backend(Sentry.LoggerBackend, excluded_domains: [:cowboy, :bandit])
   end
 
   test "ignores log messages with excluded domains" do


### PR DESCRIPTION
Based on downstream request from a user, Bandit now applies the `:bandit` domain to log messages as of 1.5.5 (just released)