### PR TITLE
Periodically purge check-ins ETS table

### DIFF
--- a/lib/sentry/application.ex
+++ b/lib/sentry/application.ex
@@ -19,11 +19,13 @@ defmodule Sentry.Application do
         []
       end
 
+    integrations = Keyword.fetch!(config, :integrations)
+
     children =
       [
         {Registry, keys: :unique, name: Sentry.Transport.SenderRegistry},
         Sentry.Dedupe,
-        Sentry.Integrations.CheckInIDMappings
+        {Sentry.Integrations.CheckInIDMappings, integrations[:ttl]}
       ] ++
         maybe_http_client_spec ++
         [Sentry.Transport.SenderPool]
@@ -33,7 +35,7 @@ defmodule Sentry.Application do
 
     with {:ok, pid} <-
            Supervisor.start_link(children, strategy: :one_for_one, name: Sentry.Supervisor) do
-      start_integrations(Keyword.fetch!(config, :integrations))
+      start_integrations(integrations)
       {:ok, pid}
     end
   end

--- a/lib/sentry/application.ex
+++ b/lib/sentry/application.ex
@@ -25,7 +25,8 @@ defmodule Sentry.Application do
       [
         {Registry, keys: :unique, name: Sentry.Transport.SenderRegistry},
         Sentry.Dedupe,
-        {Sentry.Integrations.CheckInIDMappings, integrations[:ttl]}
+        {Sentry.Integrations.CheckInIDMappings,
+         [max_expected_check_in_time: integrations_config[:max_expected_check_in_time]]}
       ] ++
         maybe_http_client_spec ++
         [Sentry.Transport.SenderPool]
@@ -35,7 +36,7 @@ defmodule Sentry.Application do
 
     with {:ok, pid} <-
            Supervisor.start_link(children, strategy: :one_for_one, name: Sentry.Supervisor) do
-      start_integrations(integrations)
+      start_integrations(integrations_config)
       {:ok, pid}
     end
   end

--- a/lib/sentry/application.ex
+++ b/lib/sentry/application.ex
@@ -26,7 +26,10 @@ defmodule Sentry.Application do
         {Registry, keys: :unique, name: Sentry.Transport.SenderRegistry},
         Sentry.Dedupe,
         {Sentry.Integrations.CheckInIDMappings,
-         [max_expected_check_in_time: integrations_config[:max_expected_check_in_time]]}
+         [
+           max_expected_check_in_time:
+             Keyword.fetch!(integrations_config, :max_expected_check_in_time)
+         ]}
       ] ++
         maybe_http_client_spec ++
         [Sentry.Transport.SenderPool]

--- a/lib/sentry/application.ex
+++ b/lib/sentry/application.ex
@@ -19,7 +19,7 @@ defmodule Sentry.Application do
         []
       end
 
