### PR TITLE
Compile code before "sentry.package_source_code"

### DIFF
--- a/lib/mix/tasks/sentry.package_source_code.ex
+++ b/lib/mix/tasks/sentry.package_source_code.ex
@@ -68,6 +68,13 @@ defmodule Mix.Tasks.Sentry.PackageSourceCode do
   @bytes_in_mb 1024 * 1024
   @bytes_in_gb 1024 * 1024 * 1024
 
+  # Don't call the app.config task here, see
+  # https://github.com/getsentry/sentry-elixir/commit/b2a04ddcf5d5c5f861da9888b3dec2f4f12cee01
+  @requirements [
+    "loadpaths",
+    "compile"
+  ]
+
   @switches [
     debug: :boolean,
     output: :string

--- a/test/mix/sentry.package_source_code_test.exs
+++ b/test/mix/sentry.package_source_code_test.exs
@@ -61,6 +61,20 @@ defmodule Mix.Tasks.Sentry.PackageSourceCodeTest do
             ]} = Process.info(self(), :messages)
   end
 
+  # This is not really a regression test, but something like was reported in
+  # https://github.com/getsentry/sentry-elixir/issues/760. Fixed by adding
+  # "loadpaths" and "compile" to the dependencies of this Mix task.
+  test "supports custom configured :json_library" do
+    defmodule Sentry.ExampleJSON do
+      defdelegate encode(term), to: Jason
+      defdelegate decode(term), to: Jason
+    end
+
+    put_test_config(json_library: Sentry.ExampleJSON)
+
+    assert :ok = Mix.Task.rerun("sentry.package_source_code")
+  end
+
   defp validate_map_file!(path) do
     assert_receive {:mix_shell, :info, ["Wrote " <> _ = message]}
     assert message =~ path


### PR DESCRIPTION
Closes #760.