### PR TITLE
fix(tp): skip sending if DSN is not set

### DIFF
--- a/lib/sentry/telemetry/scheduler.ex
+++ b/lib/sentry/telemetry/scheduler.ex
@@ -427,17 +427,23 @@ defmodule Sentry.Telemetry.Scheduler do
   end
 
   defp send_direct(envelope) do
-    client = Config.client()
-    request_retries = Application.get_env(:sentry, :request_retries, Transport.default_retries())
+    if Config.dsn() do
+      client = Config.client()
 
-    case Transport.encode_and_post_envelope(envelope, client, request_retries) do
-      {:ok, _id} ->
-        :ok
+      request_retries =
+        Application.get_env(:sentry, :request_retries, Transport.default_retries())
 
-      {:error, error} ->
-        Logger.warning("Sentry: failed to send envelope: #{Exception.message(error)}")
+      case Transport.encode_and_post_envelope(envelope, client, request_retries) do
+        {:ok, _id} ->
+          :ok
 
-        {:error, error}
+        {:error, error} ->
+          Logger.warning("Sentry: failed to send envelope: #{Exception.message(error)}")
+
+          {:error, error}
+      end
+    else
+      :ok
     end
   end
 
@@ -460,9 +466,16 @@ defmodule Sentry.Telemetry.Scheduler do
   end
 
   defp send(envelope) do
-    client = Config.client()
-    request_retries = Application.get_env(:sentry, :request_retries, Transport.default_retries())
-    Transport.encode_and_post_envelope(envelope, client, request_retries)
+    if Config.dsn() do
+      client = Config.client()
+
+      request_retries =
+        Application.get_env(:sentry, :request_retries, Transport.default_retries())
+
+      Transport.encode_and_post_envelope(envelope, client, request_retries)
+    else
+      :ok
+    end
   end
 
   defp wait_for_active(%{active_ref: nil} = state), do: state

--- a/test/sentry/application_test.exs
+++ b/test/sentry/application_test.exs
@@ -11,7 +11,7 @@ defmodule Sentry.ApplicationTest do
     end
 
     test "attaches :sentry_log_handler with defaults" do
-      restart_sentry_with(enable_logs: true)
+      restart_sentry_with(dsn: "https://public@sentry.example.com/1", enable_logs: true)
 
       assert {:ok, config} = :logger.get_handler_config(:sentry_log_handler)
       assert config.module == Sentry.LoggerHandler
@@ -21,21 +21,33 @@ defmodule Sentry.ApplicationTest do
     end
 
     test "respects logs.level config" do
-      restart_sentry_with(enable_logs: true, logs: [level: :warning])
+      restart_sentry_with(
+        dsn: "https://public@sentry.example.com/1",
+        enable_logs: true,
+        logs: [level: :warning]
+      )
 
       assert {:ok, _config} = :logger.get_handler_config(:sentry_log_handler)
       assert Sentry.Config.logs_level() == :warning
     end
 
     test "respects logs.excluded_domains config" do
-      restart_sentry_with(enable_logs: true, logs: [excluded_domains: [:cowboy, :ranch]])
+      restart_sentry_with(
+        dsn: "https://public@sentry.example.com/1",
+        enable_logs: true,
+        logs: [excluded_domains: [:cowboy, :ranch]]
+      )
 
       assert {:ok, _config} = :logger.get_handler_config(:sentry_log_handler)
       assert Sentry.Config.logs_excluded_domains() == [:cowboy, :ranch]
     end
 
     test "respects logs.metadata config" do
-      restart_sentry_with(enable_logs: true, logs: [metadata: [:request_id, :user_id]])
+      restart_sentry_with(
+        dsn: "https://public@sentry.example.com/1",
+        enable_logs: true,
+        logs: [metadata: [:request_id, :user_id]]
+      )
 
       assert {:ok, _config} = :logger.get_handler_config(:sentry_log_handler)
       assert Sentry.Config.logs_metadata() == [:request_id, :user_id]
@@ -49,10 +61,10 @@ defmodule Sentry.ApplicationTest do
     end
 
     test "removes auto-handler when enable_logs becomes false" do
-      restart_sentry_with(enable_logs: true)
+      restart_sentry_with(dsn: "https://public@sentry.example.com/1", enable_logs: true)
       assert {:ok, _} = :logger.get_handler_config(:sentry_log_handler)
 
-      restart_sentry_with(enable_logs: false)
+      restart_sentry_with(dsn: "https://public@sentry.example.com/1", enable_logs: false)
 
       assert {:error, {:not_found, :sentry_log_handler}} =
                :logger.get_handler_config(:sentry_log_handler)
@@ -70,7 +82,7 @@ defmodule Sentry.ApplicationTest do
         _ = :logger.remove_handler(existing_handler)
       end)
 
-      restart_sentry_with(enable_logs: true)
+      restart_sentry_with(dsn: "https://public@sentry.example.com/1", enable_logs: true)
 
       assert {:error, {:not_found, :sentry_log_handler}} =
                :logger.get_handler_config(:sentry_log_handler)
@@ -79,7 +91,7 @@ defmodule Sentry.ApplicationTest do
     end
 
     test "auto-handler captures logs to the buffer" do
-      restart_sentry_with(enable_logs: true)
+      restart_sentry_with(dsn: "https://public@sentry.example.com/1", enable_logs: true)
 
       assert {:ok, _} = :logger.get_handler_config(:sentry_log_handler)
 

--- a/test_integrations/phoenix_app/config/test.exs
+++ b/test_integrations/phoenix_app/config/test.exs
@@ -32,7 +32,7 @@ config :phoenix_live_view,
   enable_expensive_runtime_checks: true
 
 config :sentry,
-  dsn: nil,
+  dsn: "https://public@sentry.example.com/1",
   environment_name: :dev,
   enable_source_code_context: true,
   root_source_code_paths: [File.cwd!()],


### PR DESCRIPTION
Skip sending envelopes via Telemetry Processor if DSN is not set.

This must be refactored eventually so that it's handled consistently at the Client level, similarly to what we do in Ruby SDK.

For now this is good-enough to address the issue.