### PR TITLE
Use apply/3 to avoid Elixir 1.17 warnings

### DIFF
--- a/lib/sentry/integrations/oban/error_reporter.ex
+++ b/lib/sentry/integrations/oban/error_reporter.ex
@@ -24,11 +24,10 @@ defmodule Sentry.Integrations.Oban.ErrorReporter do
           :no_config
         ) :: :ok
   def handle_event([:oban, :job, :exception], _measurements, %{job: job} = _metadata, :no_config) do
-    oban_worker_mod = Oban.Worker
     %{reason: exception, stacktrace: stacktrace} = job.unsaved_error
 
     stacktrace =
-      case {oban_worker_mod.from_string(job.worker), stacktrace} do
+      case {apply(Oban.Worker, :from_string, [job.worker]), stacktrace} do
         {{:ok, atom_worker}, []} -> [{atom_worker, :process, 1, []}]
         _ -> stacktrace
       end


### PR DESCRIPTION
-add Kernal.apply/3 