### PR TITLE
Fix regexes on Erlang/OTP 28

### DIFF
--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -374,7 +374,6 @@ defmodule Sentry.Config do
       type:
         {:list,
          {:custom, __MODULE__, :__validate_struct__, [:source_code_exclude_patterns, Regex]}},
-      default: [~r"/_build/", ~r"/deps/", ~r"/priv/", ~r"/test/"],
       type_doc: "list of `t:Regex.t/0`",
       doc: """
       A list of regular expressions used to determine which files to

--- a/lib/sentry/sources.ex
+++ b/lib/sentry/sources.ex
@@ -105,7 +105,13 @@ defmodule Sentry.Sources do
     config = Sentry.Config.validate!(config)
 
     path_pattern = Keyword.fetch!(config, :source_code_path_pattern)
-    exclude_patterns = Keyword.fetch!(config, :source_code_exclude_patterns)
+
+    exclude_patterns =
+      Keyword.get(
+        config,
+        :source_code_exclude_patterns,
+        [~r"/_build/", ~r"/deps/", ~r"/priv/", ~r"/test/"]
+      )
 
     config
     |> Keyword.fetch!(:root_source_code_paths)

--- a/test/sentry/config_test.exs
+++ b/test/sentry/config_test.exs
@@ -93,15 +93,11 @@ defmodule Sentry.ConfigTest do
     end
 
     test ":source_code_exclude_patterns" do
-      assert Config.validate!(source_code_exclude_patterns: [])[:source_code_exclude_patterns] ==
-               []
+      assert Config.validate!([])[:source_code_exclude_patterns] == nil
 
-      assert Config.validate!([])[:source_code_exclude_patterns] == [
-               ~r"/_build/",
-               ~r"/deps/",
-               ~r"/priv/",
-               ~r"/test/"
-             ]
+      regex = ~r/foo/
+      config = [source_code_exclude_patterns: [regex]]
+      assert Config.validate!(config)[:source_code_exclude_patterns] == [regex]
 
       message = ~r/invalid list in :source_code_exclude_patterns option/
 


### PR DESCRIPTION
Regexes cannot be part of module bodies in Erlang/OTP 28, so this PR adjusts the repository accordingly.

A new release with this fix would be appreciated, since Erlang/OTP 28 has just been released. :)