### PR TITLE
Add missing cond for frames

### DIFF
--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -289,7 +289,7 @@ defmodule Sentry.Client do
     |> Map.from_struct()
     |> update_if_present(:mechanism, &Map.from_struct/1)
     |> update_if_present(:stacktrace, fn %Interfaces.Stacktrace{frames: frames} ->
-      %{frames: Enum.map(frames, &Map.from_struct/1)}
+      %{frames: frames && Enum.map(frames, &Map.from_struct/1)}
     end)
   end
 

--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -354,10 +354,27 @@ defmodule Sentry.Client do
     end
   end
 
+  defp update_if_present(map, :stacktrace, fun) do
+    case Map.pop(map, :stacktrace) do
+      {nil, _} ->
+        map
+
+      {value, map} ->
+        if is_nil(value.frames) || value.frames == [] do
+          Map.delete(map, :stacktrace)
+        else
+          Map.put(map, :stacktrace, fun.(value))
+        end
+    end
+  end
+
   defp update_if_present(map, key, fun) do
     case Map.pop(map, key) do
-      {nil, _} -> map
-      {value, map} -> Map.put(map, key, fun.(value))
+      {nil, _} ->
+        map
+
+      {value, map} ->
+        Map.put(map, key, fun.(value))
     end
   end
 

--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -287,18 +287,24 @@ defmodule Sentry.Client do
   defp render_exception(%Interfaces.Exception{} = exception) do
     exception
     |> Map.from_struct()
+    |> render_stacktrace()
     |> update_if_present(:mechanism, &Map.from_struct/1)
-    |> update_if_present(:stacktrace, fn %Interfaces.Stacktrace{frames: frames} ->
-      %{frames: frames && Enum.map(frames, &Map.from_struct/1)}
-    end)
   end
 
   defp render_thread(%Interfaces.Thread{} = thread) do
     thread
     |> Map.from_struct()
-    |> update_if_present(:stacktrace, fn %Interfaces.Stacktrace{frames: frames} ->
-      %{frames: frames && Enum.map(frames, &Map.from_struct/1)}
-    end)
+    |> render_stacktrace()
+  end
+
+  defp render_stacktrace(map) do
+    case map do
+      %{stacktrace: %{frames: %Interfaces.Stacktrace{frames: [_ | _]} = stacktrace}} ->
+        %{stacktrace | frames: Enum.map(stacktrace.frames, &Map.from_struct/1)}
+
+      map_without_stacktrace ->
+        Map.delete(map_without_stacktrace, :stacktrace)
+    end
   end
 
   defp remove_nils(map) when is_map(map) do
@@ -351,20 +357,6 @@ defmodule Sentry.Client do
     else
       {:ok, _encoded} -> :unchanged
       {:error, _reason} -> {:changed, inspect(value)}
-    end
-  end
-
-  defp update_if_present(map, :stacktrace, fun) do
-    case Map.pop(map, :stacktrace) do
-      {nil, _} ->
-        map
-
-      {value, map} ->
-        if is_nil(value.frames) || value.frames == [] do
-          Map.delete(map, :stacktrace)
-        else
-          Map.put(map, :stacktrace, fun.(value))
-        end
     end
   end
 

--- a/test/sentry/client_test.exs
+++ b/test/sentry/client_test.exs
@@ -84,22 +84,24 @@ defmodule Sentry.ClientTest do
       :code.purge(RaisingJSONClient)
     end
 
-    test "renders threads with stacktrace :frames field set to nil if empty" do
+    test "renders threads with stacktrace property deleted if :frames field set to nil if empty" do
       event =
         Event.create_event(message: "No frames in stacktrace", stacktrace: [])
 
       client = Client.render_event(event)
 
-      assert %{frames: nil} = get_in(client.threads, [Access.at(0), :stacktrace])
+      assert is_nil(get_in(client.threads, [Access.at(0), :stacktrace]))
+
+      # assert %{frames: nil} = get_in(client.threads, [Access.at(0), :stacktrace])
     end
 
-    test "renders exception with stacktrace :frames field set to nil if empty" do
+    test "renders exception with stacktrace property deleted if :frames field set to nil if empty" do
       event =
         Event.transform_exception(%RuntimeError{message: "foo"}, stacktrace: [])
 
-      assert %{
-               exception: [%{stacktrace: %{frames: nil}}]
-             } = Client.render_event(event)
+      client = Client.render_event(event)
+
+      assert is_nil(get_in(client.exception, [Access.at(0), :stacktrace]))
     end
 
     test "removes non-payload fields" do

--- a/test/sentry/client_test.exs
+++ b/test/sentry/client_test.exs
@@ -91,8 +91,6 @@ defmodule Sentry.ClientTest do
       client = Client.render_event(event)
 
       assert is_nil(get_in(client.threads, [Access.at(0), :stacktrace]))
-
-      # assert %{frames: nil} = get_in(client.threads, [Access.at(0), :stacktrace])
     end
 
     test "renders exception with stacktrace property deleted if :frames field set to nil if empty" do

--- a/test/sentry/client_test.exs
+++ b/test/sentry/client_test.exs
@@ -93,6 +93,15 @@ defmodule Sentry.ClientTest do
       assert %{frames: nil} = get_in(client.threads, [Access.at(0), :stacktrace])
     end
 
+    test "renders exception with stacktrace :frames field set to nil if empty" do
+      event =
+        Event.transform_exception(%RuntimeError{message: "foo"}, stacktrace: [])
+
+      assert %{
+               exception: [%{stacktrace: %{frames: nil}}]
+             } = Client.render_event(event)
+    end
+
     test "removes non-payload fields" do
       event = %Sentry.Event{
         event_id: "abc123",


### PR DESCRIPTION
-render_exception was missing a conditional and nil was being passed to Enum.map causing a `Protocol.Undefined` error
-closes #786 
