### PR TITLE
Add option for generating custom cron monitor slugs

### DIFF
--- a/lib/sentry/application.ex
+++ b/lib/sentry/application.ex
@@ -59,7 +59,7 @@ defmodule Sentry.Application do
 
   defp start_integrations(config) do
     if config[:oban][:cron][:enabled] do
-      Sentry.Integrations.Oban.Cron.attach_telemetry_handler()
+      Sentry.Integrations.Oban.Cron.attach_telemetry_handler(config[:oban][:cron])
     end
 
     if config[:oban][:capture_errors] do

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -60,10 +60,11 @@ defmodule Sentry.Config do
               """
             ],
             monitor_name_generator: [
-              type: {:fun, 1},
+              type: :mfa,
               doc: """
-              A function that generates a monitor name based on the Oban.Job struct. This can be used
-              to create monitors specific to a Job's argument. *Available since v10.7.1*.
+              A {module, function, arguments} tuple that generates a monitor name based on the Oban.Job struct.
+              This function should only accept a single argument, the Oban.Job struct, and return a string.
+              This can be used to create monitors specific to a Job's argument. *Available since v10.7.1*.
               """
             ]
           ]

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -58,6 +58,13 @@ defmodule Sentry.Config do
               Whether to enable the Oban integration. When enabled, the Sentry SDK will
               capture check-ins for Oban jobs. *Available since v10.2.0*.
               """
+            ],
+            monitor_name_generator: [
+              type: {:fun, 1},
+              doc: """
+              A function that generates a monitor name based on the Oban.Job struct. This can be used
+              create monitors that are specific to a Job's argument. *Available since v10.x.x*.
+              """
             ]
           ]
         ]

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -63,7 +63,7 @@ defmodule Sentry.Config do
               type: {:fun, 1},
               doc: """
               A function that generates a monitor name based on the Oban.Job struct. This can be used
-              create monitors that are specific to a Job's argument. *Available since v10.x.x*.
+              to create monitors specific to a Job's argument. *Available since v10.7.1*.
               """
             ]
           ]

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -59,12 +59,13 @@ defmodule Sentry.Config do
               capture check-ins for Oban jobs. *Available since v10.2.0*.
               """
             ],
-            monitor_name_generator: [
-              type: :mfa,
+            monitor_slug_generator: [
+              type: {:tuple, [:atom, :atom]},
+              type_doc: "`{module(), atom()}`",
               doc: """
