### PR TITLE
docs: fix :since docs in Finch client

### DIFF
--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -430,9 +430,9 @@ defmodule Sentry.Config do
       default: Sentry.FinchClient,
       doc: """
       A module that implements the `Sentry.HTTPClient`
-      behaviour. Defaults to `Sentry.FinchClient`, which uses
-      [Finch](https://github.com/sneako/finch) as the HTTP client.
-      *The default changed from Hackney to Finch in v10.11.0*.
+      behaviour. The default client uses
+      [Finch](https://github.com/sneako/finch) as the HTTP client;
+      this *changed from Hackney to Finch in v12.0.0*.
       """
     ],
     send_max_attempts: [

--- a/lib/sentry/finch_client.ex
+++ b/lib/sentry/finch_client.ex
@@ -14,7 +14,7 @@ defmodule Sentry.FinchClient do
   in the Finch documentation for details on the possible map values.
   [finch configuration options](https://hexdocs.pm/finch/Finch.html#start_link/1-pool-configuration-options)
   """
-  @moduledoc since: "10.11.0"
+  @moduledoc since: "12.0.0"
 
   @impl true
   def child_spec do


### PR DESCRIPTION
### Description

These `:since` docs are not correct, this has not been released yet.

#### Issues

n/a

#### Reminders
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-elixir/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)