### PR TITLE
Integration - Oban - max attempts flag

### DIFF
--- a/lib/sentry/application.ex
+++ b/lib/sentry/application.ex
@@ -57,7 +57,7 @@ defmodule Sentry.Application do
     end
 
     if config[:oban][:capture_errors] do
-      Sentry.Integrations.Oban.ErrorReporter.attach()
+      Sentry.Integrations.Oban.ErrorReporter.attach(config[:oban][:max_attempts_only])
     end
 
     if config[:quantum][:cron][:enabled] do

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -19,6 +19,14 @@ defmodule Sentry.Config do
           tuples. *Available since 10.3.0*.
           """
         ],
+        max_attempts_only: [
+          type: :boolean,
+          default: false,
+          doc: """
+          When `capture_errors` is enabled and `max_attempts_only` is enabled as well,
+          whether to only capture errors for jobs that have reached their maximum number of attempts.
+          """
+        ],
         cron: [
           doc: """
           Configuration options for configuring [*crons*](https://docs.sentry.io/product/crons/)


### PR DESCRIPTION
`max_attempts_only` config flag will allow to capture exception only in case max attempts were reached and Oban Job will not be retried

[#757](https://github.com/getsentry/sentry-elixir/issues/757)