### PR TITLE
Support per-module custom options for check ins

### DIFF
--- a/lib/sentry/check_in.ex
+++ b/lib/sentry/check_in.ex
@@ -20,11 +20,17 @@ defmodule Sentry.CheckIn do
   alias Sentry.{Config, Interfaces, UUID}
 
   @doc """
-  The `sentry_check_in_configuration/1` function is called to set a specific config per check-in job.
-  See the `monitor_config` type to see the available configuration options
+  Integrations can call this function on the appropriate modules to customize
+  the configuration options for the check-in.
 
+  Options returned by this function overwrite any option inferred by the specific
+  integration for the check in.
   """
-  @callback sentry_check_in_configuration(options_to_merge :: term()) :: monitor_config()
+  @doc since: "10.9.0"
+  @callback sentry_check_in_configuration(per_integration_term :: term()) :: [option_to_merge]
+            when option_to_merge:
+                   {:monitor_config, monitor_config()}
+                   | {:monitor_slug, String.t()}
 
   @typedoc """
   The possible status of the check-in.
@@ -57,23 +63,22 @@ defmodule Sentry.CheckIn do
           duration: float() | nil,
           release: String.t() | nil,
           environment: String.t() | nil,
-          monitor_config: monitor_config(),
+          monitor_config: monitor_config() | nil,
           contexts: Interfaces.context()
         }
-  @typedoc """
-  The type for the monitor_config.
-  """
 
-  @type monitor_config() ::
-    nil
-    | %{
-        required(:schedule) => monitor_config_schedule(),
-        optional(:checkin_margin) => number(),
-        optional(:max_runtime) => number(),
-        optional(:failure_issue_threshold) => number(),
-        optional(:recovery_threshold) => number(),
-        optional(:timezone) => String.t()
-      }
+  @typedoc """
+  Options for configuring a monitor check-in.
+  """
+  @typedoc since: "10.9.0"
+  @type monitor_config() :: %{
+          required(:schedule) => monitor_config_schedule(),
+          optional(:checkin_margin) => number(),
+          optional(:max_runtime) => number(),
+          optional(:failure_issue_threshold) => number(),
+          optional(:recovery_threshold) => number(),
+          optional(:timezone) => String.t()
+        }
 
   @enforce_keys [
     :check_in_id,
@@ -154,6 +159,11 @@ defmodule Sentry.CheckIn do
 
   @create_check_in_opts_schema NimbleOptions.new!(create_check_in_opts_schema)
 
+  @custom_opts_schema create_check_in_opts_schema
+                      |> Keyword.take([:monitor_config, :monitor_slug])
+                      |> put_in([:monitor_slug, :required], false)
+                      |> NimbleOptions.new!()
+
   @doc """
   Creates a new check-in struct with the given options.
 
@@ -205,5 +215,29 @@ defmodule Sentry.CheckIn do
   @spec to_map(t()) :: map()
   def to_map(%__MODULE__{} = check_in) do
     Map.from_struct(check_in)
+  end
+
+  @doc false
+  def __resolve_custom_options__(options, mod, per_integration_term) do
+    custom_opts =
+      if function_exported?(mod, :sentry_check_in_configuration, 1) do
+        mod.sentry_check_in_configuration(per_integration_term)
+      else
+        []
+      end
+
+    custom_opts = NimbleOptions.validate!(custom_opts, @custom_opts_schema)
+
+    deep_merge_keyword(options, custom_opts)
+  end
+
+  defp deep_merge_keyword(left, right) do
+    Keyword.merge(left, right, fn _key, left_val, right_val ->
+      if Keyword.keyword?(left_val) and Keyword.keyword?(right_val) do
+        deep_merge_keyword(left_val, right_val)
+      else
+        right_val
+      end
+    end)
   end
 end

--- a/lib/sentry/check_in.ex
+++ b/lib/sentry/check_in.ex
@@ -19,6 +19,13 @@ defmodule Sentry.CheckIn do
 
   alias Sentry.{Config, Interfaces, UUID}
 
+  @doc """
+  The `sentry_check_in_configuration/1` function is called to set a specific config per check-in job.
+  See the `monitor_config` type to see the available configuration options
+
+  """
+  @callback sentry_check_in_configuration(options_to_merge :: term()) :: monitor_config()
+
   @typedoc """
   The possible status of the check-in.
   """
@@ -50,18 +57,23 @@ defmodule Sentry.CheckIn do
           duration: float() | nil,
           release: String.t() | nil,
           environment: String.t() | nil,
-          monitor_config:
-            nil
-            | %{
-                required(:schedule) => monitor_config_schedule(),
-                optional(:checkin_margin) => number(),
-                optional(:max_runtime) => number(),
-                optional(:failure_issue_threshold) => number(),
-                optional(:recovery_threshold) => number(),
-                optional(:timezone) => String.t()
-              },
+          monitor_config: monitor_config(),
           contexts: Interfaces.context()
         }
