### PR TITLE
Add :transaction events to Telemetry Processor

### DIFF
--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -271,7 +271,12 @@ defmodule Sentry.Client do
         {:ok, ""}
 
       :not_collecting ->
-        :ok = Transport.Sender.send_async(client, transaction)
+        if Config.telemetry_processor_category?(:transaction) do
+          :ok = TelemetryProcessor.add(transaction)
+        else
+          :ok = Transport.Sender.send_async(client, transaction)
+        end
+
         {:ok, ""}
     end
   end

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -495,24 +495,24 @@ defmodule Sentry.Config do
       """
     ],
     telemetry_buffer_capacities: [
-      type: {:map, {:in, [:error, :check_in, :log]}, :pos_integer},
+      type: {:map, {:in, [:error, :check_in, :transaction, :log]}, :pos_integer},
       default: %{},
       type_doc: "`%{category => pos_integer()}`",
       doc: """
       Overrides for the maximum number of items each telemetry buffer can hold.
       When a buffer reaches capacity, oldest items are dropped to make room.
-      Default: error=100, check_in=100, log=1000.
+      Default: error=100, check_in=100, transaction=1000, log=1000.
       *Available since v12.0.0*.
       """
     ],
     telemetry_scheduler_weights: [
-      type: {:map, {:in, [:critical, :high, :low]}, :pos_integer},
+      type: {:map, {:in, [:critical, :high, :medium, :low]}, :pos_integer},
       default: %{},
       type_doc: "`%{priority => pos_integer()}`",
       doc: """
       Overrides for the weighted round-robin scheduler priority weights.
       Higher weights mean more sending slots for that priority level.
-      Default: critical=5, high=4, low=2.
+      Default: critical=5, high=4, medium=3, low=2.
       *Available since v12.0.0*.
       """
     ],

--- a/lib/sentry/telemetry/category.ex
+++ b/lib/sentry/telemetry/category.ex
@@ -9,22 +9,24 @@ defmodule Sentry.Telemetry.Category do
 
     * `:error` - Error events (critical priority)
     * `:check_in` - Cron check-ins (high priority)
+    * `:transaction` - Performance transactions (medium priority)
     * `:log` - Log entries (low priority)
 
   ## Priorities and Weights
 
     * `:critical` - weight 5 (errors)
     * `:high` - weight 4 (check-ins)
+    * `:medium` - weight 3 (transactions)
     * `:low` - weight 2 (logs)
 
   """
   @moduledoc since: "12.0.0"
 
   @typedoc "Telemetry category types."
-  @type t :: :error | :check_in | :log
+  @type t :: :error | :check_in | :transaction | :log
 
   @typedoc "Priority levels for categories."
-  @type priority :: :critical | :high | :low
+  @type priority :: :critical | :high | :medium | :low
 
   @typedoc "Buffer configuration for a category."
   @type config :: %{
@@ -33,18 +35,20 @@ defmodule Sentry.Telemetry.Category do
           timeout: pos_integer() | nil
         }
 
-  @priorities [:critical, :high, :low]
-  @categories [:error, :check_in, :log]
+  @priorities [:critical, :high, :medium, :low]
+  @categories [:error, :check_in, :transaction, :log]
 
   @weights %{
     critical: 5,
     high: 4,
+    medium: 3,
     low: 2
   }
 
   @default_configs %{
     error: %{capacity: 100, batch_size: 1, timeout: nil},
     check_in: %{capacity: 100, batch_size: 1, timeout: nil},
+    transaction: %{capacity: 1000, batch_size: 1, timeout: nil},
     log: %{capacity: 1000, batch_size: 100, timeout: 5000}
   }
 
@@ -59,6 +63,9 @@ defmodule Sentry.Telemetry.Category do
       iex> Sentry.Telemetry.Category.priority(:check_in)
       :high
 
+      iex> Sentry.Telemetry.Category.priority(:transaction)
+      :medium
+
       iex> Sentry.Telemetry.Category.priority(:log)
       :low
 
@@ -66,6 +73,7 @@ defmodule Sentry.Telemetry.Category do
   @spec priority(t()) :: priority()
   def priority(:error), do: :critical
   def priority(:check_in), do: :high
+  def priority(:transaction), do: :medium
   def priority(:log), do: :low
 
   @doc """
@@ -77,6 +85,9 @@ defmodule Sentry.Telemetry.Category do
 
       iex> Sentry.Telemetry.Category.weight(:high)
       4
+
+      iex> Sentry.Telemetry.Category.weight(:medium)
+      3
 
       iex> Sentry.Telemetry.Category.weight(:low)
       2
@@ -104,6 +115,9 @@ defmodule Sentry.Telemetry.Category do
       iex> Sentry.Telemetry.Category.default_config(:check_in)
       %{capacity: 100, batch_size: 1, timeout: nil}
 
+      iex> Sentry.Telemetry.Category.default_config(:transaction)
+      %{capacity: 1000, batch_size: 1, timeout: nil}
+
       iex> Sentry.Telemetry.Category.default_config(:log)
       %{capacity: 1000, batch_size: 100, timeout: 5000}
 
@@ -119,7 +133,7 @@ defmodule Sentry.Telemetry.Category do
   ## Examples
 
       iex> Sentry.Telemetry.Category.all()
-      [:error, :check_in, :log]
+      [:error, :check_in, :transaction, :log]
 
   """
   @spec all() :: [t()]
@@ -131,7 +145,7 @@ defmodule Sentry.Telemetry.Category do
   ## Examples
 
       iex> Sentry.Telemetry.Category.priorities()
-      [:critical, :high, :low]
+      [:critical, :high, :medium, :low]
 
   """
   @spec priorities() :: [priority()]

--- a/test/sentry/telemetry/scheduler_test.exs
+++ b/test/sentry/telemetry/scheduler_test.exs
@@ -19,17 +19,17 @@ defmodule Sentry.Telemetry.SchedulerTest do
     test "builds cycle with correct weights for all categories" do
       cycle = Scheduler.build_priority_cycle()
 
-      # Default weights: critical=5, high=4, low=2
-      assert length(cycle) == 11
-      assert Enum.frequencies(cycle) == %{error: 5, check_in: 4, log: 2}
+      # Default weights: critical=5, high=4, medium=3, low=2
+      assert length(cycle) == 14
+      assert Enum.frequencies(cycle) == %{error: 5, check_in: 4, transaction: 3, log: 2}
     end
 
     test "builds cycle with custom weights" do
       custom_weights = %{low: 5}
       cycle = Scheduler.build_priority_cycle(custom_weights)
 
-      assert length(cycle) == 14
-      assert Enum.frequencies(cycle) == %{error: 5, check_in: 4, log: 5}
+      assert length(cycle) == 17
+      assert Enum.frequencies(cycle) == %{error: 5, check_in: 4, transaction: 3, log: 5}
     end
   end
 

--- a/test/sentry/telemetry_processor_test.exs
+++ b/test/sentry/telemetry_processor_test.exs
@@ -19,8 +19,8 @@ defmodule Sentry.TelemetryProcessorTest do
       assert Process.alive?(pid)
 
       children = Supervisor.which_children(pid)
-      # 3 buffers (error, check_in, log) + Scheduler = 4
-      assert length(children) == 4
+      # 4 buffers (error, check_in, transaction, log) + Scheduler = 5
+      assert length(children) == 5
 
       Supervisor.stop(pid)
     end


### PR DESCRIPTION
This adds support for `:transaction` category to `TelemetryProcessor` as an opt-in feature via `telemetry_processor_categories` configuration.

--

#skip-changelog