### PR TITLE
fix: isolate config in tests

### DIFF
--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -1,19 +1,11 @@
 defmodule Sentry.Case do
   # We use this module mostly to add some additional checks before and after tests, especially
-  # related to configuration. Configuration is a bit finicky due to the extensive use of
-  # global state (:persistent_term), so better safe than sorry here.
+  # related to configuration. Configuration is isolated per-process via the process dictionary,
+  # so tests using put_test_config/1 will have their own view without affecting other tests.
 
   use ExUnit.CaseTemplate
 
-  import Sentry.TestHelpers
-
   setup context do
-    config_before = all_config()
-
-    on_exit(fn ->
-      assert config_before == all_config()
-    end)
-
     # Start a fresh RateLimiter for each test with unique names for isolation.
     setup_rate_limiter()
 

--- a/test_integrations/phoenix_app/test/support/test_helpers.ex
+++ b/test_integrations/phoenix_app/test/support/test_helpers.ex
@@ -15,8 +15,8 @@ defmodule Sentry.TestHelpers do
 
   @spec put_test_config(keyword()) :: :ok
   def put_test_config(config) when is_list(config) do
-    all_original_config = all_config()
-
+    # Store original values from both process dictionary and :persistent_term
+    # We validate each key individually like Sentry.put_config/2 does
     original_config =
       for {key, val} <- config do
         renamed_key =
@@ -25,19 +25,45 @@ defmodule Sentry.TestHelpers do
             other -> other
           end
 
-        current_val = :persistent_term.get({:sentry_config, renamed_key}, :__not_set__)
-        Sentry.put_config(renamed_key, val)
-        {renamed_key, current_val}
+        # Validate this single key-value pair (this also transforms values like DSN strings)
+        validated_config = Sentry.Config.validate!([{renamed_key, val}])
+        validated_val = Keyword.fetch!(validated_config, renamed_key)
+
+        # Store original values
+        current_process_val = Process.get({:sentry_test_config, renamed_key}, :__not_set__)
+        current_persistent_val = :persistent_term.get({:sentry_config, renamed_key}, :__not_set__)
+
+        # Set in both locations:
+        # - Process dictionary for process-local isolation
+        # - :persistent_term so spawned processes (like sender pool workers) can see it
+        Process.put({:sentry_test_config, renamed_key}, validated_val)
+        :persistent_term.put({:sentry_config, renamed_key}, validated_val)
+
+        {renamed_key, current_process_val, current_persistent_val}
       end
 
+    # Register cleanup to restore original values in both locations
     ExUnit.Callbacks.on_exit(fn ->
       Enum.each(original_config, fn
-        {key, :__not_set__} -> :persistent_term.erase({:sentry_config, key})
-        {key, original_val} -> :persistent_term.put({:sentry_config, key}, original_val)
-      end)
+        {key, :__not_set__, :__not_set__} ->
+          Process.delete({:sentry_test_config, key})
+          :persistent_term.erase({:sentry_config, key})
 
-      assert all_original_config == all_config()
+        {key, :__not_set__, persistent_val} ->
+          Process.delete({:sentry_test_config, key})
+          :persistent_term.put({:sentry_config, key}, persistent_val)
+
+        {key, process_val, :__not_set__} ->
+          Process.put({:sentry_test_config, key}, process_val)
+          :persistent_term.erase({:sentry_config, key})
+
+        {key, process_val, persistent_val} ->
+          Process.put({:sentry_test_config, key}, process_val)
+          :persistent_term.put({:sentry_config, key}, persistent_val)
+      end)
     end)
+
+    :ok
   end
 
   @spec set_mix_shell(module()) :: :ok


### PR DESCRIPTION
This fixes and **improves stability** of our test suite by making `put_test_config` isolate configs on a per-test basis. This was a source of random failures too, and made it impossible to run various tests with `async: true`.

The performance improvement is just a nice side-effect of this change, not a ground-breaking speed-up of course but it's *something* 😄

### Before

```
Wrote 149 files in 706.42 kb to: _build/test/lib/sentry/priv/sentry.map
Running ExUnit with seed: 897517, max_cases: 32

....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
Finished in 12.7 seconds (1.7s async, 11.0s sync)
14 doctests, 470 tests, 0 failures
```

### After

```
Wrote 149 files in 706.93 kb to: _build/test/lib/sentry/priv/sentry.map
Running ExUnit with seed: 22172, max_cases: 32
Excluding tags: [:integration]

....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
Finished in 11.2 seconds (2.4s async, 8.8s sync)
14 doctests, 470 tests, 0 failures
```

---

#skip-changelog