### PR TITLE
Add :check_in events to Telemetry Processor

### DIFF
--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -495,26 +495,24 @@ defmodule Sentry.Config do
       """
     ],
     telemetry_buffer_capacities: [
-      type: {:map, {:in, [:log]}, :pos_integer},
+      type: {:map, {:in, [:error, :check_in, :log]}, :pos_integer},
       default: %{},
       type_doc: "`%{category => pos_integer()}`",
       doc: """
       Overrides for the maximum number of items each telemetry buffer can hold.
       When a buffer reaches capacity, oldest items are dropped to make room.
-      Currently only the `:log` category is managed by the TelemetryProcessor.
-      Default: log=1000.
+      Default: error=100, check_in=100, log=1000.
       *Available since v12.0.0*.
       """
     ],
     telemetry_scheduler_weights: [
-      type: {:map, {:in, [:low]}, :pos_integer},
+      type: {:map, {:in, [:critical, :high, :low]}, :pos_integer},
       default: %{},
       type_doc: "`%{priority => pos_integer()}`",
       doc: """
       Overrides for the weighted round-robin scheduler priority weights.
       Higher weights mean more sending slots for that priority level.
-      Currently only the `:low` priority (logs) is managed by the TelemetryProcessor.
-      Default: low=2.
+      Default: critical=5, high=4, low=2.
       *Available since v12.0.0*.
       """
     ],

--- a/lib/sentry/telemetry/category.ex
+++ b/lib/sentry/telemetry/category.ex
@@ -8,21 +8,23 @@ defmodule Sentry.Telemetry.Category do
   ## Categories
 
     * `:error` - Error events (critical priority)
+    * `:check_in` - Cron check-ins (high priority)
     * `:log` - Log entries (low priority)
 
   ## Priorities and Weights
 
     * `:critical` - weight 5 (errors)
+    * `:high` - weight 4 (check-ins)
     * `:low` - weight 2 (logs)
 
   """
   @moduledoc since: "12.0.0"
 
   @typedoc "Telemetry category types."
-  @type t :: :error | :log
+  @type t :: :error | :check_in | :log
 
   @typedoc "Priority levels for categories."
-  @type priority :: :critical | :low
+  @type priority :: :critical | :high | :low
 
   @typedoc "Buffer configuration for a category."
   @type config :: %{
@@ -31,16 +33,18 @@ defmodule Sentry.Telemetry.Category do
           timeout: pos_integer() | nil
         }
 
-  @priorities [:critical, :low]
-  @categories [:error, :log]
+  @priorities [:critical, :high, :low]
+  @categories [:error, :check_in, :log]
 
   @weights %{
     critical: 5,
+    high: 4,
     low: 2
   }
 
   @default_configs %{
     error: %{capacity: 100, batch_size: 1, timeout: nil},
+    check_in: %{capacity: 100, batch_size: 1, timeout: nil},
     log: %{capacity: 1000, batch_size: 100, timeout: 5000}
   }
 
@@ -52,12 +56,16 @@ defmodule Sentry.Telemetry.Category do
       iex> Sentry.Telemetry.Category.priority(:error)
       :critical
 
+      iex> Sentry.Telemetry.Category.priority(:check_in)
+      :high
+
       iex> Sentry.Telemetry.Category.priority(:log)
       :low
 
   """
   @spec priority(t()) :: priority()
   def priority(:error), do: :critical
+  def priority(:check_in), do: :high
   def priority(:log), do: :low
 
   @doc """
@@ -66,6 +74,9 @@ defmodule Sentry.Telemetry.Category do
   Weights determine how many slots each priority gets in the round-robin cycle.
 
   ## Examples
+
+      iex> Sentry.Telemetry.Category.weight(:high)
+      4
 
       iex> Sentry.Telemetry.Category.weight(:low)
       2
@@ -90,6 +101,9 @@ defmodule Sentry.Telemetry.Category do
       iex> Sentry.Telemetry.Category.default_config(:error)
       %{capacity: 100, batch_size: 1, timeout: nil}
 
+      iex> Sentry.Telemetry.Category.default_config(:check_in)
+      %{capacity: 100, batch_size: 1, timeout: nil}
+
       iex> Sentry.Telemetry.Category.default_config(:log)
       %{capacity: 1000, batch_size: 100, timeout: 5000}
 
@@ -105,7 +119,7 @@ defmodule Sentry.Telemetry.Category do
   ## Examples
 
       iex> Sentry.Telemetry.Category.all()
-      [:error, :log]
+      [:error, :check_in, :log]
 
   """
   @spec all() :: [t()]
@@ -117,7 +131,7 @@ defmodule Sentry.Telemetry.Category do
   ## Examples
 
       iex> Sentry.Telemetry.Category.priorities()
-      [:critical, :low]
+      [:critical, :high, :low]
 
   """
   @spec priorities() :: [priority()]

--- a/test/sentry/telemetry/scheduler_test.exs
+++ b/test/sentry/telemetry/scheduler_test.exs
@@ -19,17 +19,17 @@ defmodule Sentry.Telemetry.SchedulerTest do
     test "builds cycle with correct weights for all categories" do
       cycle = Scheduler.build_priority_cycle()
 
-      # Default weights: critical=5, low=2
-      assert length(cycle) == 7
-      assert Enum.frequencies(cycle) == %{error: 5, log: 2}
+      # Default weights: critical=5, high=4, low=2
+      assert length(cycle) == 11
+      assert Enum.frequencies(cycle) == %{error: 5, check_in: 4, log: 2}
     end
 
     test "builds cycle with custom weights" do
       custom_weights = %{low: 5}
       cycle = Scheduler.build_priority_cycle(custom_weights)
 
-      assert length(cycle) == 10
-      assert Enum.frequencies(cycle) == %{error: 5, log: 5}
+      assert length(cycle) == 14
+      assert Enum.frequencies(cycle) == %{error: 5, check_in: 4, log: 5}
     end
   end
 

--- a/test/sentry/telemetry_processor_test.exs
+++ b/test/sentry/telemetry_processor_test.exs
@@ -19,8 +19,8 @@ defmodule Sentry.TelemetryProcessorTest do
       assert Process.alive?(pid)
 
       children = Supervisor.which_children(pid)
-      # 2 buffers (error, log) + Scheduler = 3
-      assert length(children) == 3
+      # 3 buffers (error, check_in, log) + Scheduler = 4
+      assert length(children) == 4
 
       Supervisor.stop(pid)
     end


### PR DESCRIPTION
This adds support for `:check_in` category to `TelemetryProcessor` as an opt-in feature via `telemetry_processor_categories` configuration.

--

#skip-changelog