### PR TITLE
Fix ignored Plug exception in the default filter

### DIFF
--- a/lib/sentry/default_event_filter.ex
+++ b/lib/sentry/default_event_filter.ex
@@ -5,7 +5,7 @@ defmodule Sentry.DefaultEventFilter do
     Plug.Conn.InvalidQueryError,
     Plug.Parsers.BadEncodingError,
     Plug.Parsers.ParseError,
-    Plug.Parsers.RequestTooLarge,
+    Plug.Parsers.RequestTooLargeError,
     Plug.Parsers.UnsupportedMediaTypeError,
     Plug.Static.InvalidPathError
   ]


### PR DESCRIPTION
I noticed the `Plug.Parsers.RequestTooLarge` atom does not exists in the `Plug` repo.