### PR TITLE
Improve Event callback docs

### DIFF
--- a/lib/sentry.ex
+++ b/lib/sentry.ex
@@ -124,16 +124,18 @@ defmodule Sentry do
 
       config :sentry,
         before_send: {MyModule, :before_send},
-        after_send_event: {MyModule, :after_send}
+        after_send_event: {MyModule, :after_send_event}
 
   `MyModule` could look like this:
 
       defmodule MyModule do
+        @spec before_send(Sentry.Event.t()) :: Sentry.Event.t()
         def before_send(event) do
           metadata = Map.new(Logger.metadata())
           %Sentry.Event{event | extra: Map.merge(event.extra, metadata)}
         end
 
+        @spec after_send_event(Sentry.Event.t(), {:ok, String.t()} | {:error, any()}) :: any()
         def after_send_event(event, result) do
           case result do
             {:ok, id} ->
@@ -144,6 +146,8 @@ defmodule Sentry do
           end
         end
       end
+
+  If the `before_send` callback returns `nil` or `false`, the event is not reported.
 
   ## Reporting Source Code
 

--- a/lib/sentry.ex
+++ b/lib/sentry.ex
@@ -124,7 +124,7 @@ defmodule Sentry do
 
       config :sentry,
         before_send: {MyModule, :before_send},
-        after_send_event: {MyModule, :after_send_event}
+        after_send_event: {MyModule, :after_send}
 
   `MyModule` could look like this:
 
@@ -135,8 +135,8 @@ defmodule Sentry do
           %Sentry.Event{event | extra: Map.merge(event.extra, metadata)}
         end
 
-        @spec after_send_event(Sentry.Event.t(), {:ok, String.t()} | {:error, any()}) :: any()
-        def after_send_event(event, result) do
+        @spec after_send(Sentry.Event.t(), {:ok, String.t()} | {:error, any()}) :: any()
+        def after_send(event, result) do
           case result do
             {:ok, id} ->
               Logger.info("Successfully sent event!")


### PR DESCRIPTION
Changing a few things there:
- typo in function name (`after_send` is not a function)
- Adding a note about how to stop Sentry from reporting event. `Filtering Exceptions` section says: 

> If you would like to prevent Sentry from sending certain exceptions, you can use the `:before_send` configuration option. See the [*Event Callbacks* section](#module-event-callbacks) below.

But in the Event Callbacks section it does not say a word on how to filter those.

- Adding a type spec for a bit easier investigation into how to test it. I had to look into the code of this actual repo to understand this and previous point. Now it should be a bit more obvious.

#skip-changelog