### PR TITLE
fix(oban): Handle @reboot cron schedule with timezone

### DIFF
--- a/test/sentry/integrations/oban/cron_test.exs
+++ b/test/sentry/integrations/oban/cron_test.exs
@@ -48,6 +48,19 @@ defmodule Sentry.Integrations.Oban.CronTest do
       })
     end
 
+    test "ignores #{event_type} events with a cron expr of @reboot even with timezone", %{
+      bypass: bypass
+    } do
+      Bypass.down(bypass)
+
+      :telemetry.execute([:oban, :job, unquote(event_type)], %{}, %{
+        job: %Oban.Job{
+          worker: "Sentry.MyWorker",
+          meta: %{"cron" => true, "cron_expr" => "@reboot", "cron_tz" => "Etc/UTC"}
+        }
+      })
+    end
+
     test "ignores #{event_type} events with a cron expr that is not a string", %{bypass: bypass} do
       Bypass.down(bypass)
 


### PR DESCRIPTION
Previously, Oban jobs using the @reboot schedule with a timezone set would crash the telemetry handler with a {badkey, schedule} error. This happened because:

1. @reboot correctly returns an empty schedule (can't be expressed as cron/interval)
2. The timezone was still being added to monitor_config
3. CheckIn.new/1 crashed trying to access the missing :schedule key

### Description
The fix checks for an empty schedule first and returns nil (skipping check-in) before adding timezone or other monitor config options. This ensures @reboot jobs are gracefully skipped from Sentry cron monitoring, since they cannot be represented as a scheduled monitor.




#### Issues
* resolves: #934 
* resolves: ELIXIR-30


#### Reminders
- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-elixir/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)