### PR TITLE
Only use `--check-locked` if linting in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,11 @@ jobs:
       run: |
         mix deps.get --check-locked
         cd test_integrations/phoenix_app
-        mix deps.get --check-locked
+        if [ ${{ matrix.lint }} == 'true' ]; then
+          mix deps.get --check-locked
+        else
+          mix deps.get
+        fi
 
     # We need to manually restore and then save, so that we can save the "_build" directory
     # *without* the Elixir compiled code in it.


### PR DESCRIPTION
Splitting this out of https://github.com/getsentry/sentry-elixir/pull/784 to keep concerns focused as much as possible.