### PR TITLE
Set frames to `nil` when an empty list

### DIFF
--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -297,11 +297,7 @@ defmodule Sentry.Client do
     thread
     |> Map.from_struct()
     |> update_if_present(:stacktrace, fn %Interfaces.Stacktrace{frames: frames} ->
-      if is_nil(frames) do
-        %{frames: nil}
-      else
-        %{frames: Enum.map(frames, &Map.from_struct/1)}
-      end
+      %{frames: frames && Enum.map(frames, &Map.from_struct/1)}
     end)
   end
 

--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -297,7 +297,11 @@ defmodule Sentry.Client do
     thread
     |> Map.from_struct()
     |> update_if_present(:stacktrace, fn %Interfaces.Stacktrace{frames: frames} ->
-      %{frames: Enum.map(frames, &Map.from_struct/1)}
+      if is_nil(frames) do
+        %{frames: nil}
+      else
+        %{frames: Enum.map(frames, &Map.from_struct/1)}
+      end
     end)
   end
 

--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -481,7 +481,7 @@ defmodule Sentry.Event do
 
   defp coerce_stacktrace(stacktrace) when is_list(stacktrace) do
     case stacktrace_to_frames(stacktrace) do
-      [] -> nil
+      [] -> %Interfaces.Stacktrace{frames: nil}
       frames -> %Interfaces.Stacktrace{frames: frames}
     end
   end

--- a/test/logger_backend_test.exs
+++ b/test/logger_backend_test.exs
@@ -50,7 +50,7 @@ defmodule Sentry.LoggerBackendTest do
     # it's fine. Just make sure that on the latest Elixir/OTP versions it's there.
     if System.otp_release() >= "26" do
       assert [thread] = event.threads
-      assert thread.stacktrace == nil
+      assert thread.stacktrace.frames == nil
     end
   end
 

--- a/test/sentry/client_test.exs
+++ b/test/sentry/client_test.exs
@@ -83,6 +83,15 @@ defmodule Sentry.ClientTest do
       :code.delete(RaisingJSONClient)
       :code.purge(RaisingJSONClient)
     end
+
+    test "renders threads with stacktrace :frames field set to nil if empty" do
+      event =
+        Event.create_event(message: "No frames in stacktrace", stacktrace: [])
+
+      client = Client.render_event(event)
+
+      assert %{frames: nil} = get_in(client.threads, [Access.at(0), :stacktrace])
+    end
   end
 
   describe "send_event/2" do

--- a/test/sentry/logger_handler_test.exs
+++ b/test/sentry/logger_handler_test.exs
@@ -223,7 +223,7 @@ defmodule Sentry.LoggerHandlerTest do
       if System.otp_release() >= "26" do
         assert [] = event.exception
         assert [thread] = event.threads
-        assert thread.stacktrace == nil
+        assert thread.stacktrace.frames == nil
         assert event.extra.genserver_state == ":no_state"
         assert event.extra.last_message =~ ~r/^\{:run, .*/
         assert event.extra.pid_which_sent_last_message == inspect(self())


### PR DESCRIPTION
-as mentioned in, #770 Sentry does not support empty lists being passed to the frames stacktrace. This PR sets our frames key to nil rather than omitting the key when stacktrace is nil or an empty list entirely. 
-similar to the other SDK bugs  mentioned in this issue
-closes #770