### PR TITLE
Remove --halt-exit-status option when running dialyzer on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,4 +102,4 @@ jobs:
 
     - name: Run dialyzer
       if: matrix.dialyzer
-      run: mix dialyzer --no-check --halt-exit-status
+      run: mix dialyzer --no-check


### PR DESCRIPTION
This fixes the following warning:

  halt_exit_status is no longer a valid CLI argument.