### PR TITLE
Fix our custom test task

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -64,7 +64,7 @@ defmodule Sentry.Mixfile do
         authors: ["Mitchell Henke", "Jason Stiebs", "Andrea Leopardi"]
       ],
       xref: [exclude: [:hackney, :hackney_pool, Plug.Conn, :telemetry]],
-      aliases: [aliases()]
+      aliases: aliases()
     ]
   end
 


### PR DESCRIPTION
So, we have this silly mistake that I just discovered, it causes this:

```
➜  sentry-elixir (solnic/fix-custom-test-task) mix help                                                                                                                                                         ✱
** (FunctionClauseError) no function clause matching in anonymous fn/1 in Mix.Tasks.Help.load_aliases/0    
    
    The following arguments were given to anonymous fn/1 in Mix.Tasks.Help.load_aliases/0:
    
        # 1
        [test: ["sentry.package_source_code", "test"]]
    
    (mix 1.17.2) lib/mix/tasks/help.ex:135: anonymous fn/1 in Mix.Tasks.Help.load_aliases/0
    (elixir 1.17.2) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
    (elixir 1.17.2) lib/map.ex:262: Map.new_from_enum/2
    (mix 1.17.2) lib/mix/tasks/help.ex:49: Mix.Tasks.Help.run/1
    (mix 1.17.2) lib/mix/task.ex:495: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.17.2) lib/mix/cli.ex:96: Mix.CLI.run_task/2
    /usr/local/bin/mix:2: (file)
```

...however, running `mix test` just works, but it doesn't run the alias, because defining the alias is most likely crashing silently.

I reckon it's something worth fixing in Mix itself.