### PR TITLE
fix(tasks): allow passing `--no-compile` and `--no-check-deps` to `package_source_code` task

### DIFF
--- a/lib/mix/tasks/sentry.package_source_code.ex
+++ b/lib/mix/tasks/sentry.package_source_code.ex
@@ -55,6 +55,8 @@ defmodule Mix.Tasks.Sentry.PackageSourceCode do
       `priv` directory is read-only, such as with [NixOS](https://github.com/NixOS/nixpkgs)
       and similar tools.
       *Available since v10.2.0*.
+    * `--no-compile` - does not compile applications before running
+    * `--no-deps-check` - does not check dependencies before running
 
   """
 
@@ -68,21 +70,27 @@ defmodule Mix.Tasks.Sentry.PackageSourceCode do
   @bytes_in_mb 1024 * 1024
   @bytes_in_gb 1024 * 1024 * 1024
 
-  # Don't call the app.config task here, see
-  # https://github.com/getsentry/sentry-elixir/commit/b2a04ddcf5d5c5f861da9888b3dec2f4f12cee01
-  @requirements [
-    "loadpaths",
-    "compile"
-  ]
-
   @switches [
     debug: :boolean,
-    output: :string
+    output: :string,
+    no_compile: :boolean,
+    no_deps_check: :boolean
   ]
 
   @impl true
   def run(args) do
     {opts, _args} = OptionParser.parse!(args, strict: @switches)
+
+    # Don't call the app.config task here, see
+    # https://github.com/getsentry/sentry-elixir/commit/b2a04ddcf5d5c5f861da9888b3dec2f4f12cee01
+
+    if not Keyword.get(opts, :no_deps_check, false) do
+      Mix.Task.run("loadpaths")
+    end
+
+    if not Keyword.get(opts, :no_compile, false) do
+      Mix.Task.run("compile")
+    end
 
     config = Application.get_all_env(:sentry)
 

--- a/test/mix/sentry.package_source_code_test.exs
+++ b/test/mix/sentry.package_source_code_test.exs
@@ -75,6 +75,10 @@ defmodule Mix.Tasks.Sentry.PackageSourceCodeTest do
     assert :ok = Mix.Task.rerun("sentry.package_source_code")
   end
 
+  test "supports --no-compile and --no-deps-check" do
+    assert :ok = Mix.Task.rerun("sentry.package_source_code", ["--no-compile", "--no-deps-check"])
+  end
+
   defp validate_map_file!(path) do
     assert_receive {:mix_shell, :info, ["Wrote " <> _ = message]}
     assert message =~ path


### PR DESCRIPTION
10.7.0 broke invoking `mix sentry.package_source_code` during a build using nix (xkcd 1172 😂 )

That's because inside the nix build env, running `loadpaths` and `compile` must be avoided because all deps are already compiled separately and loaded read-only via env vars.

These flags are somewhat "standard" and used in various phoenix/ecto tasks:
- https://github.com/phoenixframework/phoenix/blob/e99f657f1cc9062fca0f2b8b79bc90659d8bd514/lib/mix/tasks/phx.routes.ex#L66-L68
- https://github.com/elixir-ecto/ecto_sql/blob/master/lib/mix/tasks/ecto.load.ex#L54-L55

