### PR TITLE
Fix safe JSON encoding of improper lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 11.0.4
+
+### Bug fixes
+
+- Correctly sanitize improper lists in Sentry context (attached to any event).
+
 ## 11.0.3
 
 #### Various improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 11.0.4
+## Unreleased
 
-### Bug fixes
-
-- Correctly sanitize improper lists in Sentry context (attached to any event).
+- Fix safe JSON encoding of improper lists ([#938](https://github.com/getsentry/sentry-elixir/pull/938))
 
 ## 11.0.3
 

--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -361,18 +361,22 @@ defmodule Sentry.Client do
   end
 
   defp sanitize_non_jsonable_value(value, json_library) when is_list(value) do
-    {mapped, changed?} =
-      Enum.map_reduce(value, _changed? = false, fn value, changed? ->
-        case sanitize_non_jsonable_value(value, json_library) do
-          :unchanged -> {value, changed?}
-          {:changed, value} -> {value, true}
-        end
-      end)
-
-    if changed? do
-      {:changed, mapped}
+    if List.improper?(value) do
+      {:changed, inspect(value)}
     else
-      :unchanged
+      {mapped, changed?} =
+        Enum.map_reduce(value, _changed? = false, fn value, changed? ->
+          case sanitize_non_jsonable_value(value, json_library) do
+            :unchanged -> {value, changed?}
+            {:changed, value} -> {value, true}
+          end
+        end)
+
+      if changed? do
+        {:changed, mapped}
+      else
+        :unchanged
+      end
     end
   end
 

--- a/test/sentry/client_test.exs
+++ b/test/sentry/client_test.exs
@@ -61,7 +61,8 @@ defmodule Sentry.ClientTest do
             bool: true,
             null: nil,
             int: 2,
-            map: %{bool: false}
+            map: %{bool: false},
+            improper_list: [1 | 2]
           },
           user: %{id: "valid-ID", email: {"user", "@example.com"}},
           tags: %{valid: "yes", tokens: MapSet.new([1])},
@@ -78,6 +79,7 @@ defmodule Sentry.ClientTest do
       assert rendered.extra.null == nil
       assert rendered.extra.int == 2
       assert rendered.extra.map.bool == false
+      assert rendered.extra.improper_list == "[1 | 2]"
 
       assert rendered.user.id == "valid-ID"
       assert rendered.user.email == ~s({"user", "@example.com"})


### PR DESCRIPTION
Saw it in production in one of our services:

<img width="1348" height="1918" alt="CleanShot 2025-09-15 at 10 23 54@2x" src="https://github.com/user-attachments/assets/dab80e96-a29b-4b98-b1a2-a8b0364d84d6" />
