### PR TITLE
refactor(tests): proper config isolation

### DIFF
--- a/lib/sentry/application.ex
+++ b/lib/sentry/application.ex
@@ -11,6 +11,7 @@ defmodule Sentry.Application do
   def start(_type, _opts) do
     config = Config.validate!()
     :ok = Config.persist(config)
+    :ok = Sentry.Test.Config.maybe_activate()
 
     Config.put_config(
       :in_app_module_allow_list,

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -1126,8 +1126,10 @@ defmodule Sentry.Config do
   defp resolve(:namespace), do: :default
 
   defp resolve(key) do
-    {mod, fun} = :persistent_term.get({:sentry_config, :namespace})
-    apply(mod, fun, [key])
+    case :persistent_term.get({:sentry_config, :namespace}, nil) do
+      {mod, fun} -> apply(mod, fun, [key])
+      nil -> :default
+    end
   end
 
   def __validate_path__(nil), do: {:ok, nil}

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -464,6 +464,23 @@ defmodule Sentry.Config do
 
       *Available since 12.0.0*.
       """
+    ],
+    namespace: [
+      type: {:custom, __MODULE__, :__validate_namespace__, []},
+      type_doc: "`{module(), atom()}`",
+      default: {Sentry.Config, :namespace},
+      doc: """
+      A `{module, function}` tuple that resolves scoped configuration overrides.
+      The function receives a config key and must return `{:ok, value}` to override
+      the global value, or `:default` to fall back to the global configuration.
+
+      The default resolver (`{Sentry.Config, :namespace}`) always returns `:default`,
+      meaning global configuration is used as-is.
+
+      When `test_mode: true` is enabled, the SDK automatically uses
+      `{Sentry.Test.Config, :namespace}` as the resolver to enable per-test
+      configuration isolation via `Sentry.Test.Config.put/1`.
+      """
     ]
   ]
 
@@ -1072,17 +1089,22 @@ defmodule Sentry.Config do
     Keyword.update!(config, :environment_name, &to_string/1)
   end
 
+  @doc false
+  @spec namespace() :: {module(), atom()}
+  def namespace, do: fetch!(:namespace)
+
+  @doc """
+  Default scope resolver. Always returns `:default`, meaning the global
+  configuration stored in `:persistent_term` is used.
+  """
+  @spec namespace(atom()) :: :default
+  def namespace(_), do: :default
+
   @compile {:inline, fetch!: 1}
   defp fetch!(key) do
-    # Check process dictionary first for test-specific config overrides.
-    # This allows tests to use put_test_config/1 for isolated configuration
-    # without affecting other tests, even when running async: true.
-    case Process.get({:sentry_test_config, key}, :__not_set__) do
-      :__not_set__ ->
-        :persistent_term.get({:sentry_config, key})
-
-      value ->
-        value
+    case resolve(key) do
+      {:ok, value} -> value
+      :default -> :persistent_term.get({:sentry_config, key})
     end
   rescue
     ArgumentError ->
@@ -1095,16 +1117,17 @@ defmodule Sentry.Config do
 
   @compile {:inline, get: 1}
   defp get(key) do
-    # Check process dictionary first for test-specific config overrides.
-    # This allows tests to use put_test_config/1 for isolated configuration
-    # without affecting other tests, even when running async: true.
-    case Process.get({:sentry_test_config, key}, :__not_set__) do
-      :__not_set__ ->
-        :persistent_term.get({:sentry_config, key}, nil)
-
-      value ->
-        value
+    case resolve(key) do
+      {:ok, value} -> value
+      :default -> :persistent_term.get({:sentry_config, key}, nil)
     end
+  end
+
+  defp resolve(:namespace), do: :default
+
+  defp resolve(key) do
+    {mod, fun} = :persistent_term.get({:sentry_config, :namespace})
+    apply(mod, fun, [key])
   end
 
   def __validate_path__(nil), do: {:ok, nil}
@@ -1230,5 +1253,27 @@ defmodule Sentry.Config do
   def __validate_oban_tags_to_sentry_tags__(other) do
     {:error,
      "expected :oban_tags_to_sentry_tags to be nil, a function with arity 1, or a {module, function} tuple, got: #{inspect(other)}"}
+  end
+
+  def __validate_namespace__({mod, fun}) when is_atom(mod) and is_atom(fun) do
+    case Code.ensure_loaded(mod) do
+      {:module, ^mod} ->
+        if function_exported?(mod, fun, 1) do
+          {:ok, {mod, fun}}
+        else
+          {:error,
+           "namespace resolver #{inspect(mod)}.#{fun}/1 is not exported. " <>
+             "Ensure the module exports a function with arity 1."}
+        end
+
+      {:error, _reason} ->
+        {:error,
+         "namespace resolver module #{inspect(mod)} could not be loaded. " <>
+           "Ensure the module is compiled and available."}
+    end
+  end
+
+  def __validate_namespace__(other) do
+    {:error, "expected :namespace to be a {module, function} tuple, got: #{inspect(other)}"}
   end
 end

--- a/lib/sentry/test/config.ex
+++ b/lib/sentry/test/config.ex
@@ -195,12 +195,22 @@ defmodule Sentry.Test.Config do
   end
 
   defp register_scope(pid) do
+    already_registered? = :persistent_term.get({:sentry_test_config_scope, pid}, false)
     :persistent_term.put({:sentry_test_config_scope, pid}, true)
-    :counters.add(:persistent_term.get(:sentry_test_config_scope_counter), 1, 1)
+
+    unless already_registered? do
+      :counters.add(:persistent_term.get(:sentry_test_config_scope_counter), 1, 1)
+    end
   end
 
   defp unregister_scope(pid) do
-    :persistent_term.erase({:sentry_test_config_scope, pid})
-    :counters.sub(:persistent_term.get(:sentry_test_config_scope_counter), 1, 1)
+    case :persistent_term.get({:sentry_test_config_scope, pid}, false) do
+      true ->
+        :persistent_term.erase({:sentry_test_config_scope, pid})
+        :counters.sub(:persistent_term.get(:sentry_test_config_scope_counter), 1, 1)
+
+      false ->
+        :ok
+    end
   end
 end

--- a/lib/sentry/test/config.ex
+++ b/lib/sentry/test/config.ex
@@ -40,6 +40,7 @@ defmodule Sentry.Test.Config do
   def maybe_activate do
     if Sentry.Config.test_mode?() and Sentry.Config.namespace() == {Sentry.Config, :namespace} do
       :persistent_term.put({:sentry_config, :namespace}, {__MODULE__, :namespace})
+      :persistent_term.put(:sentry_test_config_scope_counter, :counters.new(1, [:atomics]))
     end
 
     :ok
@@ -167,7 +168,9 @@ defmodule Sentry.Test.Config do
   end
 
   defp resolve_from_active_scopes(key) do
-    if :persistent_term.get(:sentry_test_config_scope_count, 0) == 0 do
+    # Short-circuit when no test scopes are registered to avoid scanning
+    # all persistent terms via :persistent_term.get() on every config read.
+    if scope_count() == 0 do
       :default
     else
       overrides =
@@ -184,15 +187,20 @@ defmodule Sentry.Test.Config do
     end
   end
 
+  defp scope_count do
+    case :persistent_term.get(:sentry_test_config_scope_counter, nil) do
+      nil -> 0
+      ref -> :counters.get(ref, 1)
+    end
+  end
+
   defp register_scope(pid) do
     :persistent_term.put({:sentry_test_config_scope, pid}, true)
-    count = :persistent_term.get(:sentry_test_config_scope_count, 0)
-    :persistent_term.put(:sentry_test_config_scope_count, count + 1)
+    :counters.add(:persistent_term.get(:sentry_test_config_scope_counter), 1, 1)
   end
 
   defp unregister_scope(pid) do
     :persistent_term.erase({:sentry_test_config_scope, pid})
-    count = :persistent_term.get(:sentry_test_config_scope_count, 0)
-    :persistent_term.put(:sentry_test_config_scope_count, max(count - 1, 0))
+    :counters.sub(:persistent_term.get(:sentry_test_config_scope_counter), 1, 1)
   end
 end

--- a/lib/sentry/test/config.ex
+++ b/lib/sentry/test/config.ex
@@ -1,0 +1,191 @@
+defmodule Sentry.Test.Config do
+  @moduledoc """
+  Provides per-test configuration isolation for the Sentry SDK.
+
+  When `test_mode: true` is configured, the SDK automatically uses this module
+  as the `:namespace` resolver, enabling tests to override Sentry configuration
+  on a per-test basis without affecting other tests, even when running with
+  `async: true`.
+
+  ## Usage
+
+  Use `put/1` in your test setup blocks to set per-test configuration overrides:
+
+      setup do
+        Sentry.Test.Config.put(dsn: "http://public:secret@localhost:\#{bypass.port}/1")
+      end
+
+  ## How It Works
+
+  Per-test overrides are stored in `:persistent_term` keyed by `{:sentry_config, test_pid, key}`.
+  The `namespace/1` function walks the current process's caller chain (`$callers`) to find
+  overrides set by the test process, so child processes (e.g., `Task`s) automatically
+  inherit the test's configuration.
+
+  For processes that don't have `$callers` pointing to the test process (such as
+  GenServers started via `start_supervised!/1`), use `allow/2` to explicitly grant
+  them access to the test's configuration.
+
+  Overrides are automatically cleaned up when the test exits via `ExUnit.Callbacks.on_exit/1`.
+  """
+
+  @doc """
+  Activates per-test configuration isolation if `test_mode: true` is configured
+  and no custom `:namespace` resolver has been explicitly set.
+
+  Called automatically by `Sentry.Application` on startup. You do not need to
+  call this manually.
+  """
+  @spec maybe_activate() :: :ok
+  def maybe_activate do
+    if Sentry.Config.test_mode?() and Sentry.Config.namespace() == {Sentry.Config, :namespace} do
+      :persistent_term.put({:sentry_config, :namespace}, {__MODULE__, :namespace})
+    end
+
+    :ok
+  end
+
+  @doc """
+  Resolves config namespace for the current process.
+
+  The resolution order is:
+
+  1. Walks `[self() | Process.get(:"$callers", [])]` looking for per-test overrides.
+  2. Checks whether the process was explicitly allowed via `allow/2`.
+  3. As a last resort, scans all active test scopes (registered via `put/1`).
+     This fallback only applies when exactly one scope is active, making it
+     safe for `async: false` tests only.
+
+  Returns `{:ok, value}` if an override is found, or `:default` to fall back
+  to global configuration.
+  """
+  @spec namespace(atom()) :: {:ok, term()} | :default
+  def namespace(key) do
+    scopes = [self() | Process.get(:"$callers", [])]
+
+    case find_override(scopes, key) do
+      {:ok, _value} = found ->
+        found
+
+      :default ->
+        # Check if this process was explicitly allowed by a test process via allow/2.
+        case :persistent_term.get({:sentry_test_config_allowed, self()}, nil) do
+          nil ->
+            # Last resort: scan all active test scopes (safe only for async: false tests).
+            resolve_from_active_scopes(key)
+
+          owner_pid ->
+            find_override([owner_pid], key)
+        end
+    end
+  end
+
+  @doc """
+  Sets per-test configuration overrides for the current test process.
+
+  Each key-value pair is validated through `Sentry.Config.validate!/1` before
+  being stored. Overrides are automatically cleaned up when the test exits.
+
+  ## Example
+
+      setup do
+        Sentry.Test.Config.put(
+          dsn: "http://public:secret@localhost:\#{bypass.port}/1",
+          send_result: :sync
+        )
+      end
+
+  """
+  @spec put(keyword()) :: :ok
+  def put(config) when is_list(config) do
+    test_pid = self()
+
+    original_config =
+      for {key, val} <- config do
+        renamed_key =
+          case key do
+            :before_send_event -> :before_send
+            other -> other
+          end
+
+        validated_config = Sentry.Config.validate!([{renamed_key, val}])
+        validated_val = Keyword.fetch!(validated_config, renamed_key)
+
+        :persistent_term.put({:sentry_config, test_pid, renamed_key}, validated_val)
+
+        {renamed_key, validated_val}
+      end
+
+    register_scope(test_pid)
+
+    ExUnit.Callbacks.on_exit(fn ->
+      for {key, _val} <- original_config do
+        :persistent_term.erase({:sentry_config, test_pid, key})
+      end
+
+      unregister_scope(test_pid)
+    end)
+
+    :ok
+  end
+
+  @doc """
+  Allows `allowed_pid` to read the configuration of `owner_pid`'s test scope.
+
+  Use this when a supervised process (such as a `GenServer` started via
+  `start_supervised!/1`) does not inherit the test process's `$callers` chain
+  and therefore cannot resolve per-test configuration overrides on its own.
+
+  The mapping is automatically cleaned up when the test exits.
+
+  ## Example
+
+      scheduler_pid = Sentry.TelemetryProcessor.get_scheduler(processor_name)
+      Sentry.Test.Config.allow(self(), scheduler_pid)
+
+  """
+  @spec allow(pid(), pid()) :: :ok
+  def allow(owner_pid, allowed_pid) do
+    :persistent_term.put({:sentry_test_config_allowed, allowed_pid}, owner_pid)
+
+    ExUnit.Callbacks.on_exit(fn ->
+      :persistent_term.erase({:sentry_test_config_allowed, allowed_pid})
+    end)
+
+    :ok
+  end
+
+  ## Private helpers
+
+  defp find_override(scopes, key) do
+    Enum.find_value(scopes, :default, fn pid ->
+      case :persistent_term.get({:sentry_config, pid, key}, :__not_set__) do
+        :__not_set__ -> nil
+        value -> {:ok, value}
+      end
+    end)
+  end
+
+  defp resolve_from_active_scopes(key) do
+    overrides =
+      for {{:sentry_test_config_scope, pid}, true} <- :persistent_term.get(),
+          Process.alive?(pid),
+          value = :persistent_term.get({:sentry_config, pid, key}, :__not_set__),
+          value != :__not_set__,
+          uniq: true,
+          do: value
+
+    case overrides do
+      [single_value] -> {:ok, single_value}
+      _zero_or_ambiguous -> :default
+    end
+  end
+
+  defp register_scope(pid) do
+    :persistent_term.put({:sentry_test_config_scope, pid}, true)
+  end
+
+  defp unregister_scope(pid) do
+    :persistent_term.erase({:sentry_test_config_scope, pid})
+  end
+end

--- a/lib/sentry/test/config.ex
+++ b/lib/sentry/test/config.ex
@@ -167,24 +167,32 @@ defmodule Sentry.Test.Config do
   end
 
   defp resolve_from_active_scopes(key) do
-    overrides =
-      for {{:sentry_test_config_scope, pid}, true} <- :persistent_term.get(),
-          Process.alive?(pid),
-          value = :persistent_term.get({:sentry_config, pid, key}, :__not_set__),
-          value != :__not_set__,
-          do: value
+    if :persistent_term.get(:sentry_test_config_scope_count, 0) == 0 do
+      :default
+    else
+      overrides =
+        for {{:sentry_test_config_scope, pid}, true} <- :persistent_term.get(),
+            Process.alive?(pid),
+            value = :persistent_term.get({:sentry_config, pid, key}, :__not_set__),
+            value != :__not_set__,
+            do: value
 
-    case overrides do
-      [single_value] -> {:ok, single_value}
-      _zero_or_ambiguous -> :default
+      case overrides do
+        [single_value] -> {:ok, single_value}
+        _zero_or_ambiguous -> :default
+      end
     end
   end
 
   defp register_scope(pid) do
     :persistent_term.put({:sentry_test_config_scope, pid}, true)
+    count = :persistent_term.get(:sentry_test_config_scope_count, 0)
+    :persistent_term.put(:sentry_test_config_scope_count, count + 1)
   end
 
   defp unregister_scope(pid) do
     :persistent_term.erase({:sentry_test_config_scope, pid})
+    count = :persistent_term.get(:sentry_test_config_scope_count, 0)
+    :persistent_term.put(:sentry_test_config_scope_count, max(count - 1, 0))
   end
 end

--- a/lib/sentry/test/config.ex
+++ b/lib/sentry/test/config.ex
@@ -172,7 +172,6 @@ defmodule Sentry.Test.Config do
           Process.alive?(pid),
           value = :persistent_term.get({:sentry_config, pid, key}, :__not_set__),
           value != :__not_set__,
-          uniq: true,
           do: value
 
     case overrides do

--- a/test/sentry/config_test.exs
+++ b/test/sentry/config_test.exs
@@ -312,6 +312,29 @@ defmodule Sentry.ConfigTest do
       end
     end
 
+    test ":namespace with valid resolver" do
+      assert Config.validate!(namespace: {Sentry.Config, :namespace})[:namespace] ==
+               {Sentry.Config, :namespace}
+    end
+
+    test ":namespace with non-existent module" do
+      assert_raise ArgumentError, ~r/could not be loaded/, fn ->
+        Config.validate!(namespace: {NonExistentModule, :resolve})
+      end
+    end
+
+    test ":namespace with module that doesn't export the function" do
+      assert_raise ArgumentError, ~r/is not exported/, fn ->
+        Config.validate!(namespace: {Sentry.Config, :non_existent_function})
+      end
+    end
+
+    test ":namespace with invalid value" do
+      assert_raise ArgumentError, ~r/invalid value for :namespace option/, fn ->
+        Config.validate!(namespace: :not_a_tuple)
+      end
+    end
+
     test ":telemetry_scheduler_weights" do
       # Default value is empty map
       assert Config.validate!([])[:telemetry_scheduler_weights] == %{}

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -1,7 +1,8 @@
 defmodule Sentry.Case do
   # We use this module mostly to add some additional checks before and after tests, especially
-  # related to configuration. Configuration is isolated per-process via the process dictionary,
-  # so tests using put_test_config/1 will have their own view without affecting other tests.
+  # related to configuration. Configuration is isolated per-test via `Sentry.Test.Config`, which
+  # stores overrides in `:persistent_term` keyed by the test process PID. Tests using
+  # put_test_config/1 will have their own view without affecting other tests.
 
   use ExUnit.CaseTemplate
 
@@ -43,6 +44,9 @@ defmodule Sentry.Case do
       {Sentry.TelemetryProcessor, name: processor_name},
       id: processor_name
     )
+
+    scheduler_pid = Sentry.TelemetryProcessor.get_scheduler(processor_name)
+    Sentry.Test.Config.allow(self(), scheduler_pid)
 
     Process.put(:sentry_telemetry_processor, processor_name)
     processor_name

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -18,55 +18,7 @@ defmodule Sentry.TestHelpers do
 
   @spec put_test_config(keyword()) :: :ok
   def put_test_config(config) when is_list(config) do
-    # Store original values from both process dictionary and :persistent_term
-    # We validate each key individually like Sentry.put_config/2 does
-    original_config =
-      for {key, val} <- config do
-        renamed_key =
-          case key do
-            :before_send_event -> :before_send
-            other -> other
-          end
-
-        # Validate this single key-value pair (this also transforms values like DSN strings)
-        validated_config = Sentry.Config.validate!([{renamed_key, val}])
-        validated_val = Keyword.fetch!(validated_config, renamed_key)
-
-        # Store original values
-        current_process_val = Process.get({:sentry_test_config, renamed_key}, :__not_set__)
-        current_persistent_val = :persistent_term.get({:sentry_config, renamed_key}, :__not_set__)
-
-        # Set in both locations:
-        # - Process dictionary for process-local isolation
-        # - :persistent_term so spawned processes (like sender pool workers) can see it
-        Process.put({:sentry_test_config, renamed_key}, validated_val)
-        :persistent_term.put({:sentry_config, renamed_key}, validated_val)
-
-        {renamed_key, current_process_val, current_persistent_val}
-      end
-
-    # Register cleanup to restore original values in both locations
-    ExUnit.Callbacks.on_exit(fn ->
-      Enum.each(original_config, fn
-        {key, :__not_set__, :__not_set__} ->
-          Process.delete({:sentry_test_config, key})
-          :persistent_term.erase({:sentry_config, key})
-
-        {key, :__not_set__, persistent_val} ->
-          Process.delete({:sentry_test_config, key})
-          :persistent_term.put({:sentry_config, key}, persistent_val)
-
-        {key, process_val, :__not_set__} ->
-          Process.put({:sentry_test_config, key}, process_val)
-          :persistent_term.erase({:sentry_config, key})
-
-        {key, process_val, persistent_val} ->
-          Process.put({:sentry_test_config, key}, process_val)
-          :persistent_term.put({:sentry_config, key}, persistent_val)
-      end)
-    end)
-
-    :ok
+    Sentry.Test.Config.put(config)
   end
 
   @spec set_mix_shell(module()) :: :ok

--- a/test_integrations/phoenix_app/test/support/test_helpers.ex
+++ b/test_integrations/phoenix_app/test/support/test_helpers.ex
@@ -15,55 +15,7 @@ defmodule Sentry.TestHelpers do
 
   @spec put_test_config(keyword()) :: :ok
   def put_test_config(config) when is_list(config) do
-    # Store original values from both process dictionary and :persistent_term
-    # We validate each key individually like Sentry.put_config/2 does
-    original_config =
-      for {key, val} <- config do
-        renamed_key =
-          case key do
-            :before_send_event -> :before_send
-            other -> other
-          end
-
-        # Validate this single key-value pair (this also transforms values like DSN strings)
-        validated_config = Sentry.Config.validate!([{renamed_key, val}])
-        validated_val = Keyword.fetch!(validated_config, renamed_key)
-
-        # Store original values
-        current_process_val = Process.get({:sentry_test_config, renamed_key}, :__not_set__)
-        current_persistent_val = :persistent_term.get({:sentry_config, renamed_key}, :__not_set__)
-
-        # Set in both locations:
-        # - Process dictionary for process-local isolation
-        # - :persistent_term so spawned processes (like sender pool workers) can see it
-        Process.put({:sentry_test_config, renamed_key}, validated_val)
-        :persistent_term.put({:sentry_config, renamed_key}, validated_val)
-
-        {renamed_key, current_process_val, current_persistent_val}
-      end
-
-    # Register cleanup to restore original values in both locations
-    ExUnit.Callbacks.on_exit(fn ->
-      Enum.each(original_config, fn
-        {key, :__not_set__, :__not_set__} ->
-          Process.delete({:sentry_test_config, key})
-          :persistent_term.erase({:sentry_config, key})
-
-        {key, :__not_set__, persistent_val} ->
-          Process.delete({:sentry_test_config, key})
-          :persistent_term.put({:sentry_config, key}, persistent_val)
-
-        {key, process_val, :__not_set__} ->
-          Process.put({:sentry_test_config, key}, process_val)
-          :persistent_term.erase({:sentry_config, key})
-
-        {key, process_val, persistent_val} ->
-          Process.put({:sentry_test_config, key}, process_val)
-          :persistent_term.put({:sentry_config, key}, persistent_val)
-      end)
-    end)
-
-    :ok
+    Sentry.Test.Config.put(config)
   end
 
   @spec set_mix_shell(module()) :: :ok


### PR DESCRIPTION
Introduces `Sentry.Test.Config` — a new module that provides per-test configuration isolation using `:persistent_term` keyed by test process PID, replacing the previous process-dictionary-based approach.

## Problem

The old `put_test_config/1` stored overrides in the process dictionary and duplicated them into `:persistent_term` (overwriting global config). This was fragile: spawned processes (GenServers, Tasks) couldn't reliably see test-specific config, and concurrent async tests could interfere with each other through shared `:persistent_term` keys.

## Solution

A pluggable `:namespace` resolver pattern in `Sentry.Config`:

- **`Sentry.Config`** gains a `:namespace` config option — a `{module, function}` tuple that resolves scoped config overrides. The default resolver always returns `:default` (use global config).
- **`Sentry.Test.Config`** is automatically activated when `test_mode: true` is set. It stores per-test overrides in `:persistent_term` as `{:sentry_config, test_pid, key}` and resolves them by walking the `$callers` chain, `allow/2` mappings, or (for `async: false` tests) active scope fallback.
- **`put_test_config/1`** in both test helper modules now delegates to `Sentry.Test.Config.put/1`, eliminating duplication.