### PR TITLE
Accept structs as structured logs in Sentry.LoggerHandler

### DIFF
--- a/lib/sentry/logger_handler.ex
+++ b/lib/sentry/logger_handler.ex
@@ -338,7 +338,12 @@ defmodule Sentry.LoggerHandler do
     log_from_crash_reason(log_event.meta[:crash_reason], unicode_chardata, sentry_opts, config)
   end
 
-  # "report" here is of type logger:report/0, which is a map or keyword list.
+  # "report" here is of type logger:report/0, which is a struct, map or keyword list.
+  defp log_unfiltered(%{msg: {:report, report}}, sentry_opts, %__MODULE__{} = config)
+       when is_struct(report) do
+    capture(:message, inspect(report), sentry_opts, config)
+  end
+
   defp log_unfiltered(%{msg: {:report, report}}, sentry_opts, %__MODULE__{} = config) do
     case Map.new(report) do
       %{reason: {exception, stacktrace}}

--- a/test/sentry/logger_handler_test.exs
+++ b/test/sentry/logger_handler_test.exs
@@ -136,11 +136,33 @@ defmodule Sentry.LoggerHandlerTest do
     end
 
     @tag handler_config: %{capture_log_messages: true}
-    test "support structured logs", %{sender_ref: ref} do
+    test "support structured logs keyword", %{sender_ref: ref} do
       Logger.error(foo: "bar")
 
       assert_receive {^ref, event}
       assert event.message.formatted == "[foo: \"bar\"]"
+
+      refute_received {^ref, _event}, 100
+    end
+
+    test "support structured logs map", %{sender_ref: ref} do
+      Logger.error(%{foo: "bar"})
+
+      assert_receive {^ref, event}
+      assert event.message.formatted == "%{foo: \"bar\"}"
+
+      refute_received {^ref, _event}, 100
+    end
+
+    defmodule Foo do
+      defstruct [:bar]
+    end
+
+    test "support structured logs struct", %{sender_ref: ref} do
+      Logger.error(%Foo{})
+
+      assert_receive {^ref, event}
+      assert event.message.formatted == "%Sentry.LoggerHandlerTest.Foo{bar: nil}"
 
       refute_received {^ref, _event}, 100
     end


### PR DESCRIPTION
👋 

While testing my custom logger handler, which is based on the Sentry Elixir handler, I encountered an issue where passing a struct to `Logger.error` causes the handler to detach. The error handler only supports keywords and maps.

The problem arose when using the Tesla library, which passes a `Tesla.Env` struct to `Logger.error`. Interestingly, `Logger.info` does support passing structs, and the struct is displayed as a keyword list  or map with the `__struct__ `field

```elixir
iex(3)> Logger.error(%Foo{})
:ok
23:36:43.117 [error] [__struct__: Foo, bar: nil]
```

I added a test that reproduce the issue and a fix proposition.