### PR TITLE
feat(logs): support non-primitives in the attributes

### DIFF
--- a/lib/sentry/log_event.ex
+++ b/lib/sentry/log_event.ex
@@ -149,7 +149,7 @@ defmodule Sentry.LogEvent do
   # Positional parameters: %s placeholders
   defp interpolate_template(message, parameters) when is_list(parameters) do
     # Convert parameters to proper types for storage
-    processed_params = Enum.map(parameters, &stringify_parameter/1)
+    processed_params = Enum.map(parameters, &sanitize_attribute_value/1)
 
     # Interpolate %s placeholders
     body = interpolate_positional_placeholders(message, parameters)
@@ -166,7 +166,7 @@ defmodule Sentry.LogEvent do
     processed_params =
       Enum.map(keys, fn key ->
         value = Map.get(parameters, key) || Map.get(parameters, to_string(key))
-        stringify_parameter(value)
+        sanitize_attribute_value(value)
       end)
 
     # Interpolate %{key} placeholders
@@ -209,14 +209,18 @@ defmodule Sentry.LogEvent do
   defp to_string_for_interpolation(value) when is_float(value), do: Float.to_string(value)
   defp to_string_for_interpolation(value), do: inspect(value)
 
-  # Convert parameter values to a form suitable for Sentry attributes
+  # Converts values to JSON-safe attribute types.
+  # Primitives (string, boolean, integer, float) pass through unchanged.
+  # Atoms are converted to strings. All other types (structs, maps, lists,
+  # tuples, PIDs, etc.) are converted to their inspect() representation.
+  # Used for both message template parameters and user-provided attributes.
   # Note: is_boolean must come before is_atom since true/false are atoms
-  defp stringify_parameter(value) when is_binary(value), do: value
-  defp stringify_parameter(value) when is_boolean(value), do: value
-  defp stringify_parameter(value) when is_atom(value), do: Atom.to_string(value)
-  defp stringify_parameter(value) when is_integer(value), do: value
-  defp stringify_parameter(value) when is_float(value), do: value
-  defp stringify_parameter(value), do: inspect(value)
+  defp sanitize_attribute_value(value) when is_binary(value), do: value
+  defp sanitize_attribute_value(value) when is_boolean(value), do: value
+  defp sanitize_attribute_value(value) when is_atom(value), do: Atom.to_string(value)
+  defp sanitize_attribute_value(value) when is_integer(value), do: value
+  defp sanitize_attribute_value(value) when is_float(value), do: value
+  defp sanitize_attribute_value(value), do: inspect(value)
 
   # Extract message body and optionally template/parameters
   # If user_params provided via metadata, use those for interpolation
@@ -248,7 +252,7 @@ defmodule Sentry.LogEvent do
        when is_list(format) and is_list(args) do
     body = format |> :io_lib.format(args) |> IO.chardata_to_string()
     template = IO.chardata_to_string(format)
-    processed_params = Enum.map(args, &stringify_parameter/1)
+    processed_params = Enum.map(args, &sanitize_attribute_value/1)
     {body, template, processed_params}
   end
 
@@ -270,10 +274,11 @@ defmodule Sentry.LogEvent do
   defp extract_trace_context(_log_event), do: {nil, nil}
 
   defp build_attributes(%__MODULE__{} = log_event) do
-    # Start with user-provided attributes
+    # Start with user-provided attributes, converting non-primitive values to strings
     formatted_attrs =
       Enum.into(log_event.attributes, %{}, fn {key, value} ->
-        {to_string(key), %{value: value, type: attribute_type(value)}}
+        safe_value = sanitize_attribute_value(value)
+        {to_string(key), %{value: safe_value, type: attribute_type(safe_value)}}
       end)
 
     # Add Sentry-specific attributes

--- a/test/sentry/log_event_test.exs
+++ b/test/sentry/log_event_test.exs
@@ -252,5 +252,108 @@ defmodule Sentry.LogEventTest do
       refute Map.has_key?(result.attributes, "sentry.message.template")
       refute Map.has_key?(result.attributes, "sentry.message.parameter.0")
     end
