### PR TITLE
Keep Newest Breadcrumbs Instead of Oldest

### DIFF
--- a/lib/sentry/context.ex
+++ b/lib/sentry/context.ex
@@ -424,7 +424,7 @@ defmodule Sentry.Context do
       get_sentry_context()
       |> Map.update(@breadcrumbs_key, [map], fn breadcrumbs ->
         breadcrumbs = [map | breadcrumbs]
-        Enum.take(breadcrumbs, -1 * Sentry.Config.max_breadcrumbs())
+        Enum.take(breadcrumbs, 1 * Sentry.Config.max_breadcrumbs())
       end)
 
     :logger.update_process_metadata(%{@logger_metadata_key => sentry_metadata})

--- a/lib/sentry/context.ex
+++ b/lib/sentry/context.ex
@@ -423,8 +423,7 @@ defmodule Sentry.Context do
     sentry_metadata =
       get_sentry_context()
       |> Map.update(@breadcrumbs_key, [map], fn breadcrumbs ->
-        breadcrumbs = [map | breadcrumbs]
-        Enum.take(breadcrumbs, 1 * Sentry.Config.max_breadcrumbs())
+        Enum.take([map | breadcrumbs], Sentry.Config.max_breadcrumbs())
       end)
 
     :logger.update_process_metadata(%{@logger_metadata_key => sentry_metadata})

--- a/test/context_test.exs
+++ b/test/context_test.exs
@@ -39,6 +39,16 @@ defmodule Sentry.ContextTest do
     assert first_breadcrumb.timestamp <= second_breadcrumb.timestamp
   end
 
+  test "retains most recent breadcrumbs when exceeding max" do
+    put_test_config(max_breadcrumbs: 3)
+
+    for x <- 1..10, do: Context.add_breadcrumb(message: x)
+
+    event = Event.create_event([])
+
+    assert event.breadcrumbs |> Enum.map(& &1.message) == [8, 9, 10]
+  end
+
   test "storing user context appears when generating event" do
     Context.set_user_context(%{id: "345"})
 


### PR DESCRIPTION
Currently, exceeding max_breadcrumbs causes only the oldest breadcrumbs to be retained, instead of the newest, as I would have expected. I believe this is a bug?

It's caused by the following code, which inserts the newest breadcrumb at the front of the list, but then trims the list from the back.
https://github.com/getsentry/sentry-elixir/blob/8ee657f110f589a8008f56a957972c391529f879/lib/sentry/context.ex#L426-L427

Similar code exists here but is actually correct because `Context.get_all` returns the breadcrumb list reversed.
https://github.com/getsentry/sentry-elixir/blob/8ee657f110f589a8008f56a957972c391529f879/lib/sentry/event.ex#L216