### PR TITLE
fix: Set release metadata for traces

### DIFF
--- a/lib/sentry/transaction.ex
+++ b/lib/sentry/transaction.ex
@@ -60,6 +60,7 @@ defmodule Sentry.Transaction do
             },
 
             # Optional
+            release: String.t(),
             environment: String.t(),
             transaction: String.t(),
             transaction_info: transaction_info(),
@@ -83,6 +84,7 @@ defmodule Sentry.Transaction do
                 :measurements,
                 :sdk,
                 :platform,
+                :release,
                 :environment,
                 :tags,
                 :data
@@ -94,6 +96,7 @@ defmodule Sentry.Transaction do
       __MODULE__,
       attrs
       |> Map.put(:event_id, UUID.uuid4_hex())
+      |> Map.put(:release, Config.release())
       |> Map.put(:environment, Config.environment_name())
       |> Map.put(:sdk, @sdk)
       |> Map.put(:platform, "elixir")

--- a/test/sentry_test.exs
+++ b/test/sentry_test.exs
@@ -345,6 +345,33 @@ defmodule SentryTest do
 
       assert_receive {:after_send, "test-transaction", "340"}
     end
+
+    test "includes release in transaction payload when configured", %{bypass: bypass} do
+      put_test_config(release: "1.9.123")
+
+      transaction =
+        create_transaction(%{
+          transaction: "transaction-with-release",
+          contexts: %{
+            trace: %{
+              trace_id: "trace-id",
+              span_id: "root-span"
+            }
+          }
+        })
+
+      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert [{_headers, transaction_body}] = decode_envelope!(body)
+
+        assert transaction_body["transaction"] == "transaction-with-release"
+        assert transaction_body["release"] == "1.9.123"
+
+        Plug.Conn.send_resp(conn, 200, ~s<{"id": "340"}>)
+      end)
+
+      assert {:ok, "340"} = Sentry.send_transaction(transaction)
+    end
   end
 
   describe "flush/1" do


### PR DESCRIPTION
### Description
Currently, this Elixir SDK sets `release` for errors and logs, but not traces. This change adds the release field to traces.

#### Issues
I did not file an issue since the PR seemed straightforward.
