### PR TITLE
Filter out empty db.url from span's attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Deeply nested spans are handled now when building up traces in `SpanProcessor` ([#924](https://github.com/getsentry/sentry-elixir/pull/924))
 
+#### Various improvements
+
+- Span's attributes no longer include `db.url: "ecto:"` entries as they are now filtered out ([#925](https://github.com/getsentry/sentry-elixir/pull/925))
+
 ## 11.0.1
 
 #### Various improvements

--- a/test_integrations/phoenix_app/test/phoenix_app/repo_test.exs
+++ b/test_integrations/phoenix_app/test/phoenix_app/repo_test.exs
@@ -21,8 +21,17 @@ defmodule PhoenixApp.RepoTest do
     assert [transaction] = transactions
 
     assert transaction.transaction_info == %{source: :custom}
+
     assert transaction.contexts.trace.op == "db"
-    assert String.starts_with?(transaction.contexts.trace.description, "SELECT")
+
     assert transaction.contexts.trace.data["db.system"] == :sqlite
+    assert transaction.contexts.trace.data["db.type"] == :sql
+    assert transaction.contexts.trace.data["db.instance"] == "db/test.sqlite3"
+    assert transaction.contexts.trace.data["db.name"] == "db/test.sqlite3"
+
+    assert String.starts_with?(transaction.contexts.trace.description, "SELECT")
+    assert String.starts_with?(transaction.contexts.trace.data["db.statement"], "SELECT")
+
+    refute Map.has_key?(transaction.contexts.trace.data, "db.url")
   end
 end


### PR DESCRIPTION
Previously we'd include `"ecto:"` in the attributes as it was a non-empty value but it is not a useful piece of information so it's better to filter it out.