### PR TITLE
Refactor span storage

### DIFF
--- a/lib/sentry/application.ex
+++ b/lib/sentry/application.ex
@@ -10,9 +10,6 @@ defmodule Sentry.Application do
     config = Config.validate!()
     :ok = Config.persist(config)
 
-    # Setup ETS tables for span storage
-    Sentry.Opentelemetry.SpanStorage.setup()
-
     http_client = Keyword.fetch!(config, :client)
 
     maybe_http_client_spec =
@@ -30,6 +27,7 @@ defmodule Sentry.Application do
         Sentry.Sources,
         Sentry.Dedupe,
         Sentry.ClientReport.Sender,
+        Sentry.Opentelemetry.SpanStorage,
         {Sentry.Integrations.CheckInIDMappings,
          [
            max_expected_check_in_time:

--- a/lib/sentry/opentelemetry/span_storage.ex
+++ b/lib/sentry/opentelemetry/span_storage.ex
@@ -76,6 +76,4 @@ defmodule Sentry.Opentelemetry.SpanStorage do
     :ets.delete(@table, parent_span_id)
     :ok
   end
-
-  # need to ad in sweep for any leftover spans. Should we initiate a sweep on_end or add a ttl or both?
 end

--- a/lib/sentry/opentelemetry/span_storage.ex
+++ b/lib/sentry/opentelemetry/span_storage.ex
@@ -45,13 +45,13 @@ defmodule Sentry.Opentelemetry.SpanStorage do
 
   def update_span(span_data) do
     if span_data.parent_span_id == nil do
-      case :ets.lookup(@table, {:root_span, span_data.parent_span_id}) do
+      case :ets.lookup(@table, {:root_span, span_data.span_id}) do
         [] ->
-          :ets.insert(@table, {{:root_span, span_data.parent_span_id}, span_data})
+          :ets.insert(@table, {{:root_span, span_data.span_id}, span_data})
 
         _ ->
-          :ets.delete(@table, {:root_span, span_data.parent_span_id})
-          :ets.insert(@table, {{:root_span, span_data.parent_span_id}, span_data})
+          :ets.delete(@table, {:root_span, span_data.span_id})
+          :ets.insert(@table, {{:root_span, span_data.span_id}, span_data})
       end
     else
       existing_spans = :ets.lookup(@table, span_data.parent_span_id)

--- a/test/sentry/opentelemetry/span_processor_test.exs
+++ b/test/sentry/opentelemetry/span_processor_test.exs
@@ -6,17 +6,10 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
   alias Sentry.Opentelemetry.SpanStorage
 
   setup do
-    # Create tables
-    SpanStorage.setup()
-
     on_exit(fn ->
       # Only try to clean up tables if they exist
-      if :ets.whereis(:sentry_root_spans) != :undefined do
-        :ets.delete_all_objects(:sentry_root_spans)
-      end
-
-      if :ets.whereis(:sentry_child_spans) != :undefined do
-        :ets.delete_all_objects(:sentry_child_spans)
+      if :ets.whereis(:span_storage) != :undefined do
+        :ets.delete_all_objects(:span_storage)
       end
     end)
 
@@ -71,7 +64,6 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
     TestEndpoint.instrumented_function()
 
     assert [%Sentry.Transaction{} = transaction] = Sentry.Test.pop_sentry_transactions()
-
     assert_valid_iso8601(transaction.timestamp)
     assert_valid_iso8601(transaction.start_timestamp)
     assert transaction.timestamp > transaction.start_timestamp


### PR DESCRIPTION
 [ WIP] Needs test adjustment and specs
  Considerations:
  Should we store root spans and child spans in separate tables?
  Storing key/values like this -> parent: `{{:root_span, span_id}, span}`  child: `{parent_span_id, span}`
  Should we implement some sort of sweep in case spans don't get removed `on_end`
  Should we order the child spans in the table? Or have an inserted_at value?
