### PR TITLE
feat: add `tags_from_metadata` option to LoggerHandler

### DIFF
--- a/lib/sentry/logger_backend.ex
+++ b/lib/sentry/logger_backend.ex
@@ -150,7 +150,14 @@ defmodule Sentry.LoggerBackend do
     # The context in the Logger backend process is not the same as the one in the process
     # that did the logging. This behavior is different than the one in Sentry.LoggerHandler,
     # since Logger handlers run in the caller process.
-    opts = LoggerUtils.build_sentry_options(level, sentry_context, Map.new(meta), state.metadata)
+    opts =
+      LoggerUtils.build_sentry_options(
+        level,
+        sentry_context,
+        Map.new(meta),
+        state.metadata,
+        _tags_from_metadata = []
+      )
 
     case meta[:crash_reason] do
       # If the crash reason is an exception, we want to report the exception itself

--- a/lib/sentry/logger_handler.ex
+++ b/lib/sentry/logger_handler.ex
@@ -44,6 +44,14 @@ defmodule Sentry.LoggerHandler do
       If set to `:all`, all metadata will be included.
       """
     ],
+    tags_from_metadata: [
+      type: {:list, :atom},
+      default: [],
+      doc: """
+      Use this to include logger metadata as tags in reports. Metadata under the specified keys
+      in those keys will be added as tags to the event.
+      """
+    ],
     capture_log_messages: [
       type: :boolean,
       default: false,
@@ -220,6 +228,7 @@ defmodule Sentry.LoggerHandler do
     :level,
     :excluded_domains,
     :metadata,
+    :tags_from_metadata,
     :capture_log_messages,
     :rate_limiting,
     :sync_threshold
@@ -321,7 +330,8 @@ defmodule Sentry.LoggerHandler do
             log_level,
             log_meta[:sentry],
             log_meta,
-            config.metadata
+            config.metadata,
+            config.tags_from_metadata
           )
 
         log_unfiltered(log_event, sentry_opts, config)

--- a/lib/sentry/logger_handler.ex
+++ b/lib/sentry/logger_handler.ex
@@ -49,7 +49,7 @@ defmodule Sentry.LoggerHandler do
       default: [],
       doc: """
       Use this to include logger metadata as tags in reports. Metadata under the specified keys
-      in those keys will be added as tags to the event.
+      in those keys will be added as tags to the event. *Available since v10.9.0*.
       """
     ],
     capture_log_messages: [

--- a/test/sentry/logger_handler_test.exs
+++ b/test/sentry/logger_handler_test.exs
@@ -206,6 +206,36 @@ defmodule Sentry.LoggerHandlerTest do
     end
   end
 
+  describe "with logger metadata as tags" do
+    @tag handler_config: %{capture_log_messages: true, tags_from_metadata: [:string, :number]}
+    test "includes configured Logger metadata as tags", %{sender_ref: ref} do
+      Logger.metadata(string: "value", number: 42, other: "ignored")
+      Logger.error("Testing error")
+
+      assert_receive {^ref, event}
+      assert event.tags == %{string: "value", number: 42}
+    end
+
+    @tag handler_config: %{capture_log_messages: true, tags_from_metadata: []}
+    test "does not include Logger metadata as tags when disabled",
+         %{sender_ref: ref} do
+      Logger.metadata(string: "value", number: 42)
+      Logger.error("Testing error")
+
+      assert_receive {^ref, event}
+      assert event.tags == %{}
+    end
+
+    @tag handler_config: %{capture_log_messages: true, tags_from_metadata: [:string, :number]}
+    test "merges configured tags with explicitly set tags", %{sender_ref: ref} do
+      Logger.metadata(string: "value", number: 42)
+      Logger.error("Testing error", sentry: [tags: %{explicit: "tag"}])
+
+      assert_receive {^ref, event}
+      assert event.tags == %{string: "value", number: 42, explicit: "tag"}
+    end
+  end
+
   describe "with a crashing GenServer" do
     setup do
       %{test_genserver: start_supervised!(TestGenServer, restart: :temporary)}

--- a/test/sentry/logger_handler_test.exs
+++ b/test/sentry/logger_handler_test.exs
@@ -208,19 +208,18 @@ defmodule Sentry.LoggerHandlerTest do
 
   describe "with logger metadata as tags" do
     @tag handler_config: %{capture_log_messages: true, tags_from_metadata: [:string, :number]}
-    test "includes configured Logger metadata as tags", %{sender_ref: ref} do
+    test "includes configured Logger metadata as tags, but only if strings", %{sender_ref: ref} do
       Logger.metadata(string: "value", number: 42, other: "ignored")
       Logger.error("Testing error")
 
       assert_receive {^ref, event}
-      assert event.tags == %{string: "value", number: 42}
+      assert event.tags == %{string: "value"}
     end
 
     @tag handler_config: %{capture_log_messages: true, tags_from_metadata: []}
     test "does not include Logger metadata as tags when disabled",
          %{sender_ref: ref} do
-      Logger.metadata(string: "value", number: 42)
-      Logger.error("Testing error")
+      Logger.error("Testing error", string: "value", number: 42)
 
       assert_receive {^ref, event}
       assert event.tags == %{}
@@ -229,10 +228,10 @@ defmodule Sentry.LoggerHandlerTest do
     @tag handler_config: %{capture_log_messages: true, tags_from_metadata: [:string, :number]}
     test "merges configured tags with explicitly set tags", %{sender_ref: ref} do
       Logger.metadata(string: "value", number: 42)
-      Logger.error("Testing error", sentry: [tags: %{explicit: "tag"}])
+      Logger.error("Testing error", sentry: [tags: %{explicit: "tag", number: 44}])
 
       assert_receive {^ref, event}
-      assert event.tags == %{string: "value", number: 42, explicit: "tag"}
+      assert event.tags == %{string: "value", number: 44, explicit: "tag"}
     end
   end
 


### PR DESCRIPTION
Added a new configuration option 'tags_from_metadata' to both `LoggerHandler` that allows specifying which metadata fields should be included as tags in Sentry events. 

Closes #827 