### PR TITLE
Fix logger handler support for structured log messages

### DIFF
--- a/lib/sentry/logger_handler.ex
+++ b/lib/sentry/logger_handler.ex
@@ -341,17 +341,10 @@ defmodule Sentry.LoggerHandler do
   # "report" here is of type logger:report/0, which is a map or keyword list.
   defp log_unfiltered(%{msg: {:report, report}}, sentry_opts, %__MODULE__{} = config) do
     case Map.new(report) do
-      %{report: %{reason: {exception, stacktrace}}}
+      %{reason: {exception, stacktrace}}
       when is_exception(exception) and is_list(stacktrace) ->
         sentry_opts = Keyword.merge(sentry_opts, stacktrace: stacktrace, handled: false)
         capture(:exception, exception, sentry_opts, config)
-
-      %{report: %{reason: {reason, stacktrace}}} when is_list(stacktrace) ->
-        sentry_opts = Keyword.put(sentry_opts, :stacktrace, stacktrace)
-        capture(:message, "** (stop) " <> Exception.format_exit(reason), sentry_opts, config)
-
-      %{report: report_info} ->
-        capture(:message, inspect(report_info), sentry_opts, config)
 
       %{reason: {reason, stacktrace}} when is_list(stacktrace) ->
         sentry_opts = Keyword.put(sentry_opts, :stacktrace, stacktrace)
@@ -363,8 +356,8 @@ defmodule Sentry.LoggerHandler do
 
         capture(:message, "** (stop) #{Exception.format_exit(reason)}", sentry_opts, config)
 
-      _other ->
-        :ok
+      _ ->
+        capture(:message, inspect(report), sentry_opts, config)
     end
   end
 

--- a/test/sentry/logger_handler_test.exs
+++ b/test/sentry/logger_handler_test.exs
@@ -135,6 +135,16 @@ defmodule Sentry.LoggerHandlerTest do
       refute_received {^ref, _event}, 100
     end
 
+    @tag handler_config: %{capture_log_messages: true}
+    test "support structured logs", %{sender_ref: ref} do
+      Logger.error(foo: "bar")
+
+      assert_receive {^ref, event}
+      assert event.message.formatted == "[foo: \"bar\"]"
+
+      refute_received {^ref, _event}, 100
+    end
+
     @tag handler_config: %{capture_log_messages: true, level: :warning}
     test "respects the configured :level", %{sender_ref: ref} do
       Logger.log(:warning, "Testing warning")


### PR DESCRIPTION
STR:
1. In a configured project, issue a log with structured message: `Logger.error(foo: "bar")`
2. Check message didn't get to Sentry

Here's my attempt on fixing this. Looks like the case statement is trying to work on both `report` and `msg`. Also added a basic test as I don't believe there are any for `{:report, report}` clause.