### PR TITLE
Add Owner Field to Monitor Config

### DIFF
--- a/lib/sentry/check_in.ex
+++ b/lib/sentry/check_in.ex
@@ -58,7 +58,8 @@ defmodule Sentry.CheckIn do
                 optional(:max_runtime) => number(),
                 optional(:failure_issue_threshold) => number(),
                 optional(:recovery_threshold) => number(),
-                optional(:timezone) => String.t()
+                optional(:timezone) => String.t(),
+                optional(:owner) => String.t()
               },
           contexts: Interfaces.context()
         }
@@ -127,6 +128,7 @@ defmodule Sentry.CheckIn do
         failure_issue_threshold: number_schema_opts,
         recovery_threshold: number_schema_opts,
         timezone: [type: :string],
+        owner: [type: :string],
         schedule: [
           type:
             {:or,

--- a/test/sentry_test.exs
+++ b/test/sentry_test.exs
@@ -171,7 +171,8 @@ defmodule SentryTest do
                  "max_runtime" => 30,
                  "failure_issue_threshold" => 2,
                  "recovery_threshold" => 2,
-                 "timezone" => "America/Los_Angeles"
+                 "timezone" => "America/Los_Angeles",
+                 "owner" => "user:john@example.com"
                }
 
         Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
@@ -191,7 +192,8 @@ defmodule SentryTest do
                    max_runtime: 30,
                    failure_issue_threshold: 2,
                    recovery_threshold: 2,
-                   timezone: "America/Los_Angeles"
+                   timezone: "America/Los_Angeles",
+                   owner: "user:john@example.com"
                  ]
                )
     end


### PR DESCRIPTION
Small addition that adds the `:owner` field to a check-in's monitor_config. Closes #824 