### PR TITLE
Support non-exception error values from Oban jobs

### DIFF
--- a/lib/sentry/integrations/oban/error_reporter.ex
+++ b/lib/sentry/integrations/oban/error_reporter.ex
@@ -33,18 +33,22 @@ defmodule Sentry.Integrations.Oban.ErrorReporter do
       end
 
     _ =
-      Sentry.capture_exception(exception,
-        stacktrace: stacktrace,
-        tags: %{oban_worker: job.worker, oban_queue: job.queue, oban_state: job.state},
-        fingerprint: [
-          inspect(exception.__struct__),
-          inspect(job.worker),
-          Exception.message(exception)
-        ],
-        extra:
-          Map.take(job, [:args, :attempt, :id, :max_attempts, :meta, :queue, :tags, :worker]),
-        integration_meta: %{oban: %{job: job}}
-      )
+      if is_struct(exception) do
+        Sentry.capture_exception(exception,
+          stacktrace: stacktrace,
+          tags: %{oban_worker: job.worker, oban_queue: job.queue, oban_state: job.state},
+          fingerprint: [
+            inspect(exception.__struct__),
+            inspect(job.worker),
+            Exception.message(exception)
+          ],
+          extra:
+            Map.take(job, [:args, :attempt, :id, :max_attempts, :meta, :queue, :tags, :worker]),
+          integration_meta: %{oban: %{job: job}}
+        )
+      else
+        Sentry.capture_message("Error with %s", interpolation_parameters: [exception])
+      end
 
     :ok
   end

--- a/lib/sentry/integrations/oban/error_reporter.ex
+++ b/lib/sentry/integrations/oban/error_reporter.ex
@@ -49,17 +49,18 @@ defmodule Sentry.Integrations.Oban.ErrorReporter do
         integration_meta: %{oban: %{job: job}}
       ]
 
-    if is_exception(reason) do
-      Sentry.capture_exception(
-        reason,
-        opts
-      )
-    else
-      Sentry.capture_message(
-        "Oban job #{job.worker} errored out: %s",
-        opts ++ [interpolation_parameters: [inspect(reason)]]
-      )
-    end
+    _ =
+      if is_exception(reason) do
+        Sentry.capture_exception(
+          reason,
+          opts
+        )
+      else
+        Sentry.capture_message(
+          "Oban job #{job.worker} errored out: %s",
+          opts ++ [interpolation_parameters: [inspect(reason)]]
+        )
+      end
 
     :ok
   end

--- a/lib/sentry/integrations/oban/error_reporter.ex
+++ b/lib/sentry/integrations/oban/error_reporter.ex
@@ -33,7 +33,7 @@ defmodule Sentry.Integrations.Oban.ErrorReporter do
       end
 
     _ =
-      if is_struct(exception) do
+      if is_exception(exception) do
         Sentry.capture_exception(exception,
           stacktrace: stacktrace,
           tags: %{oban_worker: job.worker, oban_queue: job.queue, oban_state: job.state},

--- a/test/sentry/integrations/oban/error_reporter_test.exs
+++ b/test/sentry/integrations/oban/error_reporter_test.exs
@@ -50,5 +50,35 @@ defmodule Sentry.Integrations.Oban.ErrorReporterTest do
       assert event.tags.oban_worker == "Sentry.Integrations.Oban.ErrorReporterTest.MyWorker"
       assert %{job: %Oban.Job{}} = event.integration_meta.oban
     end
+
+    test "reports non-exception errors to Sentry" do
+      job =
+        %{"id" => "123", "entity" => "user", "type" => "delete"}
+        |> MyWorker.new()
+        |> Ecto.Changeset.apply_action!(:validate)
+        |> Map.replace!(:unsaved_error, %{
+          reason: :undef,
+          kind: :error,
+          stacktrace: []
+        })
+
+      Sentry.Test.start_collecting()
+
+      assert :ok =
+               ErrorReporter.handle_event(
+                 [:oban, :job, :exception],
+                 %{},
+                 %{job: job},
+                 :no_config
+               )
+
+      assert [event] = Sentry.Test.pop_sentry_reports()
+
+      assert event.message == %Sentry.Interfaces.Message{
+               message: "Error with %s",
+               params: [:undef],
+               formatted: "Error with undef"
+             }
+    end
   end
 end


### PR DESCRIPTION
-added `capture_message` to `handle_event` in `Sentry.Integrations.Oban.ErrorReporter` to account for non-exception args that are passed

-closes #805 