### PR TITLE
Add :monitor_config_defaults integrations option

### DIFF
--- a/lib/sentry/application.ex
+++ b/lib/sentry/application.ex
@@ -19,7 +19,7 @@ defmodule Sentry.Application do
         []
       end
 
-    integrations_config = Keyword.fetch!(config, :integrations)
+    integrations_config = Config.integrations()
 
     children =
       [

--- a/lib/sentry/check_in.ex
+++ b/lib/sentry/check_in.ex
@@ -115,7 +115,11 @@ defmodule Sentry.CheckIn do
       """
     ],
     monitor_config: [
-      doc: "If you pass this optional option, you **must** pass the nested `:schedule` option.",
+      doc: """
+      If you pass this optional option, you **must** pass the nested `:schedule` option. The
+      options below are described in detail in the [Sentry
+      documentation](https://develop.sentry.dev/sdk/telemetry/check-ins/#monitor-upsert-support).
+      """,
       type: :keyword_list,
       keys: [
         checkin_margin: number_schema_opts,

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -17,6 +17,16 @@ defmodule Sentry.Config do
       *Available since 10.6.3*.
       """
     ],
+    monitor_config_defaults: [
+      type: :keyword_list,
+      default: [],
+      doc: """
+      Defaults to be used for the `monitor_config` when reporting cron jobs with one of the
+      integrations. This supports all the keys defined in the [Sentry
+      documentation](https://develop.sentry.dev/sdk/telemetry/check-ins/#monitor-upsert-support).
+      See also `Sentry.CheckIn.new/1`. *Available since v10.8.0*.
+      """
+    ],
     oban: [
       type: :keyword_list,
       doc: """
@@ -554,6 +564,9 @@ defmodule Sentry.Config do
 
   @spec test_mode?() :: boolean()
   def test_mode?, do: fetch!(:test_mode)
+
+  @spec integrations() :: keyword()
+  def integrations, do: fetch!(:integrations)
 
   @spec put_config(atom(), term()) :: :ok
   def put_config(key, value) when is_atom(key) do


### PR DESCRIPTION
Without this, we (at Veeps) get tons of missed check-ins for jobs that take longer than the default threshold. This way, we can configure things at least at a global level. Ideally we'll do the same for a per-worker level at some point but this should be enough for now.