+
+    test "safely serializes struct attribute values" do
+      uri = URI.parse("https://example.com/path")
+
+      log_event = %LogEvent{
+        level: :info,
+        body: "test",
+        timestamp: 1_000_000.5,
+        attributes: %{uri: uri}
+      }
+
+      result = LogEvent.to_map(log_event)
+
+      assert result.attributes["uri"] == %{value: inspect(uri), type: "string"}
+    end
+
+    test "safely serializes map attribute values" do
+      log_event = %LogEvent{
+        level: :info,
+        body: "test",
+        timestamp: 1_000_000.5,
+        attributes: %{data: %{nested: "value"}}
+      }
+
+      result = LogEvent.to_map(log_event)
+
+      assert result.attributes["data"] == %{value: ~s(%{nested: "value"}), type: "string"}
+    end
+
+    test "safely serializes list attribute values" do
+      log_event = %LogEvent{
+        level: :info,
+        body: "test",
+        timestamp: 1_000_000.5,
+        attributes: %{items: [1, "two", :three]}
+      }
+
+      result = LogEvent.to_map(log_event)
+
+      assert result.attributes["items"] == %{value: ~s([1, "two", :three]), type: "string"}
+    end
+
+    test "safely serializes tuple attribute values" do
+      log_event = %LogEvent{
+        level: :info,
+        body: "test",
+        timestamp: 1_000_000.5,
+        attributes: %{pair: {:ok, "done"}}
+      }
+
+      result = LogEvent.to_map(log_event)
+
+      assert result.attributes["pair"] == %{value: ~s({:ok, "done"}), type: "string"}
+    end
+
+    test "safely serializes PID attribute values" do
+      pid = self()
+
+      log_event = %LogEvent{
+        level: :info,
+        body: "test",
+        timestamp: 1_000_000.5,
+        attributes: %{pid: pid}
+      }
+
+      result = LogEvent.to_map(log_event)
+
+      assert result.attributes["pid"] == %{value: inspect(pid), type: "string"}
+    end
+
+    test "converts atom attribute values to strings" do
+      log_event = %LogEvent{
+        level: :info,
+        body: "test",
+        timestamp: 1_000_000.5,
+        attributes: %{status: :active}
+      }
+
+      result = LogEvent.to_map(log_event)
+
+      assert result.attributes["status"] == %{value: "active", type: "string"}
+    end
+
+    test "preserves primitive attribute values unchanged" do
+      log_event = %LogEvent{
+        level: :info,
+        body: "test",
+        timestamp: 1_000_000.5,
+        attributes: %{
+          name: "Alice",
+          count: 42,
+          price: 9.99,
+          active: true
+        }
+      }
+
+      result = LogEvent.to_map(log_event)
+
+      assert result.attributes["name"] == %{value: "Alice", type: "string"}
+      assert result.attributes["count"] == %{value: 42, type: "integer"}
+      assert result.attributes["price"] == %{value: 9.99, type: "double"}
+      assert result.attributes["active"] == %{value: true, type: "boolean"}
+    end
   end
 end

--- a/test/sentry/logger_handler/logs_test.exs
+++ b/test/sentry/logger_handler/logs_test.exs
@@ -189,6 +189,40 @@ defmodule Sentry.LoggerHandler.LogsTest do
       assert_receive :envelope_sent, 1000
     end
 
+    test "safely serializes struct metadata as string attributes", %{bypass: bypass} do
+      test_pid = self()
+
+      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        [_header, _item_header, item_body, _] = String.split(body, "\n")
+
+        item_body_map = decode!(item_body)
+        assert %{"items" => [log_event]} = item_body_map
+
+        assert %{"my_uri" => %{"type" => "string", "value" => value}} =
+                 log_event["attributes"]
+
+        assert value == inspect(URI.parse("https://example.com/path"))
+
+        send(test_pid, :envelope_sent)
+
+        Plug.Conn.resp(conn, 200, ~s<{"id": "test-123"}>)
+      end)
+
+      put_test_config(logs: [metadata: [:my_uri]])
+
+      TelemetryProcessor.flush()
+
+      Logger.metadata(my_uri: URI.parse("https://example.com/path"))
+      Logger.info("Request with struct metadata")
+
+      assert_buffer_size(nil, 1)
+
+      TelemetryProcessor.flush()
+
+      assert_receive :envelope_sent, 1000
+    end
+
     test "includes all metadata when configured with :all" do
       put_test_config(logs: [metadata: :all])
 

--- a/test_integrations/phoenix_app/config/dev.exs
+++ b/test_integrations/phoenix_app/config/dev.exs
@@ -90,7 +90,11 @@ config :sentry,
   enable_source_code_context: true,
   send_result: :sync,
   traces_sample_rate: 1.0,
