### PR TITLE
handle nil drop list in otel sampler

### DIFF
--- a/lib/sentry/opentelemetry/sampler.ex
+++ b/lib/sentry/opentelemetry/sampler.ex
@@ -35,7 +35,7 @@ if Code.ensure_loaded?(:otel_sampler) do
           config
         ) do
       result =
-        if span_name in config[:drop] do
+        if config[:drop] && span_name in config[:drop] do
           {:drop, [], []}
         else
           traces_sampler = Sentry.Config.traces_sampler()

--- a/test/sentry/opentelemetry/sampler_test.exs
+++ b/test/sentry/opentelemetry/sampler_test.exs
@@ -50,6 +50,26 @@ defmodule Sentry.Opentelemetry.SamplerTest do
       assert {"sentry-sample_rate", "1.0"} in tracestate
       assert {"sentry-sampled", "true"} in tracestate
     end
+
+    test "records and samples spans when drop list is nil" do
+      put_test_config(traces_sample_rate: 1.0)
+      test_ctx = create_test_span_context()
+
+      assert {:record_and_sample, [], tracestate} =
+               Sampler.should_sample(
+                 test_ctx,
+                 123,
+                 nil,
+                 "Elixir.Oban.Worker process",
+                 nil,
+                 nil,
+                 []
+               )
+
+      assert is_list(tracestate)
+      assert {"sentry-sample_rate", "1.0"} in tracestate
+      assert {"sentry-sampled", "true"} in tracestate
+    end
   end
 
   describe "sampling based on traces_sample_rate" do


### PR DESCRIPTION
I'm not completely sure if there's another root issue at play here, but I updated my codebase to use 11.0.0 and set up the configuration to start sending traces to Sentry, and got the following error reported to Sentry:

```
Protocol.UndefinedError: protocol Enumerable not implemented for nil of type Atom. This protocol is implemented for the following type(s): DBConnection.PrepareStream, DBConnection.Stream, Date.Range, Ecto.Adapters.SQL.Stream, File.Stream, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, Jason.OrderedObject, List, Map, MapSet, Phoenix.LiveView.LiveStream, Postgrex.Stream, Range, Req.Response.Async, Stream
  File "lib/enum.ex", line 1, in Enumerable.impl_for!/1
  File "lib/enum.ex", line 194, in Enumerable.member?/2
  File "lib/enum.ex", line 2009, in Enum.member?/2
  File "lib/sentry/opentelemetry/sampler.ex", line 38, in Sentry.OpenTelemetry.Sampler.should_sample/7
  File "/app/deps/opentelemetry/src/otel_sampler.erl", line 129, in :otel_sampler.should_sample/7
  File "/app/deps/opentelemetry/src/otel_span_utils.erl", line 118, in :otel_span_utils.sample/7
  File "/app/deps/opentelemetry/src/otel_span_utils.erl", line 59, in :otel_span_utils.new_span/9
  File "/app/deps/opentelemetry/src/otel_span_ets.erl", line 61, in :otel_span_ets.start_span/7
```

I believe this will fix the problem. I'm having a hard time finding any documentation of what the configuration given to the sampler should look like (the official type for it is just `term()`) so I don't think we can rely on it being an enumerable with the `:drop` key. Please let me know if I'm wrong on that though!