### PR TITLE
Fix flaky logger test

### DIFF
--- a/test/sentry/client_test.exs
+++ b/test/sentry/client_test.exs
@@ -388,7 +388,7 @@ defmodule Sentry.ClientTest do
 
       event =
         fn ->
-          assert_receive {^ref, body}, 1000
+          assert_receive {^ref, body}, 5000
           assert [{%{"type" => "event"}, event}] = decode_envelope!(body)
           event
         end

--- a/test/sentry/logger_handler_test.exs
+++ b/test/sentry/logger_handler_test.exs
@@ -64,7 +64,7 @@ defmodule Sentry.LoggerHandlerTest do
 
     {:ok, _task_pid} = Task.start(fn -> raise "oops" end)
 
-    assert_receive {^ref, event}
+    assert_receive {^ref, event}, 5000
 
     assert event.user.user_id == 3
     assert event.extra.day_of_week == "Friday"


### PR DESCRIPTION
This just adds a couple of timeouts for `assert_receive` to reduce the risk of random test failures.

Closes #896 

#skip-changelog