### PR TITLE
Don't use local function capture for Telemetry handler

### DIFF
--- a/lib/sentry/integrations/telemetry.ex
+++ b/lib/sentry/integrations/telemetry.ex
@@ -16,7 +16,7 @@ defmodule Sentry.Integrations.Telemetry do
       :telemetry.attach(
         "#{inspect(__MODULE__)}-telemetry-failures",
         @failure_event,
-        &handle_event/4,
+        &__MODULE__.handle_event/4,
         :no_config
       )
 


### PR DESCRIPTION
When the integration enabled on app start it throws the message:

> The function passed as a handler with ID "Sentry.Integrations.Telemetry-telemetry-failures" is a local function.
This means that it is either an anonymous function or a capture of a function without a module specified. That may cause a performance penalty when calling that handler. For more details see the note in `telemetry:attach/4` documentation.