-    integrations = Keyword.fetch!(config, :integrations)
+    integrations_config = Keyword.fetch!(config, :integrations)
 
     children =
       [

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -2,6 +2,16 @@ defmodule Sentry.Config do
   @moduledoc false
 
   integrations_schema = [
+    ttl: [
+      type: :integer,
+      default: 600_000,
+      doc: """
+      The time in milliseconds that a check-in id will live after it has been created.
+
+      For long running cron jobs, set ttl (time to live) to longest running job time in milliseconds.
+      This avoids jobs being sweeped from table before they've been completed. Defaults to ten minutes.
+      """
+    ],
     oban: [
       type: :keyword_list,
       doc: """

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -14,6 +14,8 @@ defmodule Sentry.Config do
       if a check-in end event is reported after the specified `max_expected_check_in_time`,
       the SDK will not report it. This behavior helps manage resource usage effectively while still
       providing necessary tracking for your jobs.
+      
+      *Available since 10.6.3*.
       """
     ],
     oban: [

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -6,12 +6,14 @@ defmodule Sentry.Config do
       type: :integer,
       default: 600_000,
       doc: """
-      The time in milliseconds that a check-in id will live after it has been created.
+      The time in milliseconds that a check-in ID will live after it has been created.
 
-      The SDK reports the start and end of each check-in. However, to optimize performance and prevent
-      potential memory issues, if a check-in end event is reported after the specified `max_expected_check_in_time`,
-      the SDK will not report it. This behavior helps manage resource usage effectively while still providing necessary
-      tracking for your jobs.
+      The SDK reports the start and end of each check-in. A check-in is used to track the
+      progress of a specific check-in event associated with cron job telemetry events that are a part
+      of the same job. However, to optimize performance and prevent potential memory issues,
+      if a check-in end event is reported after the specified `max_expected_check_in_time`,
+      the SDK will not report it. This behavior helps manage resource usage effectively while still
+      providing necessary tracking for your jobs.
       """
     ],
     oban: [

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -2,14 +2,16 @@ defmodule Sentry.Config do
   @moduledoc false
 
   integrations_schema = [
-    ttl: [
+    max_expected_check_in_time: [
       type: :integer,
       default: 600_000,
       doc: """
       The time in milliseconds that a check-in id will live after it has been created.
 
-      For long running cron jobs, set ttl (time to live) to longest running job time in milliseconds.
-      This avoids jobs being sweeped from table before they've been completed. Defaults to ten minutes.
+      The SDK reports the start and end of each check-in. However, to optimize performance and prevent
+      potential memory issues, if a check-in end event is reported after the specified `max_expected_check_in_time`,
+      the SDK will not report it. This behavior helps manage resource usage effectively while still providing necessary
+      tracking for your jobs.
       """
     ],
     oban: [

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -14,7 +14,6 @@ defmodule Sentry.Config do
       if a check-in end event is reported after the specified `max_expected_check_in_time`,
       the SDK will not report it. This behavior helps manage resource usage effectively while still
       providing necessary tracking for your jobs.
-      
       *Available since 10.6.3*.
       """
     ],

--- a/lib/sentry/integrations/check_in_id_mappings.ex
+++ b/lib/sentry/integrations/check_in_id_mappings.ex
@@ -33,9 +33,10 @@ defmodule Sentry.Integrations.CheckInIDMappings do
 
   @impl true
   def init(ttl_millisec) do
-    if :ets.whereis(@table) == :undefined do
-      :ets.new(@table, [:named_table, :public, :set])
-    end
+    _table =
+      if :ets.whereis(@table) == :undefined do
+        :ets.new(@table, [:named_table, :public, :set])
+      end
 
     schedule_sweep()
     {:ok, ttl_millisec}

--- a/lib/sentry/integrations/check_in_id_mappings.ex
+++ b/lib/sentry/integrations/check_in_id_mappings.ex
@@ -5,6 +5,8 @@ defmodule Sentry.Integrations.CheckInIDMappings do
   alias Sentry.UUID
 
   @table :sentry_cron_mappings
+  @sweep_interval_millisec 30_000
+  @ttl_millisec 10_000_000
 
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link([] = _opts) do
@@ -12,15 +14,17 @@ defmodule Sentry.Integrations.CheckInIDMappings do
   end
 
   @spec lookup_or_insert_new(String.t()) :: UUID.t()
-  def lookup_or_insert_new(key) do
-    case :ets.lookup(@table, key) do
-      [{^key, value}] ->
-        value
+  def lookup_or_insert_new(cron_key) do
+    inserted_at = System.system_time(:millisecond)
+
+    case :ets.lookup(@table, cron_key) do
+      [{^cron_key, uuid, _inserted_at}] ->
+        uuid
 
       [] ->
-        value = UUID.uuid4_hex()
-        :ets.insert(@table, {key, value})
-        value
+        uuid = UUID.uuid4_hex()
+        :ets.insert(@table, {cron_key, uuid, inserted_at})
+        uuid
     end
   end
 
@@ -29,6 +33,31 @@ defmodule Sentry.Integrations.CheckInIDMappings do
   @impl true
   def init(nil) do
     _table = :ets.new(@table, [:named_table, :public, :set])
+    schedule_sweep()
     {:ok, :no_state}
   end
+
+  @impl true
+  def handle_info({:sweep, ttl_millisec}, state) do
+    now = System.system_time(:millisecond)
+
+    # All rows (which are {cron_key, uuid, inserted_at}) with an inserted_at older than
+    # now - @ttl_millisec.
+    match_spec = [{{:"$1", :"$2", :"$3"}, [], [{:<, :"$3", now - ttl_millisec}]}]
+    _ = :ets.select_delete(@table, match_spec)
+
+    schedule_sweep()
+    {:noreply, state}
+  end
+
+  ## Helpers
+
+  defp schedule_sweep do
+    Process.send_after(self(), {:sweep, @ttl_millisec}, @sweep_interval_millisec)
+  end
 end
+
+# Let's go with the GenServer that owns the table periodically sweeping it.
+# Every ~30 seconds, it can send a message to itself, go through the all table and use ets:select_delete or
+# something like that to remove all check-ins that are older than, say, 10 minutes.
+# If needed we can add a timestamp to the check ins, I don't recall if we do that already.

--- a/test/sentry/check_in_id_mappings_test.exs
+++ b/test/sentry/check_in_id_mappings_test.exs
@@ -1,0 +1,21 @@
+defmodule Sentry.CheckInIDMappingsTest do
+  # This is not async because it tests a singleton (the CheckInIDMappings GenServer).
+  use Sentry.Case, async: false
+
+  alias Sentry.Integrations.CheckInIDMappings
+
+  describe "lookup_or_insert_new/1" do
+    test "works correctly" do
+      cron_key = "quantum_123"
+
+      CheckInIDMappings.lookup_or_insert_new(cron_key)
+      assert :ets.lookup(:sentry_cron_mappings, cron_key) != []
+
+      Process.sleep(5)
+      send(CheckInIDMappings, {:sweep, 0})
+      _ = :sys.get_state(CheckInIDMappings)
+
+      assert :ets.lookup(:sentry_cron_mappings, cron_key) == []
+    end
+  end
+end

--- a/test/sentry/check_in_id_mappings_test.exs
+++ b/test/sentry/check_in_id_mappings_test.exs
@@ -3,19 +3,28 @@ defmodule Sentry.CheckInIDMappingsTest do
   use Sentry.Case, async: false
 
   alias Sentry.Integrations.CheckInIDMappings
+  @table :sentry_cron_mappings
 
   describe "lookup_or_insert_new/1" do
     test "works correctly" do
       cron_key = "quantum_123"
 
+      child_spec = %{
+        id: TestMappings,
+        start:
+          {CheckInIDMappings, :start_link, [[max_expected_check_in_time: 0, name: TestMappings]]}
+      }
+
+      pid = start_supervised!(child_spec)
+
       CheckInIDMappings.lookup_or_insert_new(cron_key)
-      assert :ets.lookup(:sentry_cron_mappings, cron_key) != []
+      assert :ets.lookup(@table, cron_key) != []
 
       Process.sleep(5)
-      send(CheckInIDMappings, {:sweep, 0})
-      _ = :sys.get_state(CheckInIDMappings)
+      send(pid, :sweep)
+      _ = :sys.get_state(pid)
 
-      assert :ets.lookup(:sentry_cron_mappings, cron_key) == []
+      assert :ets.lookup(@table, cron_key) == []
     end
   end
 end


### PR DESCRIPTION
-add sweep functionality to CheckInIDMappings ets table to clear out stale jobs
-add configurable option to corn integrations (TTL) for long standing jobs
-closes #762 