### PR TITLE
update maybe_log_send_result/2 with proper error

### DIFF
--- a/test/sentry/client_test.exs
+++ b/test/sentry/client_test.exs
@@ -297,8 +297,8 @@ defmodule Sentry.ClientTest do
         end)
 
       assert log =~ "[info]"
-      assert log =~ "Failed to send Sentry event."
-      assert log =~ "Received 400 from Sentry server: Rate limiting."
+      assert log =~ "Sentry failed to report event"
+      assert log =~ "400"
     end
 
     test "returns an error if Sentry server responds with error status", %{bypass: bypass} do


### PR DESCRIPTION
-When `Sentry.ClientError` was created, it was not passed updated in the `maybe_log_send_result/2` function
-This was originally found from debugging issue #788 