### PR TITLE
Fix invalid JSON in `:message`

### DIFF
--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -284,7 +284,11 @@ defmodule Sentry.Event do
     {iodata, _params} =
       Enum.reduce(parts, {"", params}, fn
         "%s", {acc, [param | rest_params]} ->
-          {[acc, to_string(param)], rest_params}
+          cond do
+            is_binary(param) and String.printable?(param) -> {[acc, param], rest_params}
+            is_binary(param) -> {[acc, inspect(param)], rest_params}
+            true -> {[acc, to_string(param)], rest_params}
+          end
 
         "%s", {acc, []} ->
           {[acc, "%s"], []}


### PR DESCRIPTION
We've seen this in some of our internal logs. Easy to break the Sentry reporting by using messages (or interpolation paramaters) that are not JSON-encodable strings.