### PR TITLE
fix(config): Only warn about deprecated hackney options when explicitly configured

### DIFF
--- a/test/sentry/config_test.exs
+++ b/test/sentry/config_test.exs
@@ -255,6 +255,40 @@ defmodule Sentry.ConfigTest do
         Config.validate!(before_send_log: :not_a_function)
       end
     end
+
+    test "deprecated hackney options do not warn when not explicitly configured" do
+      output =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          # Only configure non-hackney options
+          Config.validate!(dsn: "https://public:secret@app.getsentry.com/1")
+        end)
+
+      refute output =~ "hackney"
+    end
+
+    test "deprecated hackney options warn when explicitly configured" do
+      output =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          Config.validate!(hackney_opts: [pool: :my_pool])
+        end)
+
+      assert output =~ ":hackney_opts option is deprecated"
+      assert output =~ "Use Finch as the default HTTP client instead"
+
+      output =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          Config.validate!(hackney_pool_timeout: 10_000)
+        end)
+
+      assert output =~ ":hackney_pool_timeout option is deprecated"
+
+      output =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          Config.validate!(hackney_pool_max_connections: 100)
+        end)
+
+      assert output =~ ":hackney_pool_max_connections option is deprecated"
+    end
   end
 
   describe "put_config/2" do


### PR DESCRIPTION
## Summary

- Remove the `deprecated:` directive from hackney options in NimbleOptions schema
- Handle deprecation warnings manually, only when users explicitly configure hackney options
- Skip warnings when using default values with the Finch client

## Test plan

- [x] All existing tests pass (523 tests, 0 failures)
- [x] Config tests specifically pass (23 tests)

Fixes #984

🤖 Generated with [Claude Code](https://claude.ai/code)

#skip-changelog