### PR TITLE
Transform Sentry.Event to JSON 

### DIFF
--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -345,7 +345,8 @@ defmodule Sentry.Client do
 
   defp sanitize_non_jsonable_value(value, json_library) do
     try do
-      json_library.encode(value)
+      struct(Sentry.Event, value)
+      |> json_library.encode()
     catch
       _type, _reason -> {:changed, inspect(value)}
     else

--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -301,8 +301,12 @@ defmodule Sentry.Client do
     end)
   end
 
-  defp remove_nils(map) when is_map(map) do
+  defp remove_nils(map) when is_map(map) and not is_struct(map) do
     :maps.filter(fn _key, value -> not is_nil(value) end, map)
+  end
+
+  defp remove_nils(value) do
+    :maps.filter(fn _key, value -> not is_nil(value) end, Map.from_struct(value))
   end
 
   defp sanitize_non_jsonable_values(map, json_library) do


### PR DESCRIPTION
So I think this is wrong.. but I've taken some time to consider how we'd go about this and seems changing it back to a struct in the pattern matched `sanitize_non_jsonable_value` is the way to push it through `Jason.Encoder`. But since the one I'm changing is a catch all function, it's not a map to begin with... But this is the function in the stacktrace from #769 that the value is being sent to in version 10.3 ->

_lib/ecto/json.ex in Jason.Encoder.Ecto.Association.NotLoaded.encode/2 at line 4
lib/encode.ex in Jason.Encode.encode/2 at line 37
lib/jason.ex in Jason.encode/2 at line 139
lib/sentry/client.ex in Sentry.Client.sanitize_non_jsonable_value/2 at line 326
lib/sentry/client.ex in anonymous fn/3 in Sentry.Client.sanitize_non_jsonable_values/2 at line 291
maps.erl in :maps.fold_1/4 at line 416
lib/sentry/client.ex in Sentry.Client.update_if_present/3 at line 335
lib/sentry/client.ex in Sentry.Client.render_event/1 at line 259__

Thoughts @whatyouhide?
