### PR TITLE
Add integration_meta key to event

### DIFF
--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -59,7 +59,7 @@ defmodule Sentry.Event do
           modules: %{optional(String.t()) => String.t()},
           extra: map(),
           fingerprint: [String.t()],
-          integration_meta: map() | nil,
+          integration_meta: map(),
 
           # Interfaces.
           breadcrumbs: [Interfaces.Breadcrumb.t()],

--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -349,31 +349,30 @@ defmodule Sentry.Event do
     source = Keyword.get(opts, :event_source)
     handled? = Keyword.fetch!(opts, :handled)
 
-    event =
-      %__MODULE__{
-        attachments: attachments_context,
-        breadcrumbs: breadcrumbs,
-        contexts: generate_contexts(),
-        culprit: culprit_from_stacktrace(Keyword.get(opts, :stacktrace, [])),
-        environment: Config.environment_name(),
-        event_id: UUID.uuid4_hex(),
-        exception: List.wrap(coerce_exception(exception, stacktrace, message, handled?)),
-        extra: extra,
-        fingerprint: Keyword.fetch!(opts, :fingerprint),
-        level: Keyword.fetch!(opts, :level),
-        message: message && build_message_interface(message, opts),
-        modules: :persistent_term.get({:sentry, :loaded_applications}),
-        original_exception: exception,
-        release: Config.release(),
-        request: struct(%Interfaces.Request{}, request),
-        sdk: @sdk,
-        server_name: Config.server_name() || to_string(:net_adm.localhost()),
-        source: source,
-        tags: tags,
-        timestamp: timestamp,
-        user: user,
-        integration_meta: nil
-      }
+    event = %__MODULE__{
+      attachments: attachments_context,
+      breadcrumbs: breadcrumbs,
+      contexts: generate_contexts(),
+      culprit: culprit_from_stacktrace(Keyword.get(opts, :stacktrace, [])),
+      environment: Config.environment_name(),
+      event_id: UUID.uuid4_hex(),
+      exception: List.wrap(coerce_exception(exception, stacktrace, message, handled?)),
+      extra: extra,
+      fingerprint: Keyword.fetch!(opts, :fingerprint),
+      level: Keyword.fetch!(opts, :level),
+      message: message && build_message_interface(message, opts),
+      modules: :persistent_term.get({:sentry, :loaded_applications}),
+      original_exception: exception,
+      release: Config.release(),
+      request: struct(%Interfaces.Request{}, request),
+      sdk: @sdk,
+      server_name: Config.server_name() || to_string(:net_adm.localhost()),
+      source: source,
+      tags: tags,
+      timestamp: timestamp,
+      user: user,
+      integration_meta: Keyword.fetch!(opts, :integration_meta)
+    }
 
     # If we have a message *and* a stacktrace, but no exception, we need to store the stacktrace
     # information within a "thread" interface. This is how the Python SDK also does it. An issue

--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -118,7 +118,7 @@ defmodule Sentry.Event do
     transaction: nil,
     threads: nil,
     user: %{},
-    integration_meta: nil,
+    integration_meta: %{},
 
     # "Culprit" is not documented anymore and we should move to transactions at some point.
     # https://forum.sentry.io/t/culprit-deprecated-in-favor-of-what/4871/9

--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -259,11 +259,8 @@ defmodule Sentry.Event do
     ],
     integration_meta: [
       type: :map,
-      doc: """
-      A map to store metadata specific to the integration.
-      It allows cron integrations, such as the Oban integration,
-      to store job-related metadata. *Available since v10.1.0*.
-      """
+      default: %{},
+      doc: false
     ],
 
     ## Internal options

--- a/lib/sentry/integrations/oban/error_reporter.ex
+++ b/lib/sentry/integrations/oban/error_reporter.ex
@@ -41,7 +41,9 @@ defmodule Sentry.Integrations.Oban.ErrorReporter do
           inspect(job.worker),
           Exception.message(exception)
         ],
-        extra: Map.take(job, [:args, :attempt, :id, :max_attempts, :meta, :queue, :tags, :worker])
+        extra:
+          Map.take(job, [:args, :attempt, :id, :max_attempts, :meta, :queue, :tags, :worker]),
+        integration_meta: %{oban: %{job_meta: job}}
       )
 
     :ok

--- a/test/sentry/integrations/oban/error_reporter_test.exs
+++ b/test/sentry/integrations/oban/error_reporter_test.exs
@@ -48,6 +48,7 @@ defmodule Sentry.Integrations.Oban.ErrorReporterTest do
       assert event.tags.oban_queue == "default"
       assert event.tags.oban_state == "available"
       assert event.tags.oban_worker == "Sentry.Integrations.Oban.ErrorReporterTest.MyWorker"
+      assert %{job_meta: %Oban.Job{}} = event.integration_meta.oban
     end
   end
 end


### PR DESCRIPTION
-Added an integration_meta key to store the metadata of a cron job, allowing the user to filter what events are reported based on the values. 
-Alternate solution to PR #759 
-Related to #757 