### PR TITLE
Update caching strategy in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         include:
           # Newest supported Elixir/Erlang pair.
           - elixir: '1.17'
-            otp: '27.0'
+            otp: '27.1'
             lint: true
             dialyzer: true
 
@@ -45,48 +45,47 @@ jobs:
         elixir-version: ${{ matrix.elixir }}
         otp-version: ${{ matrix.otp }}
 
+    - name: Cache downloaded dependencies
+      uses: actions/cache@v4
+      id: mix-downloaded-deps-cache
+      with:
+        path: |
+          deps
+          test_integrations/phoenix_app/deps
+        key: |
+          ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-deps-${{ hashFiles('**/mix.lock') }}
+
+    - name: Download Mix dependencies
+      if: steps.mix-downloaded-deps-cache.outputs.cache-hit != 'true'
+      run: |
+        mix deps.get --check-locked
+        cd test_integrations/phoenix_app
+        mix deps.get --check-locked
+
     # We need to manually restore and then save, so that we can save the "_build" directory
     # *without* the Elixir compiled code in it.
-    - name: Restore Mix dependencies cache
-      uses: actions/cache/restore@v4
-      id: mix-deps-cache
+    - name: Cache compiled Elixir code
+      uses: actions/cache@v4
+      id: mix-cache
       with:
         path: |
           _build
-          deps
           test_integrations/phoenix_app/_build
-          test_integrations/phoenix_app/deps
         key: |
-          ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+          ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles('**/mix.lock') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-
 
-    - name: Install and compile Mix dependencies
-      if: steps.mix-deps-cache.outputs.cache-hit != 'true'
+    - name: Compile Elixir code (with --warnings-as-errors)
+      if: matrix.lint
       run: |
-        mix do deps.get --check-locked, deps.compile
+        mix compile --warnings-as-errors
         cd test_integrations/phoenix_app
-        mix do deps.get --check-locked, deps.compile
-
-    - name: Save Mix dependencies cache
-      uses: actions/cache/save@v4
-      if: steps.mix-deps-cache.outputs.cache-hit != 'true'
-      with:
-        path: |
-          _build
-          deps
-          test_integrations/phoenix_app/_build
-          test_integrations/phoenix_app/deps
-        key: |
-          ${{ steps.mix-deps-cache.outputs.cache-primary-key }}
+        mix compile --warnings-as-errors
 
     - name: Check formatting
       if: matrix.lint
       run: mix format --check-formatted
-
-    - name: Check compiler warnings
-      if: matrix.lint
-      run: mix compile --warnings-as-errors
 
     - name: Run tests
       run: mix test
@@ -94,14 +93,14 @@ jobs:
     - name: Run integration tests
       run: mix test.integrations
 
-    - name: Retrieve PLT Cache
+    - name: Cache Dialyzer PLT
       uses: actions/cache@v4
       if: matrix.dialyzer
       id: plt-cache
       with:
         path: plts
         key: |
-          ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-plts-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+          ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-plts-${{ hashFiles(format('**/mix.lock')) }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-plts-
 


### PR DESCRIPTION
Avoids full recompiles of Sentry itself and the test Phoenix app.