### PR TITLE
Ensure standard log messages are not captured with capture_log_messages false

### DIFF
--- a/lib/sentry/logger_handler.ex
+++ b/lib/sentry/logger_handler.ex
@@ -341,6 +341,11 @@ defmodule Sentry.LoggerHandler do
           SenderPool.get_queued_events_counter() >= config.discard_threshold ->
         :ok
 
+      # If it's a crash we want to always capture it. Otherwise we only capture if
+      # `capture_log_messages` is set to true.
+      !log_meta[:crash_reason] && !config.capture_log_messages ->
+        :ok
+
       true ->
         # Logger handlers run in the process that logs, so we already read all the
         # necessary Sentry context from the process dictionary (when creating the event).

--- a/test/sentry/logger_handler_test.exs
+++ b/test/sentry/logger_handler_test.exs
@@ -181,6 +181,7 @@ defmodule Sentry.LoggerHandlerTest do
       refute_received {^ref, _event}, 100
     end
 
+    @tag handler_config: %{capture_log_messages: true}
     test "support structured logs map", %{sender_ref: ref} do
       Logger.error(%{foo: "bar"})
 
@@ -194,6 +195,7 @@ defmodule Sentry.LoggerHandlerTest do
       defstruct [:bar]
     end
 
+    @tag handler_config: %{capture_log_messages: true}
     test "support structured logs struct", %{sender_ref: ref} do
       Logger.error(%Foo{})
 


### PR DESCRIPTION
This adds another clause to exclude any logger events that are not crash reports if capture_log_messages is set to false.

Based on #864