### PR TITLE
Fix `on_mount` LiveView hook when given `:not_mounted_at_router`

### DIFF
--- a/lib/sentry/live_view_hook.ex
+++ b/lib/sentry/live_view_hook.ex
@@ -53,8 +53,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     # https://develop.sentry.dev/sdk/event-payloads/request/
 
     @doc false
-    @spec on_mount(:default, map(), map(), struct()) :: {:cont, struct()}
-    def on_mount(:default, params, _session, socket), do: on_mount(params, socket)
+    @spec on_mount(:default, map() | :not_mounted_at_router, map(), struct()) :: {:cont, struct()}
+    def on_mount(:default, %{} = params, _session, socket), do: on_mount(params, socket)
+    def on_mount(:default, :not_mounted_at_router, _session, socket), do: {:cont, socket}
 
     ## Helpers
 

--- a/test/sentry/live_view_hook_test.exs
+++ b/test/sentry/live_view_hook_test.exs
@@ -43,10 +43,6 @@ defmodule SentryTest.DeadLive do
   end
 end
 
-defmodule SentryTest.ErrorView do
-  def render(template, _), do: Phoenix.Controller.status_message_from_template(template)
-end
-
 defmodule SentryTest.PageController do
   use Phoenix.Controller
   use Phoenix.Component


### PR DESCRIPTION
Closes #738.

* Added new on_mount for params atom :not_mounted_at_router and bypasses logging error when a liveview process is a child of a non-live controller/view
* added test - checks to ensure logger has no errors in metadata