### PR TITLE
Remove extra inspect/1 for Oban errors fingerprints

### DIFF
--- a/lib/sentry/integrations/oban/error_reporter.ex
+++ b/lib/sentry/integrations/oban/error_reporter.ex
@@ -43,7 +43,7 @@ defmodule Sentry.Integrations.Oban.ErrorReporter do
       [
         stacktrace: stacktrace,
         tags: %{oban_worker: job.worker, oban_queue: job.queue, oban_state: job.state},
-        fingerprint: [inspect(job.worker)] ++ fingerprint_opts,
+        fingerprint: [job.worker] ++ fingerprint_opts,
         extra:
           Map.take(job, [:args, :attempt, :id, :max_attempts, :meta, :queue, :tags, :worker]),
         integration_meta: %{oban: %{job: job}}


### PR DESCRIPTION
`job.worker` is already a string.