### PR TITLE
Add support for Req http client (draft)

### DIFF
--- a/lib/mix/tasks/sentry.send_test_event.ex
+++ b/lib/mix/tasks/sentry.send_test_event.ex
@@ -26,6 +26,8 @@ defmodule Mix.Tasks.Sentry.SendTestEvent do
     type: :string
   ]
 
+  @requirements ["app.start"]
+
   @impl true
   def run(args) when is_list(args) do
     {opts, args} = OptionParser.parse!(args, strict: @switches)

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -322,6 +322,14 @@ defmodule Sentry.Config do
       connections to keep in the pool. Only applied if `:client` is set to
       `Sentry.HackneyClient`.
       """
+    ],
+    req_opts: [
+      type: :keyword_list,
+      default: [],
+      doc: """
+      Options to be passed to `Req`. Only
+      applied if `:client` is set to `Sentry.ReqClient`.
+      """
     ]
   ]
 
@@ -558,6 +566,9 @@ defmodule Sentry.Config do
 
   @spec hackney_opts() :: keyword()
   def hackney_opts, do: fetch!(:hackney_opts)
+
+  @spec req_opts() :: keyword()
+  def req_opts, do: fetch!(:req_opts)
 
   @spec before_send() :: (Sentry.Event.t() -> Sentry.Event.t()) | {module(), atom()} | nil
   def before_send, do: get(:before_send)

--- a/lib/sentry/req_client.ex
+++ b/lib/sentry/req_client.ex
@@ -1,0 +1,32 @@
+defmodule Sentry.ReqClient do
+  @behaviour Sentry.HTTPClient
+
+  @moduledoc """
+  The built-in HTTP client.
+
+  This client implements the `Sentry.HTTPClient` behaviour.
+
+  It's based on the [Req](https://github.com/wojtekmach/req) HTTP client,
+  which is an *optional dependency* of this library. If you wish to use another
+  HTTP client, you'll have to implement your own `Sentry.HTTPClient`. See the
+  documentation for `Sentry.HTTPClient` for more information.
+  """
+
+  @impl true
+  def post(url, headers, body) do
+    opts =
+      Sentry.Config.req_opts()
+      |> Keyword.put(:decode_body, false)
+      |> Keyword.put(:url, url)
+      |> Keyword.put(:body, body)
+
+    req =
+      Req.new(opts)
+      |> Req.merge(headers: headers)
+
+    case Req.post(req) do
+      {:ok, %{status: status, headers: headers, body: body}} = result -> {:ok, status, headers, body}
+      {:error, _reason} = error -> error
+    end
+  end
+end

--- a/lib/sentry/transport.ex
+++ b/lib/sentry/transport.ex
@@ -125,7 +125,7 @@ defmodule Sentry.Transport do
   defp client_post_and_validate_return_value(client, endpoint, headers, body) do
     case client.post(endpoint, headers, body) do
       {:ok, status, resp_headers, resp_body}
-      when is_integer(status) and status in 200..599 and is_list(resp_headers) and
+      when is_integer(status) and status in 200..599 and
              is_binary(resp_body) ->
         {:ok, status, resp_headers, resp_body}
 
@@ -152,8 +152,8 @@ defmodule Sentry.Transport do
       |> Enum.map_join(", ", fn {name, value} -> "#{name}=#{value}" end)
 
     auth_headers = [
-      {"User-Agent", @sentry_client},
-      {"X-Sentry-Auth", "Sentry " <> auth_query}
+      {"user-agent", @sentry_client},
+      {"x-sentry-auth", "Sentry " <> auth_query}
     ]
 
     {dsn.endpoint_uri, auth_headers}

--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,7 @@ defmodule Sentry.Mixfile do
           "Plug and Phoenix": [Sentry.PlugCapture, Sentry.PlugContext, Sentry.LiveViewHook],
           Loggers: [Sentry.LoggerBackend, Sentry.LoggerHandler],
           "Data Structures": [Sentry.Attachment, Sentry.CheckIn, Sentry.ClientReport],
-          HTTP: [Sentry.HTTPClient, Sentry.HackneyClient],
+          HTTP: [Sentry.HTTPClient, Sentry.HackneyClient, Sentry.ReqClient],
           Interfaces: [~r/^Sentry\.Interfaces/],
           Testing: [Sentry.Test]
         ],


### PR DESCRIPTION
Hello, I would be happy if Req would be supported as http client lib. Here is a working proof of concept.

Since Hackney is the only HTTP client that is supported so far, I had to bend a little in some places. A few comments on this below.

One general question:

Because Req is not known in the Sentry library I get a few warning like:

```
warning: Req.new/1 is undefined (module Req is not available or is yet to be defined). Make sure the module name is correct and has been specified in full (or that an alias has been defined)
warning: Req.merge/2 is undefined (module Req is not available or is yet to be defined). Make sure the module name is correct and has been specified in full (or that an alias has been defined)
warning: Req.post/1 is undefined (module Req is not available or is yet to be defined). Make sure the module name is correct and has been specified in full (or that an alias has been defined)
```

Should I make use of `Code.ensure_loaded?(Req)` and `Application.ensure_all_started(:req)`?