### PR TITLE
Add timezone to Oban Integration

### DIFF
--- a/lib/sentry/integrations/oban/cron.ex
+++ b/lib/sentry/integrations/oban/cron.ex
@@ -89,8 +89,8 @@ defmodule Sentry.Integrations.Oban.Cron do
   end
 
   defp job_to_check_in_opts(job, config) when is_struct(job, Oban.Job) do
-    monitor_config_opts =
-      Keyword.merge(Sentry.Config.integrations()[:monitor_config_defaults], timezone_opts(job))
+    monitor_config_opts = Sentry.Config.integrations()
+    monitor_config_opts = maybe_put_timezone_option(monitor_config_opts, job)
 
     monitor_slug =
       case config[:monitor_slug_generator] do

--- a/lib/sentry/integrations/oban/cron.ex
+++ b/lib/sentry/integrations/oban/cron.ex
@@ -39,8 +39,7 @@ defmodule Sentry.Integrations.Oban.Cron do
   def handle_event(
         [:oban, :job, event],
         measurements,
-        %{job: %mod{meta: %{"cron" => true, "cron_expr" => cron_expr}}} =
-          metadata,
+        %{job: %mod{meta: %{"cron" => true, "cron_expr" => cron_expr}}} = metadata,
         config
       )
       when event in [:start, :stop, :exception] and mod == Oban.Job and is_binary(cron_expr) do
@@ -172,7 +171,7 @@ defmodule Sentry.Integrations.Oban.Cron do
     end
   end
 
-  defp maybe_put_timezone_option(opts, %{meta: %{"cron_tz" => tz}}) do
+  defp maybe_put_timezone_option(opts, %{meta: %{"cron_tz" => tz}} = _job) do
     Keyword.put(opts, :timezone, tz)
   end
 

--- a/lib/sentry/integrations/oban/cron.ex
+++ b/lib/sentry/integrations/oban/cron.ex
@@ -39,7 +39,7 @@ defmodule Sentry.Integrations.Oban.Cron do
   def handle_event(
         [:oban, :job, event],
         measurements,
-        %{job: %mod{meta: %{"cron" => true, "cron_expr" => cron_expr, "cron_tz" => _timezone}}} =
+        %{job: %mod{meta: %{"cron" => true, "cron_expr" => cron_expr}}} =
           metadata,
         config
       )
@@ -89,7 +89,7 @@ defmodule Sentry.Integrations.Oban.Cron do
   end
 
   defp job_to_check_in_opts(job, config) when is_struct(job, Oban.Job) do
-    monitor_config_opts = Sentry.Config.integrations()
+    monitor_config_opts = Sentry.Config.integrations()[:monitor_config_defaults]
     monitor_config_opts = maybe_put_timezone_option(monitor_config_opts, job)
 
     monitor_slug =
@@ -172,12 +172,12 @@ defmodule Sentry.Integrations.Oban.Cron do
     end
   end
 
-  defp timezone_opts(%{meta: meta} = job) when is_struct(job, Oban.Job) do
-    if meta["cron_tz"] do
-      [timezone: meta["cron_tz"]]
-    else
-      []
-    end
+  defp maybe_put_timezone_option(opts, %{meta: %{"cron_tz" => tz}}) do
+    Keyword.put(opts, :timezone, tz)
+  end
+
+  defp maybe_put_timezone_option(opts, _job) do
+    opts
   end
 
   defp duration_in_seconds(%{duration: duration} = _measurements) do

--- a/test/sentry/integrations/oban/cron_test.exs
+++ b/test/sentry/integrations/oban/cron_test.exs
@@ -77,8 +77,8 @@ defmodule Sentry.Integrations.Oban.CronTest do
       assert check_in_body["monitor_config"] == %{
                "schedule" => %{
                  "type" => "interval",
-                 "unit" => "day",
-                 "value" => 1
+                 "value" => 1,
+                 "unit" => "day"
                }
              }
 

--- a/test/sentry/integrations/oban/cron_test.exs
+++ b/test/sentry/integrations/oban/cron_test.exs
@@ -79,8 +79,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
                  "type" => "interval",
                  "unit" => "day",
                  "value" => 1
-               },
-               "timezone" => "Europe/Rome"
+               }
              }
 
       send(test_pid, {ref, :done})
@@ -92,7 +91,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
       job: %Oban.Job{
         worker: "Sentry.MyWorker",
         id: 123,
-        meta: %{"cron" => true, "cron_expr" => "@daily", "cron_tz" => "Europe/Rome"}
+        meta: %{"cron" => true, "cron_expr" => "@daily"}
       }
     })
 
