### PR TITLE
Add global `:extra` config

### DIFF
--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -197,6 +197,13 @@ defmodule Sentry.Config do
       A map of tags to be sent with every event.
       """
     ],
+    extra: [
+      type: {:map, :any, :any},
+      default: %{},
+      doc: """
+      A map of extra data to be sent with every event.
+      """
+    ],
     max_breadcrumbs: [
       type: :non_neg_integer,
       default: 100,
@@ -545,6 +552,9 @@ defmodule Sentry.Config do
 
   @spec tags() :: map()
   def tags, do: fetch!(:tags)
+
+  @spec extra() :: map()
+  def extra, do: fetch!(:extra)
 
   @spec release() :: String.t() | nil
   def release, do: get(:release)

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -198,7 +198,8 @@ defmodule Sentry.Config do
       """
     ],
     extra: [
-      type: {:map, :any, :any},
+      type: {:map, :atom, :any},
+      type_doc: "`t:Sentry.Context.extra/0`",
       default: %{},
       doc: """
       A map of extra data to be sent with every event.

--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -200,7 +200,11 @@ defmodule Sentry.Event do
       attachments: attachments_context
     } = Sentry.Context.get_all()
 
-    extra = Map.merge(extra_context, Keyword.fetch!(opts, :extra))
+    extra =
+      Config.extra()
+      |> Map.merge(extra_context)
+      |> Map.merge(Keyword.fetch!(opts, :extra))
+
     user = Map.merge(user_context, Keyword.fetch!(opts, :user))
     request = Map.merge(request_context, Keyword.fetch!(opts, :request))
 

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -97,12 +97,12 @@ defmodule Sentry.EventTest do
     test "includes the config defaults" do
       put_test_config(
         tags: %{"test-tag" => "test-value"},
-        extra: %{"some-data" => "with-a-value"}
+        extra: %{"some-data": "with-a-value"}
       )
 
       assert %Event{} = event = Event.create_event([])
       assert event.tags == %{"test-tag" => "test-value"}
-      assert event.extra == %{"some-data" => "with-a-value"}
+      assert event.extra == %{"some-data": "with-a-value"}
     end
 
     test "fills in passed-in options" do
@@ -163,9 +163,9 @@ defmodule Sentry.EventTest do
           "overriden-by-options" => "config"
         },
         extra: %{
-          "not-overriden" => "config",
-          "overriden-by-context" => "config",
-          "overriden-by-options" => "config"
+          "not-overriden": "config",
+          "overriden-by-context": "config",
+          "overriden-by-options": "config"
         }
       )
 
@@ -175,15 +175,15 @@ defmodule Sentry.EventTest do
       })
 
       Sentry.Context.set_extra_context(%{
-        "overriden-by-context" => "context",
-        "overriden-by-options" => "context"
+        "overriden-by-context": "context",
+        "overriden-by-options": "context"
       })
 
       assert %Event{} =
                event =
                Event.create_event(
                  tags: %{"overriden-by-options" => "options"},
-                 extra: %{"overriden-by-options" => "options"}
+                 extra: %{"overriden-by-options": "options"}
                )
 
       assert event.tags == %{
@@ -193,9 +193,9 @@ defmodule Sentry.EventTest do
              }
 
       assert event.extra == %{
-               "not-overriden" => "config",
-               "overriden-by-context" => "context",
-               "overriden-by-options" => "options"
+               "not-overriden": "config",
+               "overriden-by-context": "context",
+               "overriden-by-options": "options"
              }
     end
 


### PR DESCRIPTION
This PR aims to add a new `:extra` configuration option, to be able to add global `:extra` context, passed in to every event.

Resolves #863
