### PR TITLE
chore: ignore local Claude settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ test_integrations/phoenix_app/db
 test_integrations/*/_build
 test_integrations/*/deps
 test_integrations/*/test-results/
+
+# Local Claude Code settings that should not be committed
+.claude/settings.local.json


### PR DESCRIPTION
Ignore .claude/settings.local.json as these are local settings not intended for version control.

#skip-changelog