@@ -304,7 +303,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
     assert_receive {^ref, :done}, 1000
   end
 
-  test "custom options", %{bypass: bypass} do
+  test "custom options overide job metadata", %{bypass: bypass} do
     test_pid = self()
     ref = make_ref()
 

--- a/test/sentry/integrations/oban/cron_test.exs
+++ b/test/sentry/integrations/oban/cron_test.exs
@@ -77,9 +77,10 @@ defmodule Sentry.Integrations.Oban.CronTest do
       assert check_in_body["monitor_config"] == %{
                "schedule" => %{
                  "type" => "interval",
-                 "value" => 1,
-                 "unit" => "day"
-               }
+                 "unit" => "day",
+                 "value" => 1
+               },
+               "timezone" => "Europe/Rome"
              }
 
       send(test_pid, {ref, :done})
@@ -91,7 +92,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
       job: %Oban.Job{
         worker: "Sentry.MyWorker",
         id: 123,
-        meta: %{"cron" => true, "cron_expr" => "@daily"}
+        meta: %{"cron" => true, "cron_expr" => "@daily", "cron_tz" => "Europe/Rome"}
       }
     })
 
@@ -135,7 +136,8 @@ defmodule Sentry.Integrations.Oban.CronTest do
                    "type" => "interval",
                    "value" => 1,
                    "unit" => unquote(expected_unit)
-                 }
+                 },
+                 "timezone" => "Europe/Rome"
                }
 
         send(test_pid, {ref, :done})
@@ -150,7 +152,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
         job: %Oban.Job{
           worker: "Sentry.MyWorker",
           id: 942,
-          meta: %{"cron" => true, "cron_expr" => unquote(frequency)}
+          meta: %{"cron" => true, "cron_expr" => unquote(frequency), "cron_tz" => "Europe/Rome"}
         }
       })
 
@@ -179,7 +181,8 @@ defmodule Sentry.Integrations.Oban.CronTest do
                "schedule" => %{
                  "type" => "crontab",
                  "value" => "* 1 1 1 1"
-               }
+               },
+               "timezone" => "Europe/Rome"
              }
 
       send(test_pid, {ref, :done})
@@ -194,7 +197,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
       job: %Oban.Job{
         worker: "Sentry.MyWorker",
         id: 942,
-        meta: %{"cron" => true, "cron_expr" => "* 1 1 1 1"}
+        meta: %{"cron" => true, "cron_expr" => "* 1 1 1 1", "cron_tz" => "Europe/Rome"}
       }
     })
 
@@ -226,7 +229,8 @@ defmodule Sentry.Integrations.Oban.CronTest do
                "schedule" => %{
                  "type" => "crontab",
                  "value" => "* 1 1 1 1"
-               }
+               },
+               "timezone" => "Europe/Rome"
              }
 
       send(test_pid, {ref, :done})
@@ -239,7 +243,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
       job: %Oban.Job{
         worker: "Sentry.MyWorker",
         id: 942,
-        meta: %{"cron" => true, "cron_expr" => "* 1 1 1 1"}
+        meta: %{"cron" => true, "cron_expr" => "* 1 1 1 1", "cron_tz" => "Europe/Rome"}
       }
     })
 
@@ -265,7 +269,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
       job: %Oban.Job{
         worker: "Sentry.MyWorker",
         id: 123,
-        meta: %{"cron" => true, "cron_expr" => "@daily"}
+        meta: %{"cron" => true, "cron_expr" => "@daily", "cron_tz" => "Europe/Rome"}
       }
     })
 
@@ -293,7 +297,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
         worker: "Sentry.ClientWorker",
         id: 123,
         args: %{"client" => client_name},
-        meta: %{"cron" => true, "cron_expr" => "@daily"}
+        meta: %{"cron" => true, "cron_expr" => "@daily", "cron_tz" => "Europe/Rome"}
       }
     })
 
@@ -339,7 +343,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
         worker: inspect(WorkerWithCustomOptions),
         id: 123,
         args: %{},
-        meta: %{"cron" => true, "cron_expr" => "@daily"}
+        meta: %{"cron" => true, "cron_expr" => "@daily", "cron_tz" => "America/Chicago"}
       }
     })
 


### PR DESCRIPTION
-metadata now includes timezones that can be set from Oban
-update tests to include new metadata
-closes #861 