-  enable_logs: true
+  enable_logs: true,
+  logs: [
+    level: :info,
+    metadata: :all
+  ]
 
 config :phoenix_app, Oban,
   repo: PhoenixApp.Repo,

--- a/test_integrations/phoenix_app/lib/phoenix_app_web/controllers/page_controller.ex
+++ b/test_integrations/phoenix_app/lib/phoenix_app_web/controllers/page_controller.ex
@@ -91,6 +91,20 @@ defmodule PhoenixAppWeb.PageController do
   # 1. Start the Phoenix app: cd test_integrations/phoenix_app && iex -S mix phx.server
   # 2. Visit: http://localhost:4000/logs
   # 3. Check Sentry logs - they should have trace_id matching the transaction traces
+  def logs_with_structs(conn, _params) do
+    Logger.metadata(
+      uri: URI.parse("https://example.com/path"),
+      conn_info: %{method: conn.method, path: conn.request_path},
+      tags: [:web, :test]
+    )
+
+    Logger.info("Log with struct metadata")
+
+    Sentry.flush()
+
+    json(conn, %{message: "ok"})
+  end
+
   def logs_demo(conn, params) do
     request_id =
       get_req_header(conn, "x-request-id") |> List.first() || "demo-#{:rand.uniform(10000)}"

--- a/test_integrations/phoenix_app/lib/phoenix_app_web/router.ex
+++ b/test_integrations/phoenix_app/lib/phoenix_app_web/router.ex
@@ -34,6 +34,7 @@ defmodule PhoenixAppWeb.Router do
     get "/transaction", PageController, :transaction
     get "/nested-spans", PageController, :nested_spans
     get "/logs", PageController, :logs_demo
+    get "/logs-with-structs", PageController, :logs_with_structs
 
     live "/test-worker", TestWorkerLive
     live "/tracing-test", TracingTestLive

--- a/test_integrations/phoenix_app/test/phoenix_app_web/controllers/logs_test.exs
+++ b/test_integrations/phoenix_app/test/phoenix_app_web/controllers/logs_test.exs
@@ -104,6 +104,44 @@ defmodule Sentry.Integrations.Phoenix.LogsTest do
     end
   end
 
+  describe "structured logging with complex metadata" do
+    test "GET /logs-with-structs safely serializes struct attributes for JSON encoding", %{
+      conn: conn
+    } do
+      put_test_config(logs: [level: :info, excluded_domains: [:cowboy, :ranch], metadata: :all])
+
+      get(conn, ~p"/logs-with-structs")
+
+      logs = Sentry.Test.pop_sentry_logs()
+
+      struct_log =
+        Enum.find(logs, fn log ->
+          String.contains?(log.body, "Log with struct metadata")
+        end)
+
+      assert struct_log != nil
+
+      log_map = Sentry.LogEvent.to_map(struct_log)
+      attrs = log_map.attributes
+
+      assert %{type: "string", value: uri_value} = attrs["uri"]
+      assert uri_value == inspect(URI.parse("https://example.com/path"))
+
+      assert %{type: "string", value: conn_value} = attrs["conn_info"]
+      assert conn_value =~ "method"
+
+      assert %{type: "string", value: tags_value} = attrs["tags"]
+      assert tags_value == "[:web, :test]"
+
+      assert {:ok, json} = Sentry.JSON.encode(log_map, Sentry.Config.json_library())
+      assert is_binary(json)
+
+      assert {:ok, decoded} = Sentry.JSON.decode(json, Sentry.Config.json_library())
+      assert decoded["attributes"]["uri"]["value"] == uri_value
+      assert decoded["attributes"]["tags"]["value"] == "[:web, :test]"
+    end
+  end
+
   defp filter_app_logs(logs) do
     Enum.filter(logs, fn log ->
       body = log.body


### PR DESCRIPTION
Follow-up after https://github.com/getsentry/sentry-elixir/issues/886#issuecomment-4001701360

Please notice that [according to our docs](https://develop.sentry.dev/sdk/foundations/state-management/scopes/attributes/#attribute-object-structure) complex objects are not yet supported, hence we use `inspect`. This is what other SDKs are doing at the moment too.

## ⚠️ PII data

Given that this is based on `metadata` configuration provided by the user, it's the user's responsibility to ensure nothing will accidentally leak to Sentry.

This does follow our official guidelines. See https://develop.sentry.dev/sdk/getting-started/philosophy/#handle-pii-and-sensitive-data-with-care for more information.