### PR TITLE
fix: handle nil environment values correctly in Sentry config

### DIFF
--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -561,7 +561,10 @@ defmodule Sentry.Config do
   ## Helpers
 
   defp fill_in_from_env(config, key, system_key) do
-    Keyword.put_new_lazy(config, key, fn -> System.get_env(system_key, nil) end)
+    case System.get_env(system_key) do
+      nil -> config
+      value -> Keyword.put_new(config, key, value)
+    end
   end
 
   # TODO: remove me on v11.0.0, :included_environments has been deprecated

--- a/test/sentry/config_test.exs
+++ b/test/sentry/config_test.exs
@@ -131,6 +131,18 @@ defmodule Sentry.ConfigTest do
       assert Config.validate!(environment_name: "test")[:environment_name] == "test"
     end
 
+    test ":environment_name set to default" do
+      previous_value = Application.get_env(:sentry, :environment_name)
+      Application.delete_env(:sentry, :environment_name)
+
+      on_exit(fn ->
+        Application.put_env(:sentry, :environment_name, previous_value)
+        assert previous_value === Application.get_env(:sentry, :environment_name)
+      end)
+
+      assert Config.validate!()[:environment_name] == "production"
+    end
+
     test ":environment_name from system env" do
       with_system_env("SENTRY_ENVIRONMENT", "my_env", fn ->
         assert Config.validate!([])[:environment_name] == "my_env"


### PR DESCRIPTION
If neither the `:environment_name` nor the `"SENTRY_ENVIRONMENT"` environment variable is provided, the `:environment_name` is set to `nil` by the `fill_in_from_env/3` function. This behavior is consistent for other configurations that utilize the `fill_in_from_env/3` function.

Here's the change in behavior demonstrated through test assertions:

**Before the change:**
```elixir
assert Config.validate!()[:environment_name] === ""
```

**After the change:**
```elixir
# Now, if not set, the environment name defaults to "production".
assert Config.validate!()[:environment_name] === "production"
```

This aligns with Sentry’s configuration as detailed in the document.
https://github.com/getsentry/sentry-elixir/blob/bc01cc977ca4af3124a5fae1f92771d34d3d8ff5/lib/sentry/config.ex#L81-L93