-              A {module, function, arguments} tuple that generates a monitor name based on the Oban.Job struct.
-              This function should only accept a single argument, the Oban.Job struct, and return a string.
-              This can be used to create monitors specific to a Job's argument. *Available since v10.7.1*.
+              A `{module, function}` tuple that generates a monitor name based on the `Oban.Job` struct.
+              The function is called with the `Oban.Job` as its arguments and must return a string.
+              This can be used to customize monitor slugs. *Available since v10.8.0*.
               """
             ]
           ]

--- a/lib/sentry/integrations/oban/cron.ex
+++ b/lib/sentry/integrations/oban/cron.ex
@@ -72,16 +72,12 @@ defmodule Sentry.Integrations.Oban.Cron do
     monitor_config_opts = Sentry.Config.integrations()[:monitor_config_defaults]
 
     monitor_slug =
-      case config[:monitor_name_generator] do
+      case config[:monitor_slug_generator] do
         nil ->
           slugify(job.worker)
 
-        {mod, fun, args} when is_atom(mod) and is_atom(fun) and is_list(args) ->
-          if function_exported?(mod, fun, Enum.count(args) + 1) do
-            apply(mod, fun, [job | args]) |> slugify()
-          else
-            slugify(job.worker)
-          end
+        {mod, fun} when is_atom(mod) and is_atom(fun) ->
+          mod |> apply(fun, [job]) |> slugify()
       end
 
     case Keyword.merge(monitor_config_opts, schedule_opts(job)) do

--- a/test/sentry/integrations/oban/cron_test.exs
+++ b/test/sentry/integrations/oban/cron_test.exs
@@ -5,12 +5,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
   import Sentry.TestHelpers
 
   setup context do
-    opts =
-      if context[:custom_monitor_name_generator] do
-        [monitor_name_generator: {__MODULE__, :custom_name_generator, []}]
-      else
-        []
-      end
+    opts = context[:attach_opts] || []
 
     Sentry.Integrations.Oban.Cron.attach_telemetry_handler(opts)
     on_exit(fn -> :telemetry.detach(Sentry.Integrations.Oban.Cron) end)
@@ -248,7 +243,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
     assert_receive {^ref, :done}, 1000
   end
 
-  @tag :custom_monitor_name_generator
+  @tag attach_opts: [monitor_slug_generator: {__MODULE__, :custom_name_generator}]
   test "monitor_slug is not affected if the custom monitor_name_generator does not target the worker",
        %{bypass: bypass} do
     test_pid = self()
@@ -274,7 +269,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
     assert_receive {^ref, :done}, 1000
   end
 
-  @tag :custom_monitor_name_generator
+  @tag attach_opts: [monitor_slug_generator: {__MODULE__, :custom_name_generator}]
   test "monitor_slug is set based on the custom monitor_name_generator if it targets the worker",
        %{bypass: bypass} do
     client_name = "my-client"

--- a/test/sentry/integrations/oban/cron_test.exs
+++ b/test/sentry/integrations/oban/cron_test.exs
@@ -269,7 +269,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
 
       Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
         {:ok, body, conn} = Plug.Conn.read_body(conn)
-        assert [{headers, check_in_body}] = decode_envelope!(body)
+        assert [{_headers, check_in_body}] = decode_envelope!(body)
         assert check_in_body["monitor_slug"] == "sentry-my-worker"
         send(test_pid, {ref, :done})
 
@@ -296,7 +296,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
 
       Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
         {:ok, body, conn} = Plug.Conn.read_body(conn)
-        assert [{headers, check_in_body}] = decode_envelope!(body)
+        assert [{_headers, check_in_body}] = decode_envelope!(body)
         assert check_in_body["monitor_slug"] == "sentry-client-worker-my-client"
         send(test_pid, {ref, :done})
 

--- a/test/sentry/integrations/oban/cron_test.exs
+++ b/test/sentry/integrations/oban/cron_test.exs
@@ -4,157 +4,119 @@ defmodule Sentry.Integrations.Oban.CronTest do
 
   import Sentry.TestHelpers
 
-  describe "default configuration" do
-    setup do
-      Sentry.Integrations.Oban.Cron.attach_telemetry_handler()
-      on_exit(fn -> :telemetry.detach(Sentry.Integrations.Oban.Cron) end)
+  setup context do
+    opts =
+      if context[:custom_monitor_name_generator] do
+        [monitor_name_generator: {__MODULE__, :custom_name_generator, []}]
+      else
+        []
+      end
+
+    Sentry.Integrations.Oban.Cron.attach_telemetry_handler(opts)
+    on_exit(fn -> :telemetry.detach(Sentry.Integrations.Oban.Cron) end)
+  end
+
+  setup do
+    bypass = Bypass.open()
+
+    put_test_config(
+      dsn: "http://public:secret@localhost:#{bypass.port}/1",
+      dedup_events: false,
+      environment_name: "test"
+    )
+
+    %{bypass: bypass}
+  end
+
+  for event_type <- [:start, :stop, :exception] do
+    test "ignores #{event_type} events without a cron meta", %{bypass: bypass} do
+      Bypass.down(bypass)
+      :telemetry.execute([:oban, :job, unquote(event_type)], %{}, %{job: %Oban.Job{}})
     end
 
-    setup do
-      bypass = Bypass.open()
+    test "ignores #{event_type} events without a cron_expr meta", %{bypass: bypass} do
+      Bypass.down(bypass)
 
-      put_test_config(
-        dsn: "http://public:secret@localhost:#{bypass.port}/1",
-        dedup_events: false,
-        environment_name: "test"
-      )
-
-      %{bypass: bypass}
-    end
-
-    for event_type <- [:start, :stop, :exception] do
-      test "ignores #{event_type} events without a cron meta", %{bypass: bypass} do
-        Bypass.down(bypass)
-        :telemetry.execute([:oban, :job, unquote(event_type)], %{}, %{job: %Oban.Job{}})
-      end
-
-      test "ignores #{event_type} events without a cron_expr meta", %{bypass: bypass} do
-        Bypass.down(bypass)
-
-        :telemetry.execute([:oban, :job, unquote(event_type)], %{}, %{
-          job: %Oban.Job{meta: %{"cron" => true}}
-        })
-      end
-
-      test "ignores #{event_type} events with a cron expr of @reboot", %{bypass: bypass} do
-        Bypass.down(bypass)
-
-        :telemetry.execute([:oban, :job, unquote(event_type)], %{}, %{
-          job: %Oban.Job{meta: %{"cron" => true, "cron_expr" => "@reboot"}}
-        })
-      end
-
-      test "ignores #{event_type} events with a cron expr that is not a string", %{bypass: bypass} do
-        Bypass.down(bypass)
-
-        :telemetry.execute([:oban, :job, unquote(event_type)], %{}, %{
-          job: %Oban.Job{meta: %{"cron" => true, "cron_expr" => 123}}
-        })
-      end
-    end
-
-    test "captures start events with monitor config", %{bypass: bypass} do
-      test_pid = self()
-      ref = make_ref()
-
-      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-        assert [{headers, check_in_body}] = decode_envelope!(body)
-        id = CheckInIDMappings.lookup_or_insert_new(123)
-
-        assert headers["type"] == "check_in"
-
-        assert check_in_body["check_in_id"] == id
-        assert check_in_body["status"] == "in_progress"
-        assert check_in_body["monitor_slug"] == "sentry-my-worker"
-        assert check_in_body["duration"] == nil
-        assert check_in_body["environment"] == "test"
-
-        assert check_in_body["monitor_config"] == %{
-                 "schedule" => %{
-                   "type" => "interval",
-                   "value" => 1,
-                   "unit" => "day"
-                 }
-               }
-
-        send(test_pid, {ref, :done})
-
-        Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-      end)
-
-      :telemetry.execute([:oban, :job, :start], %{}, %{
-        job: %Oban.Job{
-          worker: "Sentry.MyWorker",
-          id: 123,
-          meta: %{"cron" => true, "cron_expr" => "@daily"}
-        }
+      :telemetry.execute([:oban, :job, unquote(event_type)], %{}, %{
+        job: %Oban.Job{meta: %{"cron" => true}}
       })
-
-      assert_receive {^ref, :done}, 1000
     end
 
-    for {oban_state, expected_status} <- [
-          success: "ok",
-          failure: "error",
-          cancelled: "ok",
-          discard: "ok",
-          snoozed: "ok"
-        ],
-        {frequency, expected_unit} <- [
-          {"@hourly", "hour"},
-          {"@daily", "day"},
-          {"@weekly", "week"},
-          {"@monthly", "month"},
-          {"@yearly", "year"},
-          {"@annually", "year"}
-        ] do
-      test "captures stop events with monitor config and state of #{inspect(oban_state)} and frequency of #{frequency}",
-           %{bypass: bypass} do
-        test_pid = self()
-        ref = make_ref()
+    test "ignores #{event_type} events with a cron expr of @reboot", %{bypass: bypass} do
+      Bypass.down(bypass)
 
-        Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-          {:ok, body, conn} = Plug.Conn.read_body(conn)
-          assert [{headers, check_in_body}] = decode_envelope!(body)
-          id = CheckInIDMappings.lookup_or_insert_new(942)
-
-          assert headers["type"] == "check_in"
-          assert check_in_body["check_in_id"] == id
-          assert check_in_body["status"] == unquote(expected_status)
-          assert check_in_body["monitor_slug"] == "sentry-my-worker"
-          assert check_in_body["duration"] == 12.099
-          assert check_in_body["environment"] == "test"
-
-          assert check_in_body["monitor_config"] == %{
-                   "schedule" => %{
-                     "type" => "interval",
-                     "value" => 1,
-                     "unit" => unquote(expected_unit)
-                   }
-                 }
-
-          send(test_pid, {ref, :done})
-
-          Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-        end)
-
-        duration = System.convert_time_unit(12_099, :millisecond, :native)
-
-        :telemetry.execute([:oban, :job, :stop], %{duration: duration}, %{
-          state: unquote(oban_state),
-          job: %Oban.Job{
-            worker: "Sentry.MyWorker",
-            id: 942,
-            meta: %{"cron" => true, "cron_expr" => unquote(frequency)}
-          }
-        })
-
-        assert_receive {^ref, :done}, 1000
-      end
+      :telemetry.execute([:oban, :job, unquote(event_type)], %{}, %{
+        job: %Oban.Job{meta: %{"cron" => true, "cron_expr" => "@reboot"}}
+      })
     end
 
-    test "captures exception events with monitor config", %{bypass: bypass} do
+    test "ignores #{event_type} events with a cron expr that is not a string", %{bypass: bypass} do
+      Bypass.down(bypass)
+
+      :telemetry.execute([:oban, :job, unquote(event_type)], %{}, %{
+        job: %Oban.Job{meta: %{"cron" => true, "cron_expr" => 123}}
+      })
+    end
+  end
+
+  test "captures start events with monitor config", %{bypass: bypass} do
+    test_pid = self()
+    ref = make_ref()
+
+    Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      assert [{headers, check_in_body}] = decode_envelope!(body)
+      id = CheckInIDMappings.lookup_or_insert_new(123)
+
+      assert headers["type"] == "check_in"
+
+      assert check_in_body["check_in_id"] == id
+      assert check_in_body["status"] == "in_progress"
+      assert check_in_body["monitor_slug"] == "sentry-my-worker"
+      assert check_in_body["duration"] == nil
+      assert check_in_body["environment"] == "test"
+
+      assert check_in_body["monitor_config"] == %{
+               "schedule" => %{
+                 "type" => "interval",
+                 "value" => 1,
+                 "unit" => "day"
+               }
+             }
+
+      send(test_pid, {ref, :done})
+
+      Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
+    end)
+
+    :telemetry.execute([:oban, :job, :start], %{}, %{
+      job: %Oban.Job{
+        worker: "Sentry.MyWorker",
+        id: 123,
+        meta: %{"cron" => true, "cron_expr" => "@daily"}
+      }
+    })
+
+    assert_receive {^ref, :done}, 1000
+  end
+
+  for {oban_state, expected_status} <- [
+        success: "ok",
+        failure: "error",
+        cancelled: "ok",
+        discard: "ok",
+        snoozed: "ok"
+      ],
+      {frequency, expected_unit} <- [
+        {"@hourly", "hour"},
+        {"@daily", "day"},
+        {"@weekly", "week"},
+        {"@monthly", "month"},
+        {"@yearly", "year"},
+        {"@annually", "year"}
+      ] do
+    test "captures stop events with monitor config and state of #{inspect(oban_state)} and frequency of #{frequency}",
+         %{bypass: bypass} do
       test_pid = self()
       ref = make_ref()
 
@@ -164,17 +126,17 @@ defmodule Sentry.Integrations.Oban.CronTest do
         id = CheckInIDMappings.lookup_or_insert_new(942)
 
         assert headers["type"] == "check_in"
-
         assert check_in_body["check_in_id"] == id
-        assert check_in_body["status"] == "error"
+        assert check_in_body["status"] == unquote(expected_status)
         assert check_in_body["monitor_slug"] == "sentry-my-worker"
         assert check_in_body["duration"] == 12.099
         assert check_in_body["environment"] == "test"
 
         assert check_in_body["monitor_config"] == %{
                  "schedule" => %{
-                   "type" => "crontab",
-                   "value" => "* 1 1 1 1"
+                   "type" => "interval",
+                   "value" => 1,
+                   "unit" => unquote(expected_unit)
                  }
                }
 
@@ -185,57 +147,12 @@ defmodule Sentry.Integrations.Oban.CronTest do
 
       duration = System.convert_time_unit(12_099, :millisecond, :native)
 
-      :telemetry.execute([:oban, :job, :exception], %{duration: duration}, %{
-        state: :success,
+      :telemetry.execute([:oban, :job, :stop], %{duration: duration}, %{
+        state: unquote(oban_state),
         job: %Oban.Job{
           worker: "Sentry.MyWorker",
           id: 942,
-          meta: %{"cron" => true, "cron_expr" => "* 1 1 1 1"}
-        }
-      })
-
-      assert_receive {^ref, :done}, 1000
-    end
-
-    test "uses default monitor configuration in Sentry's config if present", %{bypass: bypass} do
-      put_test_config(
-        integrations: [
-          monitor_config_defaults: [
-            checkin_margin: 10,
-            max_runtime: 42,
-            failure_issue_threshold: 84
-          ]
-        ]
-      )
-
-      test_pid = self()
-      ref = make_ref()
-
-      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-        assert [{_headers, check_in_body}] = decode_envelope!(body)
-
-        assert check_in_body["monitor_config"] == %{
-                 "checkin_margin" => 10,
-                 "failure_issue_threshold" => 84,
-                 "max_runtime" => 42,
-                 "schedule" => %{
-                   "type" => "crontab",
-                   "value" => "* 1 1 1 1"
-                 }
-               }
-
-        send(test_pid, {ref, :done})
-
-        Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-      end)
-
-      :telemetry.execute([:oban, :job, :exception], %{duration: 0}, %{
-        state: :success,
-        job: %Oban.Job{
-          worker: "Sentry.MyWorker",
-          id: 942,
-          meta: %{"cron" => true, "cron_expr" => "* 1 1 1 1"}
+          meta: %{"cron" => true, "cron_expr" => unquote(frequency)}
         }
       })
 
@@ -243,80 +160,146 @@ defmodule Sentry.Integrations.Oban.CronTest do
     end
   end
 
-  describe "custom monitor_name_generator" do
-    setup do
-      Sentry.Integrations.Oban.Cron.attach_telemetry_handler(
-        monitor_name_generator: &custom_name_generator/1
-      )
+  test "captures exception events with monitor config", %{bypass: bypass} do
+    test_pid = self()
+    ref = make_ref()
 
-      on_exit(fn -> :telemetry.detach(Sentry.Integrations.Oban.Cron) end)
-    end
+    Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      assert [{headers, check_in_body}] = decode_envelope!(body)
+      id = CheckInIDMappings.lookup_or_insert_new(942)
 
-    setup do
-      bypass = Bypass.open()
+      assert headers["type"] == "check_in"
 
-      put_test_config(
-        dsn: "http://public:secret@localhost:#{bypass.port}/1",
-        dedup_events: false,
-        environment_name: "test"
-      )
+      assert check_in_body["check_in_id"] == id
+      assert check_in_body["status"] == "error"
+      assert check_in_body["monitor_slug"] == "sentry-my-worker"
+      assert check_in_body["duration"] == 12.099
+      assert check_in_body["environment"] == "test"
 
-      %{bypass: bypass}
-    end
+      assert check_in_body["monitor_config"] == %{
+               "schedule" => %{
+                 "type" => "crontab",
+                 "value" => "* 1 1 1 1"
+               }
+             }
 
-    @tag :custom_monitor_name_generator
-    test "monitor_slug is not affected if the custom monitor_name_generator does not target the worker",
-         %{bypass: bypass} do
-      test_pid = self()
-      ref = make_ref()
+      send(test_pid, {ref, :done})
 
-      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-        assert [{_headers, check_in_body}] = decode_envelope!(body)
-        assert check_in_body["monitor_slug"] == "sentry-my-worker"
-        send(test_pid, {ref, :done})
+      Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
+    end)
 
-        Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-      end)
+    duration = System.convert_time_unit(12_099, :millisecond, :native)
 
-      :telemetry.execute([:oban, :job, :start], %{}, %{
-        job: %Oban.Job{
-          worker: "Sentry.MyWorker",
-          id: 123,
-          meta: %{"cron" => true, "cron_expr" => "@daily"}
-        }
-      })
+    :telemetry.execute([:oban, :job, :exception], %{duration: duration}, %{
+      state: :success,
+      job: %Oban.Job{
+        worker: "Sentry.MyWorker",
+        id: 942,
+        meta: %{"cron" => true, "cron_expr" => "* 1 1 1 1"}
+      }
+    })
 
-      assert_receive {^ref, :done}, 1000
-    end
+    assert_receive {^ref, :done}, 1000
+  end
 
-    @tag :custom_monitor_name_generator
-    test "monitor_slug is set based on the custom monitor_name_generator if it targets the worker",
-         %{bypass: bypass} do
-      client_name = "my-client"
-      test_pid = self()
-      ref = make_ref()
+  test "uses default monitor configuration in Sentry's config if present", %{bypass: bypass} do
+    put_test_config(
+      integrations: [
+        monitor_config_defaults: [
+          checkin_margin: 10,
+          max_runtime: 42,
+          failure_issue_threshold: 84
+        ]
+      ]
+    )
 
-      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-        assert [{_headers, check_in_body}] = decode_envelope!(body)
-        assert check_in_body["monitor_slug"] == "sentry-client-worker-my-client"
-        send(test_pid, {ref, :done})
+    test_pid = self()
+    ref = make_ref()
 
-        Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-      end)
+    Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      assert [{_headers, check_in_body}] = decode_envelope!(body)
 
-      :telemetry.execute([:oban, :job, :start], %{}, %{
-        job: %Oban.Job{
-          worker: "Sentry.ClientWorker",
-          id: 123,
-          args: %{"client" => client_name},
-          meta: %{"cron" => true, "cron_expr" => "@daily"}
-        }
-      })
+      assert check_in_body["monitor_config"] == %{
+               "checkin_margin" => 10,
+               "failure_issue_threshold" => 84,
+               "max_runtime" => 42,
+               "schedule" => %{
+                 "type" => "crontab",
+                 "value" => "* 1 1 1 1"
+               }
+             }
 
-      assert_receive {^ref, :done}, 1000
-    end
+      send(test_pid, {ref, :done})
+
+      Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
+    end)
+
+    :telemetry.execute([:oban, :job, :exception], %{duration: 0}, %{
+      state: :success,
+      job: %Oban.Job{
+        worker: "Sentry.MyWorker",
+        id: 942,
+        meta: %{"cron" => true, "cron_expr" => "* 1 1 1 1"}
+      }
+    })
+
+    assert_receive {^ref, :done}, 1000
+  end
+
+  @tag :custom_monitor_name_generator
+  test "monitor_slug is not affected if the custom monitor_name_generator does not target the worker",
+       %{bypass: bypass} do
+    test_pid = self()
+    ref = make_ref()
+
+    Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      assert [{_headers, check_in_body}] = decode_envelope!(body)
+      assert check_in_body["monitor_slug"] == "sentry-my-worker"
+      send(test_pid, {ref, :done})
+
+      Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
+    end)
+
+    :telemetry.execute([:oban, :job, :start], %{}, %{
+      job: %Oban.Job{
+        worker: "Sentry.MyWorker",
+        id: 123,
+        meta: %{"cron" => true, "cron_expr" => "@daily"}
+      }
+    })
+
+    assert_receive {^ref, :done}, 1000
+  end
+
+  @tag :custom_monitor_name_generator
+  test "monitor_slug is set based on the custom monitor_name_generator if it targets the worker",
+       %{bypass: bypass} do
+    client_name = "my-client"
+    test_pid = self()
+    ref = make_ref()
+
+    Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      assert [{_headers, check_in_body}] = decode_envelope!(body)
+      assert check_in_body["monitor_slug"] == "sentry-client-worker-my-client"
+      send(test_pid, {ref, :done})
+
+      Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
+    end)
+
+    :telemetry.execute([:oban, :job, :start], %{}, %{
+      job: %Oban.Job{
+        worker: "Sentry.ClientWorker",
+        id: 123,
+        args: %{"client" => client_name},
+        meta: %{"cron" => true, "cron_expr" => "@daily"}
+      }
+    })
+
+    assert_receive {^ref, :done}, 1000
   end
 
   def custom_name_generator(%Oban.Job{worker: "Sentry.ClientWorker", args: %{"client" => client}}) do

--- a/test/sentry/integrations/oban/cron_test.exs
+++ b/test/sentry/integrations/oban/cron_test.exs
@@ -4,111 +4,156 @@ defmodule Sentry.Integrations.Oban.CronTest do
 
   import Sentry.TestHelpers
 
-  setup_all do
-    Sentry.Integrations.Oban.Cron.attach_telemetry_handler()
-  end
-
-  setup do
-    bypass = Bypass.open()
-
-    put_test_config(
-      dsn: "http://public:secret@localhost:#{bypass.port}/1",
-      dedup_events: false,
-      environment_name: "test"
-    )
-
-    %{bypass: bypass}
-  end
-
-  for event_type <- [:start, :stop, :exception] do
-    test "ignores #{event_type} events without a cron meta", %{bypass: bypass} do
-      Bypass.down(bypass)
-      :telemetry.execute([:oban, :job, unquote(event_type)], %{}, %{job: %Oban.Job{}})
+  describe "default configuration" do
+    setup do
+      Sentry.Integrations.Oban.Cron.attach_telemetry_handler()
     end
 
-    test "ignores #{event_type} events without a cron_expr meta", %{bypass: bypass} do
-      Bypass.down(bypass)
+    setup do
+      bypass = Bypass.open()
 
-      :telemetry.execute([:oban, :job, unquote(event_type)], %{}, %{
-        job: %Oban.Job{meta: %{"cron" => true}}
-      })
+      put_test_config(
+        dsn: "http://public:secret@localhost:#{bypass.port}/1",
+        dedup_events: false,
+        environment_name: "test"
+      )
+
+      %{bypass: bypass}
     end
 
-    test "ignores #{event_type} events with a cron expr of @reboot", %{bypass: bypass} do
-      Bypass.down(bypass)
+    for event_type <- [:start, :stop, :exception] do
+      test "ignores #{event_type} events without a cron meta", %{bypass: bypass} do
+        Bypass.down(bypass)
+        :telemetry.execute([:oban, :job, unquote(event_type)], %{}, %{job: %Oban.Job{}})
+      end
 
-      :telemetry.execute([:oban, :job, unquote(event_type)], %{}, %{
-        job: %Oban.Job{meta: %{"cron" => true, "cron_expr" => "@reboot"}}
-      })
+      test "ignores #{event_type} events without a cron_expr meta", %{bypass: bypass} do
+        Bypass.down(bypass)
+
+        :telemetry.execute([:oban, :job, unquote(event_type)], %{}, %{
+          job: %Oban.Job{meta: %{"cron" => true}}
+        })
+      end
+
+      test "ignores #{event_type} events with a cron expr of @reboot", %{bypass: bypass} do
+        Bypass.down(bypass)
+
+        :telemetry.execute([:oban, :job, unquote(event_type)], %{}, %{
+          job: %Oban.Job{meta: %{"cron" => true, "cron_expr" => "@reboot"}}
+        })
+      end
+
+      test "ignores #{event_type} events with a cron expr that is not a string", %{bypass: bypass} do
+        Bypass.down(bypass)
+
+        :telemetry.execute([:oban, :job, unquote(event_type)], %{}, %{
+          job: %Oban.Job{meta: %{"cron" => true, "cron_expr" => 123}}
+        })
+      end
     end
 
-    test "ignores #{event_type} events with a cron expr that is not a string", %{bypass: bypass} do
-      Bypass.down(bypass)
+    test "captures start events with monitor config", %{bypass: bypass} do
+      test_pid = self()
+      ref = make_ref()
 
-      :telemetry.execute([:oban, :job, unquote(event_type)], %{}, %{
-        job: %Oban.Job{meta: %{"cron" => true, "cron_expr" => 123}}
-      })
-    end
-  end
+      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert [{headers, check_in_body}] = decode_envelope!(body)
+        id = CheckInIDMappings.lookup_or_insert_new(123)
 
-  test "captures start events with monitor config", %{bypass: bypass} do
-    test_pid = self()
-    ref = make_ref()
+        assert headers["type"] == "check_in"
 
-    Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-      {:ok, body, conn} = Plug.Conn.read_body(conn)
-      assert [{headers, check_in_body}] = decode_envelope!(body)
-      id = CheckInIDMappings.lookup_or_insert_new(123)
+        assert check_in_body["check_in_id"] == id
+        assert check_in_body["status"] == "in_progress"
+        assert check_in_body["monitor_slug"] == "sentry-my-worker"
+        assert check_in_body["duration"] == nil
+        assert check_in_body["environment"] == "test"
 
-      assert headers["type"] == "check_in"
-
-      assert check_in_body["check_in_id"] == id
-      assert check_in_body["status"] == "in_progress"
-      assert check_in_body["monitor_slug"] == "sentry-my-worker"
-      assert check_in_body["duration"] == nil
-      assert check_in_body["environment"] == "test"
-
-      assert check_in_body["monitor_config"] == %{
-               "schedule" => %{
-                 "type" => "interval",
-                 "value" => 1,
-                 "unit" => "day"
+        assert check_in_body["monitor_config"] == %{
+                 "schedule" => %{
+                   "type" => "interval",
+                   "value" => 1,
+                   "unit" => "day"
+                 }
                }
-             }
 
-      send(test_pid, {ref, :done})
+        send(test_pid, {ref, :done})
 
-      Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-    end)
+        Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
+      end)
 
-    :telemetry.execute([:oban, :job, :start], %{}, %{
-      job: %Oban.Job{
-        worker: "Sentry.MyWorker",
-        id: 123,
-        meta: %{"cron" => true, "cron_expr" => "@daily"}
-      }
-    })
+      :telemetry.execute([:oban, :job, :start], %{}, %{
+        job: %Oban.Job{
+          worker: "Sentry.MyWorker",
+          id: 123,
+          meta: %{"cron" => true, "cron_expr" => "@daily"}
+        }
+      })
 
-    assert_receive {^ref, :done}, 1000
-  end
+      assert_receive {^ref, :done}, 1000
+    end
 
-  for {oban_state, expected_status} <- [
-        success: "ok",
-        failure: "error",
-        cancelled: "ok",
-        discard: "ok",
-        snoozed: "ok"
-      ],
-      {frequency, expected_unit} <- [
-        {"@hourly", "hour"},
-        {"@daily", "day"},
-        {"@weekly", "week"},
-        {"@monthly", "month"},
-        {"@yearly", "year"},
-        {"@annually", "year"}
-      ] do
-    test "captures stop events with monitor config and state of #{inspect(oban_state)} and frequency of #{frequency}",
-         %{bypass: bypass} do
+    for {oban_state, expected_status} <- [
+          success: "ok",
+          failure: "error",
+          cancelled: "ok",
+          discard: "ok",
+          snoozed: "ok"
+        ],
+        {frequency, expected_unit} <- [
+          {"@hourly", "hour"},
+          {"@daily", "day"},
+          {"@weekly", "week"},
+          {"@monthly", "month"},
+          {"@yearly", "year"},
+          {"@annually", "year"}
+        ] do
+      test "captures stop events with monitor config and state of #{inspect(oban_state)} and frequency of #{frequency}",
+           %{bypass: bypass} do
+        test_pid = self()
+        ref = make_ref()
+
+        Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
+          {:ok, body, conn} = Plug.Conn.read_body(conn)
+          assert [{headers, check_in_body}] = decode_envelope!(body)
+          id = CheckInIDMappings.lookup_or_insert_new(942)
+
+          assert headers["type"] == "check_in"
+          assert check_in_body["check_in_id"] == id
+          assert check_in_body["status"] == unquote(expected_status)
+          assert check_in_body["monitor_slug"] == "sentry-my-worker"
+          assert check_in_body["duration"] == 12.099
+          assert check_in_body["environment"] == "test"
+
+          assert check_in_body["monitor_config"] == %{
+                   "schedule" => %{
+                     "type" => "interval",
+                     "value" => 1,
+                     "unit" => unquote(expected_unit)
+                   }
+                 }
+
+          send(test_pid, {ref, :done})
+
+          Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
+        end)
+
+        duration = System.convert_time_unit(12_099, :millisecond, :native)
+
+        :telemetry.execute([:oban, :job, :stop], %{duration: duration}, %{
+          state: unquote(oban_state),
+          job: %Oban.Job{
+            worker: "Sentry.MyWorker",
+            id: 942,
+            meta: %{"cron" => true, "cron_expr" => unquote(frequency)}
+          }
+        })
+
+        assert_receive {^ref, :done}, 1000
+      end
+    end
+
+    test "captures exception events with monitor config", %{bypass: bypass} do
       test_pid = self()
       ref = make_ref()
 
@@ -118,17 +163,17 @@ defmodule Sentry.Integrations.Oban.CronTest do
         id = CheckInIDMappings.lookup_or_insert_new(942)
 
         assert headers["type"] == "check_in"
+
         assert check_in_body["check_in_id"] == id
-        assert check_in_body["status"] == unquote(expected_status)
+        assert check_in_body["status"] == "error"
         assert check_in_body["monitor_slug"] == "sentry-my-worker"
         assert check_in_body["duration"] == 12.099
         assert check_in_body["environment"] == "test"
 
         assert check_in_body["monitor_config"] == %{
                  "schedule" => %{
-                   "type" => "interval",
-                   "value" => 1,
-                   "unit" => unquote(expected_unit)
+                   "type" => "crontab",
+                   "value" => "* 1 1 1 1"
                  }
                }
 
@@ -139,12 +184,57 @@ defmodule Sentry.Integrations.Oban.CronTest do
 
       duration = System.convert_time_unit(12_099, :millisecond, :native)
 
-      :telemetry.execute([:oban, :job, :stop], %{duration: duration}, %{
-        state: unquote(oban_state),
+      :telemetry.execute([:oban, :job, :exception], %{duration: duration}, %{
+        state: :success,
         job: %Oban.Job{
           worker: "Sentry.MyWorker",
           id: 942,
-          meta: %{"cron" => true, "cron_expr" => unquote(frequency)}
+          meta: %{"cron" => true, "cron_expr" => "* 1 1 1 1"}
+        }
+      })
+
+      assert_receive {^ref, :done}, 1000
+    end
+
+    test "uses default monitor configuration in Sentry's config if present", %{bypass: bypass} do
+      put_test_config(
+        integrations: [
+          monitor_config_defaults: [
+            checkin_margin: 10,
+            max_runtime: 42,
+            failure_issue_threshold: 84
+          ]
+        ]
+      )
+
+      test_pid = self()
+      ref = make_ref()
+
+      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert [{_headers, check_in_body}] = decode_envelope!(body)
+
+        assert check_in_body["monitor_config"] == %{
+                 "checkin_margin" => 10,
+                 "failure_issue_threshold" => 84,
+                 "max_runtime" => 42,
+                 "schedule" => %{
+                   "type" => "crontab",
+                   "value" => "* 1 1 1 1"
+                 }
+               }
+
+        send(test_pid, {ref, :done})
+
+        Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
+      end)
+
+      :telemetry.execute([:oban, :job, :exception], %{duration: 0}, %{
+        state: :success,
+        job: %Oban.Job{
+          worker: "Sentry.MyWorker",
+          id: 942,
+          meta: %{"cron" => true, "cron_expr" => "* 1 1 1 1"}
         }
       })
 
@@ -152,91 +242,83 @@ defmodule Sentry.Integrations.Oban.CronTest do
     end
   end
 
-  test "captures exception events with monitor config", %{bypass: bypass} do
-    test_pid = self()
-    ref = make_ref()
+  describe "custom monitor_name_generator" do
+    setup do
+      Sentry.Integrations.Oban.Cron.attach_telemetry_handler(
+        monitor_name_generator: &custom_name_generator/1
+      )
+    end
 
-    Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-      {:ok, body, conn} = Plug.Conn.read_body(conn)
-      assert [{headers, check_in_body}] = decode_envelope!(body)
-      id = CheckInIDMappings.lookup_or_insert_new(942)
+    setup do
+      bypass = Bypass.open()
 
-      assert headers["type"] == "check_in"
+      put_test_config(
+        dsn: "http://public:secret@localhost:#{bypass.port}/1",
+        dedup_events: false,
+        environment_name: "test"
+      )
 
-      assert check_in_body["check_in_id"] == id
-      assert check_in_body["status"] == "error"
-      assert check_in_body["monitor_slug"] == "sentry-my-worker"
-      assert check_in_body["duration"] == 12.099
-      assert check_in_body["environment"] == "test"
+      %{bypass: bypass}
+    end
 
-      assert check_in_body["monitor_config"] == %{
-               "schedule" => %{
-                 "type" => "crontab",
-                 "value" => "* 1 1 1 1"
-               }
-             }
+    @tag :custom_monitor_name_generator
+    test "monitor_slug is not affected if the custom monitor_name_generator does not target the worker",
+         %{bypass: bypass} do
+      test_pid = self()
+      ref = make_ref()
 
-      send(test_pid, {ref, :done})
+      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert [{headers, check_in_body}] = decode_envelope!(body)
+        assert check_in_body["monitor_slug"] == "sentry-my-worker"
+        send(test_pid, {ref, :done})
 
-      Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-    end)
+        Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
+      end)
 
-    duration = System.convert_time_unit(12_099, :millisecond, :native)
+      :telemetry.execute([:oban, :job, :start], %{}, %{
+        job: %Oban.Job{
+          worker: "Sentry.MyWorker",
+          id: 123,
+          meta: %{"cron" => true, "cron_expr" => "@daily"}
+        }
+      })
 
-    :telemetry.execute([:oban, :job, :exception], %{duration: duration}, %{
-      state: :success,
-      job: %Oban.Job{
-        worker: "Sentry.MyWorker",
-        id: 942,
-        meta: %{"cron" => true, "cron_expr" => "* 1 1 1 1"}
-      }
-    })
+      assert_receive {^ref, :done}, 1000
+    end
 
-    assert_receive {^ref, :done}, 1000
+    @tag :custom_monitor_name_generator
+    test "monitor_slug is set based on the custom monitor_name_generator if it targets the worker",
+         %{bypass: bypass} do
+      client_name = "my-client"
+      test_pid = self()
+      ref = make_ref()
+
+      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert [{headers, check_in_body}] = decode_envelope!(body)
+        assert check_in_body["monitor_slug"] == "sentry-client-worker-my-client"
+        send(test_pid, {ref, :done})
+
+        Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
+      end)
+
+      :telemetry.execute([:oban, :job, :start], %{}, %{
+        job: %Oban.Job{
+          worker: "Sentry.ClientWorker",
+          id: 123,
+          args: %{"client" => client_name},
+          meta: %{"cron" => true, "cron_expr" => "@daily"}
+        }
+      })
+
+      assert_receive {^ref, :done}, 1000
+    end
   end
 
-  test "uses default monitor configuration in Sentry's config if present", %{bypass: bypass} do
-    put_test_config(
-      integrations: [
-        monitor_config_defaults: [
-          checkin_margin: 10,
-          max_runtime: 42,
-          failure_issue_threshold: 84
-        ]
-      ]
-    )
-
-    test_pid = self()
-    ref = make_ref()
-
-    Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-      {:ok, body, conn} = Plug.Conn.read_body(conn)
-      assert [{_headers, check_in_body}] = decode_envelope!(body)
-
-      assert check_in_body["monitor_config"] == %{
-               "checkin_margin" => 10,
-               "failure_issue_threshold" => 84,
-               "max_runtime" => 42,
-               "schedule" => %{
-                 "type" => "crontab",
-                 "value" => "* 1 1 1 1"
-               }
-             }
-
-      send(test_pid, {ref, :done})
-
-      Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-    end)
-
-    :telemetry.execute([:oban, :job, :exception], %{duration: 0}, %{
-      state: :success,
-      job: %Oban.Job{
-        worker: "Sentry.MyWorker",
-        id: 942,
-        meta: %{"cron" => true, "cron_expr" => "* 1 1 1 1"}
-      }
-    })
-
-    assert_receive {^ref, :done}, 1000
+  def custom_name_generator(%Oban.Job{worker: "Sentry.ClientWorker", args: %{"client" => client}}) do
+    "Sentry.ClientWorker.#{client}"
   end
+
+  def custom_name_generator(%Oban.Job{worker: worker}), do: worker
 end

--- a/test/sentry/integrations/oban/cron_test.exs
+++ b/test/sentry/integrations/oban/cron_test.exs
@@ -7,6 +7,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
   describe "default configuration" do
     setup do
       Sentry.Integrations.Oban.Cron.attach_telemetry_handler()
+      on_exit(fn -> :telemetry.detach(Sentry.Integrations.Oban.Cron) end)
     end
 
     setup do
@@ -247,6 +248,8 @@ defmodule Sentry.Integrations.Oban.CronTest do
       Sentry.Integrations.Oban.Cron.attach_telemetry_handler(
         monitor_name_generator: &custom_name_generator/1
       )
+
+      on_exit(fn -> :telemetry.detach(Sentry.Integrations.Oban.Cron) end)
     end
 
     setup do


### PR DESCRIPTION
We've recently adopted the Oban integration with Sentry but have noticed that some of our jobs do not play nice with the assumptions in the library.  We have a pattern of reuse of cron workers where there's an argument that is the key differentiator.  As one example, this might be a `client_id`. 

We would like to be able to monitor these cron jobs separately.

I would be happy to add/improve more testing and/or documentation.  I really just wanted to get this opened as a starting point for discussion.

🙏 Thank you for this consideration.