### PR TITLE
chore: update GitHub Actions setup to use latest action versions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Elixir and Erlang
-        uses: erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           elixir-version: "1.18"
           otp-version: "27.2"
@@ -29,7 +29,7 @@ jobs:
           node-version: "20"
 
       - name: Cache Elixir dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -41,7 +41,7 @@ jobs:
             ${{ runner.os }}-elixir-1.18-otp-27.2-mix-
 
       - name: Cache Node.js dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             test_integrations/tracing/node_modules

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,16 +53,16 @@ jobs:
 
     steps:
     - name: Check out this repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup Elixir and Erlang
-      uses: erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9
+      uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
       with:
         elixir-version: ${{ matrix.elixir }}
         otp-version: ${{ matrix.otp }}
 
     - name: Cache downloaded dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       id: mix-downloaded-deps-cache
       with:
         path: |
@@ -93,7 +93,7 @@ jobs:
     # We need to manually restore and then save, so that we can save the "_build" directory
     # *without* the Elixir compiled code in it.
     - name: Cache compiled Elixir code
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       id: mix-cache
       with:
         path: |
@@ -130,7 +130,7 @@ jobs:
         MIX_ENV=prod mix release
 
     - name: Cache Dialyzer PLT
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       if: matrix.dialyzer
       id: plt-cache
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           token: ${{ steps.token.outputs.token }}
           fetch-depth: 0


### PR DESCRIPTION
Just addressing this one quickly:

```
[Test (Elixir 1.13, OTP 25.3)](https://github.com/getsentry/sentry-elixir/actions/runs/24131477045/job/70408896158#step:29:2)
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4, erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```