### PR TITLE
Move source code maps to ETS

### DIFF
--- a/lib/sentry/application.ex
+++ b/lib/sentry/application.ex
@@ -3,7 +3,7 @@ defmodule Sentry.Application do
 
   use Application
 
-  alias Sentry.{Config, Sources}
+  alias Sentry.Config
 
   @impl true
   def start(_type, _opts) do
@@ -24,6 +24,7 @@ defmodule Sentry.Application do
     children =
       [
         {Registry, keys: :unique, name: Sentry.Transport.SenderRegistry},
+        Sentry.Sources,
         Sentry.Dedupe,
         {Sentry.Integrations.CheckInIDMappings,
          [
@@ -35,7 +36,6 @@ defmodule Sentry.Application do
         [Sentry.Transport.SenderPool]
 
     cache_loaded_applications()
-    _ = Sources.load_source_code_map_if_present()
 
     with {:ok, pid} <-
            Supervisor.start_link(children, strategy: :one_for_one, name: Sentry.Supervisor) do

--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -551,8 +551,9 @@ defmodule Sentry.Event do
       not Config.enable_source_code_context?() ->
         frame
 
-      source_map = Sources.get_source_code_map_from_persistent_term() ->
-        {pre_context, context, post_context} = Sources.get_source_context(source_map, file, line)
+      source_map_for_file = Sources.get_lines_for_file(file) ->
+        {pre_context, context, post_context} =
+          Sources.get_source_context(source_map_for_file, line)
 
         %Interfaces.Stacktrace.Frame{
           frame

--- a/lib/sentry/sources.ex
+++ b/lib/sentry/sources.ex
@@ -30,11 +30,14 @@ defmodule Sentry.Sources do
 
   @impl true
   def handle_continue(:load_source_code_map, state) do
-    with {:loaded, source_map} <- load_source_code_map_if_present() do
-      Enum.each(source_map, fn {path, lines_map} ->
-        :ets.insert(@table, {path, lines_map})
-      end)
-    end
+    :ok =
+      with {:loaded, source_map} <- load_source_code_map_if_present() do
+        Enum.each(source_map, fn {path, lines_map} ->
+          :ets.insert(@table, {path, lines_map})
+        end)
+      else
+        _error -> :ok
+      end
 
     {:noreply, state}
   end

--- a/lib/sentry/sources.ex
+++ b/lib/sentry/sources.ex
@@ -24,7 +24,7 @@ defmodule Sentry.Sources do
 
   @impl true
   def init(nil) do
-    :ets.new(@table, [:public, :named_table, read_concurrency: true])
+    _ = :ets.new(@table, [:public, :named_table, read_concurrency: true])
     {:ok, :no_state, {:continue, :load_source_code_map}}
   end
 

--- a/lib/sentry/sources.ex
+++ b/lib/sentry/sources.ex
@@ -1,15 +1,46 @@
 defmodule Sentry.Sources do
   @moduledoc false
 
+  use GenServer
+
   alias Sentry.Config
 
-  @type source_map :: %{
-          optional(String.t()) => %{
-            (line_no :: pos_integer()) => line_contents :: String.t()
-          }
+  @type source_map_for_file :: %{
+          optional(line_no :: pos_integer()) => line_contents :: String.t()
         }
 
-  @source_code_map_key {:sentry, :source_code_map}
+  @type source_map :: %{
+          optional(String.t()) => source_map_for_file()
+        }
+
+  ## GenServer
+
+  @table __MODULE__
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link([] = _) do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+  @impl true
+  def init(nil) do
+    :ets.new(@table, [:public, :named_table, read_concurrency: true])
+    {:ok, :no_state, {:continue, :load_source_code_map}}
+  end
+
+  @impl true
+  def handle_continue(:load_source_code_map, state) do
+    with {:loaded, source_map} <- load_source_code_map_if_present() do
+      Enum.each(source_map, fn {path, lines_map} ->
+        :ets.insert(@table, {path, lines_map})
+      end)
+    end
+
+    {:noreply, state}
+  end
+
+  ## Other functions
+
   @compression_level if Mix.env() == :test, do: 0, else: 9
 
   # Default argument is here for testing.
@@ -21,7 +52,6 @@ defmodule Sentry.Sources do
 
     with {:ok, contents} <- File.read(path),
          {:ok, source_map} <- decode_source_code_map(contents) do
-      :persistent_term.put(@source_code_map_key, source_map)
       {:loaded, source_map}
     else
       {:error, :binary_to_term} ->
@@ -67,11 +97,6 @@ defmodule Sentry.Sources do
     end
   end
 
-  @spec get_source_code_map_from_persistent_term() :: source_map() | nil
-  def get_source_code_map_from_persistent_term do
-    :persistent_term.get(@source_code_map_key, nil)
-  end
-
   @spec load_files(keyword()) :: {:ok, source_map()} | {:error, message :: String.t()}
   def load_files(config \\ []) when is_list(config) do
     config = Sentry.Config.validate!(config)
@@ -106,23 +131,25 @@ defmodule Sentry.Sources do
     source_map -> {:ok, source_map}
   end
 
-  @spec get_source_context(source_map(), String.t() | nil, pos_integer() | nil) ::
-          {[String.t()], String.t() | nil, [String.t()]}
-  def get_source_context(%{} = files, file_name, line_number) do
-    context_lines = Config.context_lines()
-
-    case Map.fetch(files, file_name) do
-      :error -> {[], nil, []}
-      {:ok, file} -> get_source_context_for_file(file, line_number, context_lines)
+  @spec get_lines_for_file(Path.t()) :: map() | nil
+  def get_lines_for_file(file) do
+    case :ets.lookup(@table, file) do
+      [{^file, lines}] -> lines
+      [] -> nil
     end
   end
 
-  defp get_source_context_for_file(file, line_number, context_lines) do
+  @spec get_source_context(source_map_for_file(), pos_integer() | nil) ::
+          {[String.t()], String.t() | nil, [String.t()]}
+  def get_source_context(source_map_for_file, line_number)
+      when is_map(source_map_for_file) and (is_integer(line_number) or is_nil(line_number)) do
+    context_lines = Config.context_lines()
+
     context_line_indices = 0..(2 * context_lines)
 
     Enum.reduce(context_line_indices, {[], nil, []}, fn i, {pre_context, context, post_context} ->
       context_line_number = line_number - context_lines + i
-      source = Map.get(file, context_line_number)
+      source = Map.get(source_map_for_file, context_line_number)
 
       cond do
         context_line_number == line_number && source ->

--- a/lib/sentry/transport/sender.ex
+++ b/lib/sentry/transport/sender.ex
@@ -32,6 +32,10 @@ defmodule Sentry.Transport.Sender do
 
   @impl GenServer
   def init([]) do
+    if function_exported?(Process, :set_label, 1) do
+      apply(Process, :set_label, [__MODULE__])
+    end
+
     {:ok, %__MODULE__{}}
   end
 


### PR DESCRIPTION
Part of fixing #773 is to move the source maps—which can be really big—out of persistent term and into ETS. `persistent_term` is copied over to every process, so while faster, in this case it causes the whole system to be a bit too memory hungry.