### PR TITLE
Remain compatible with new translation format to be introduced in Elixir 1.19

### DIFF
--- a/lib/sentry/logger_handler.ex
+++ b/lib/sentry/logger_handler.ex
@@ -360,6 +360,16 @@ defmodule Sentry.LoggerHandler do
     end
   end
 
+  # Elixir 1.19 puts string translation inside the report instead of replacing
+  # it completely. We switch it back for compatibility with existing code.
+  defp log_unfiltered(
+         %{msg: {:report, %{elixir_translation: unicode_chardata}}} = log_event,
+         sentry_opts,
+         %__MODULE__{} = config
+       ) do
+    log_unfiltered(%{log_event | msg: {:string, unicode_chardata}}, sentry_opts, config)
+  end
+
   # A string was logged. We check for the :crash_reason metadata and try to build a sensible
   # report from there, otherwise we use the logged string directly.
   defp log_unfiltered(

--- a/test/sentry/logger_handler_test.exs
+++ b/test/sentry/logger_handler_test.exs
@@ -154,7 +154,7 @@ defmodule Sentry.LoggerHandlerTest do
       assert %KeyError{} = event.original_exception
       assert [exception] = event.exception
       assert exception.type == "KeyError"
-      assert exception.value == "key :foo not found in: []"
+      assert exception.value =~ ~r"key :foo not found in:\s+\[\]"
       assert Enum.find(exception.stacktrace.frames, &(&1.function =~ "Keyword.fetch!/2"))
     end
   end
@@ -286,7 +286,7 @@ defmodule Sentry.LoggerHandlerTest do
       assert %KeyError{} = event.original_exception
       assert [exception] = event.exception
       assert exception.type == "KeyError"
-      assert exception.value == "key :foo not found in: []"
+      assert exception.value =~ ~r"key :foo not found in:\s+\[\]"
       assert Enum.find(exception.stacktrace.frames, &(&1.function =~ "Keyword.fetch!/2"))
     end
 


### PR DESCRIPTION
Hi 👋 

Elixir 1.19 will [change](https://github.com/elixir-lang/elixir/pull/14380) how log translation works. Instead of replacing structured reports elixir will inject string translation into the report and wrap the `report_cb` callback. This enables logging libraries like Sentry to access report data directly instead of parsing iodata like they do now. But it also breaks the parsing. 

This PR introduces a bare minimum change to make Sentry work with the new translations – whenever we detect a report with `elixir_translation` key, we replace the report with the translation, effectively restoring pre-1.19 behaviour.

Feel free to close this PR and replace it with a more sophisticated solution that takes advantage of the new structure 🙏 