### PR TITLE
Add OTP 28 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,12 +25,12 @@ jobs:
           - elixir: '1.18.4-otp-27'
             otp: '28.0'
             lint: true
-            dialyzer: true
             os: ubuntu-latest
 
           - elixir: '1.18'
             otp: '27.2'
             lint: true
+            dialyzer: true
             os: ubuntu-latest
 
           # One version before the last supported one.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,10 +22,15 @@ jobs:
         # https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
         include:
           # Newest supported Elixir/Erlang pair.
+          - elixir: '1.18.4'
+            otp: '28.0'
+            lint: true
+            dialyzer: true
+            os: ubuntu-latest
+
           - elixir: '1.18'
             otp: '27.2'
             lint: true
-            dialyzer: true
             os: ubuntu-latest
 
           # One version before the last supported one.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         # https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
         include:
           # Newest supported Elixir/Erlang pair.
-          - elixir: '1.18.4'
+          - elixir: '1.18.4-otp-27'
             otp: '28.0'
             lint: true
             dialyzer: true


### PR DESCRIPTION
Using 1.18.4-otp-27 + OTP-28 for now as there's no Elixir precompiled for 28 just yet in the GHA that we use.

#skip-changelog