+  @typedoc """
+  The type for the monitor_config.
+  """
+
+  @type monitor_config() ::
+    nil
+    | %{
+        required(:schedule) => monitor_config_schedule(),
+        optional(:checkin_margin) => number(),
+        optional(:max_runtime) => number(),
+        optional(:failure_issue_threshold) => number(),
+        optional(:recovery_threshold) => number(),
+        optional(:timezone) => String.t()
+      }
 
   @enforce_keys [
     :check_in_id,

--- a/lib/sentry/integrations/oban/cron.ex
+++ b/lib/sentry/integrations/oban/cron.ex
@@ -113,13 +113,7 @@ defmodule Sentry.Integrations.Oban.Cron do
           monitor_config: monitor_config_opts
         ]
 
-        try do
-          resolve_custom_opts(opts, job)
-        rescue
-          x ->
-            IO.inspect(x)
-            reraise x, __STACKTRACE__
-        end
+        resolve_custom_opts(opts, job)
     end
   end
 
@@ -130,7 +124,7 @@ defmodule Sentry.Integrations.Oban.Cron do
     ArgumentError -> opts
   else
     worker ->
-      if Code.loaded?(worker) do
+      if Code.ensure_loaded?(worker) do
         resolve_custom_opts(opts, worker, job)
       else
         opts

--- a/lib/sentry/integrations/oban/cron.ex
+++ b/lib/sentry/integrations/oban/cron.ex
@@ -113,7 +113,13 @@ defmodule Sentry.Integrations.Oban.Cron do
           monitor_config: monitor_config_opts
         ]
 
-        resolve_custom_opts(opts, job)
+        try do
+          resolve_custom_opts(opts, job)
+        rescue
+          x ->
+            IO.inspect(x)
+            reraise x, __STACKTRACE__
+        end
     end
   end
 

--- a/test/sentry/integrations/oban/cron_test.exs
+++ b/test/sentry/integrations/oban/cron_test.exs
@@ -321,12 +321,12 @@ defmodule Sentry.Integrations.Oban.CronTest do
     defmodule WorkerWithCustomOptions do
       use Oban.Worker
 
-      @behaviour Sentry.CheckIn
+      @behaviour Sentry.Integrations.Oban.Cron
 
       @impl Oban.Worker
       def perform(_job), do: :ok
 
-      @impl Sentry.CheckIn
+      @impl Sentry.Integrations.Oban.Cron
       def sentry_check_in_configuration(job) do
         [
           monitor_slug: "this-is-a-custom-slug-#{job.id}",

--- a/test/sentry/integrations/oban/cron_test.exs
+++ b/test/sentry/integrations/oban/cron_test.exs
@@ -307,7 +307,6 @@ defmodule Sentry.Integrations.Oban.CronTest do
     Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
       {:ok, body, conn} = Plug.Conn.read_body(conn)
       assert [{_headers, check_in_body}] = decode_envelope!(body)
-      IO.inspect(check_in_body)
 
       assert check_in_body["monitor_slug"] == "this-is-a-custom-slug-123"
       assert check_in_body["monitor_config"]["schedule"]["type"] == "interval"

--- a/test/sentry/integrations/oban/cron_test.exs
+++ b/test/sentry/integrations/oban/cron_test.exs
@@ -307,7 +307,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
     Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
       {:ok, body, conn} = Plug.Conn.read_body(conn)
       assert [{_headers, check_in_body}] = decode_envelope!(body)
-      dbg(check_in_body)
+      IO.inspect(check_in_body)
 
       assert check_in_body["monitor_slug"] == "this-is-a-custom-slug-123"
       assert check_in_body["monitor_config"]["schedule"]["type"] == "interval"

--- a/test/sentry/integrations/oban/cron_test.exs
+++ b/test/sentry/integrations/oban/cron_test.exs
@@ -300,7 +300,6 @@ defmodule Sentry.Integrations.Oban.CronTest do
     assert_receive {^ref, :done}, 1000
   end
 
-  @tag :focus
   test "custom options", %{bypass: bypass} do
     test_pid = self()
     ref = make_ref()
@@ -308,6 +307,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
     Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
       {:ok, body, conn} = Plug.Conn.read_body(conn)
       assert [{_headers, check_in_body}] = decode_envelope!(body)
+      dbg(check_in_body)
 
       assert check_in_body["monitor_slug"] == "this-is-a-custom-slug-123"
       assert check_in_body["monitor_config"]["schedule"]["type"] == "interval"


### PR DESCRIPTION
Following the conversations from issues #830 & #824, the decision to add a public API to be able to set custom config options to the monitor is in-progress.