### PR TITLE
feat(tests): add test helpers

### DIFF
--- a/lib/sentry/test.ex
+++ b/lib/sentry/test.ex
@@ -243,6 +243,26 @@ defmodule Sentry.Test do
     pop_by_struct_type(Sentry.LogEvent)
   end
 
+  @doc """
+  Pops all the collected metrics from the current process.
+
+  Returns a list of all `Sentry.Metric` structs that have been collected.
+  After this function returns, the collected metrics are cleared but
+  collection continues.
+
+  > #### Metrics are Asynchronous {: .info}
+  >
+  > Metric events flow through the `TelemetryProcessor` pipeline asynchronously.
+  > You may need to add a small delay before calling this function to ensure
+  > all metrics have been processed by the `before_send_metric` callback.
+
+  """
+  @doc since: "13.0.0"
+  @spec pop_sentry_metrics(pid()) :: [Sentry.Metric.t()]
+  def pop_sentry_metrics(owner_pid \\ self()) when is_pid(owner_pid) do
+    pop_by_struct_type(Sentry.Metric)
+  end
+
   # Bypass envelope helpers
 
   @doc """
@@ -400,6 +420,7 @@ defmodule Sentry.Test do
     {user_before_send, extra_config} = Keyword.pop(extra_config, :before_send)
     {user_before_send_event, extra_config} = Keyword.pop(extra_config, :before_send_event)
     {user_before_send_log, extra_config} = Keyword.pop(extra_config, :before_send_log)
+    {user_before_send_metric, extra_config} = Keyword.pop(extra_config, :before_send_metric)
 
     # Use the caller-only registry lookup instead of `Sentry.Config.before_send/0`
     # so the captured "original" callback is only this test's override (or the
@@ -411,9 +432,13 @@ defmodule Sentry.Test do
     original_before_send_log =
       user_before_send_log || original_config_value(:before_send_log)
 
+    original_before_send_metric =
+      user_before_send_metric || original_config_value(:before_send_metric)
+
     # Build collecting callbacks that wrap the originals
     new_before_send = build_collecting_callback(original_before_send)
     new_before_send_log = build_collecting_callback(original_before_send_log)
+    new_before_send_metric = build_collecting_callback(original_before_send_metric)
 
     # Always set a per-test DSN override. When no DSN is provided, use the
     # default Bypass DSN.
@@ -432,7 +457,8 @@ defmodule Sentry.Test do
       |> Keyword.merge(extra_config)
       |> Keyword.merge(
         before_send: new_before_send,
-        before_send_log: new_before_send_log
+        before_send_log: new_before_send_log,
+        before_send_metric: new_before_send_metric
       )
 
     put_test_config(config)

--- a/lib/sentry/test.ex
+++ b/lib/sentry/test.ex
@@ -366,6 +366,151 @@ defmodule Sentry.Test do
   end
 
   @doc """
+  Extracts check-in payloads from decoded envelope item lists.
+  """
+  @doc since: "13.0.0"
+  @spec extract_check_ins([[{map(), map()}]]) :: [map()]
+  def extract_check_ins(envelope_items_list) do
+    for items <- envelope_items_list,
+        {%{"type" => "check_in"}, payload} <- items,
+        do: payload
+  end
+
+  @doc """
+  Extracts metric batch payloads from decoded envelope item lists.
+
+  Each returned map has an `"items"` key containing the individual
+  metric maps for that batch. This mirrors the structure of `extract_log_items/1`.
+  """
+  @doc since: "13.0.0"
+  @spec extract_metric_items([[{map(), map()}]]) :: [map()]
+  def extract_metric_items(envelope_items_list) do
+    for items <- envelope_items_list,
+        {%{"type" => "trace_metric"}, payload} <- items,
+        do: payload
+  end
+
+  @doc """
+  Collects events sent through a Bypass envelope collector.
+
+  This is a high-level helper combining `collect_envelopes/3` and `extract_events/1`.
+  Use this instead of `collect_envelopes(ref, count) |> extract_events()`.
+
+  ## Options
+
+    * `:timeout` - timeout in ms to wait for each envelope (default: 1000)
+
+  ## Examples
+
+      ref = setup_bypass_envelope_collector(bypass)
+      trigger_event()
+      [event] = collect_sentry_events(ref, 1)
+
+  """
+  @doc since: "13.0.0"
+  @spec collect_sentry_events(reference(), pos_integer(), keyword()) :: [map()]
+  def collect_sentry_events(ref, expected_count, opts \\ []) do
+    collect_envelopes(ref, expected_count, opts) |> extract_events()
+  end
+
+  @doc """
+  Collects transactions sent through a Bypass envelope collector.
+
+  This is a high-level helper combining `collect_envelopes/3` and `extract_transactions/1`.
+  Use this instead of `collect_envelopes(ref, count) |> extract_transactions()`.
+
+  ## Options
+
+    * `:timeout` - timeout in ms to wait for each envelope (default: 1000)
+
+  ## Examples
+
+      ref = setup_bypass_envelope_collector(bypass)
+      run_traced_job()
+      [tx] = collect_sentry_transactions(ref, 1)
+
+  """
+  @doc since: "13.0.0"
+  @spec collect_sentry_transactions(reference(), pos_integer(), keyword()) :: [map()]
+  def collect_sentry_transactions(ref, expected_count, opts \\ []) do
+    collect_envelopes(ref, expected_count, opts) |> extract_transactions()
+  end
+
+  @doc """
+  Collects log items sent through a Bypass envelope collector.
+
+  This is a high-level helper combining `collect_envelopes/3` and `extract_log_items/1`.
+  Use this instead of `collect_envelopes(ref, count) |> extract_log_items()`.
+
+  ## Options
+
+    * `:timeout` - timeout in ms to wait for each envelope (default: 1000)
+
+  ## Examples
+
+      ref = setup_bypass_envelope_collector(bypass)
+      Logger.info("something happened")
+      [log] = collect_sentry_logs(ref, 1)
+
+  """
+  @doc since: "13.0.0"
+  @spec collect_sentry_logs(reference(), pos_integer(), keyword()) :: [map()]
+  def collect_sentry_logs(ref, expected_count, opts \\ []) do
+    collect_envelopes(ref, expected_count, opts) |> extract_log_items()
+  end
+
+  @doc """
+  Collects check-in payloads sent through a Bypass envelope collector.
+
+  This is a high-level helper combining `collect_envelopes/3` and `extract_check_ins/1`.
+  Use this instead of manually destructuring `[[{header, body}]]` from `collect_envelopes/3`.
+
+  ## Options
+
+    * `:timeout` - timeout in ms to wait for each envelope (default: 1000)
+
+  ## Examples
+
+      ref = setup_bypass_envelope_collector(bypass, type: "check_in")
+      Sentry.capture_check_in(status: :ok, monitor_slug: "my-job")
+      [check_in] = collect_sentry_check_ins(ref, 1)
+      assert check_in["status"] == "ok"
+
+  """
+  @doc since: "13.0.0"
+  @spec collect_sentry_check_ins(reference(), pos_integer(), keyword()) :: [map()]
+  def collect_sentry_check_ins(ref, expected_count, opts \\ []) do
+    collect_envelopes(ref, expected_count, opts) |> extract_check_ins()
+  end
+
+  @doc """
+  Collects metric batch payloads sent through a Bypass envelope collector.
+
+  This is a high-level helper combining `collect_envelopes/3` and `extract_metric_items/1`.
+  Use this instead of `collect_envelopes(ref, count) |> extract_metric_items()`.
+
+  Each returned map has an `"items"` key containing the individual metric maps.
+
+  ## Options
+
+    * `:timeout` - timeout in ms to wait for each envelope (default: 1000)
+
+  ## Examples
+
+      ref = setup_bypass_envelope_collector(bypass, type: "trace_metric")
+      Sentry.Metrics.count("button.clicks", 1)
+      [batch] = collect_sentry_metric_items(ref, 1)
+      [metric] = batch["items"]
+      assert metric["name"] == "button.clicks"
+
+  """
+  @doc since: "13.0.0"
+  @spec collect_sentry_metric_items(reference(), pos_integer(), keyword()) :: [map()]
+  def collect_sentry_metric_items(ref, expected_count, opts \\ []) do
+    collect_envelopes(ref, expected_count, opts) |> extract_metric_items()
+  end
+
+  @doc """
   Decodes a raw envelope binary into a list of `{header, item}` tuples.
   """
   @doc since: "12.1.0"

--- a/lib/sentry/test.ex
+++ b/lib/sentry/test.ex
@@ -43,6 +43,11 @@ defmodule Sentry.Test do
 
       setup :start_collecting_sentry_reports
 
+  ## Assertion Helpers
+
+  See `Sentry.Test.Assertions` for convenient assertion functions that reduce
+  boilerplate when validating captured events, transactions, and logs.
+
   """
 
   @moduledoc since: "10.2.0"

--- a/lib/sentry/test/assertions.ex
+++ b/lib/sentry/test/assertions.ex
@@ -87,7 +87,7 @@ defmodule Sentry.Test.Assertions do
       assert_sentry_report(:transaction, transaction: "test_span")
 
       # With explicit data from envelope collection:
-      [event] = collect_envelopes(ref, 1) |> extract_events()
+      [event] = collect_sentry_events(ref, 1)
       assert_sentry_report(event, "tags" => %{"oban_queue" => "default"})
 
   """

--- a/lib/sentry/test/assertions.ex
+++ b/lib/sentry/test/assertions.ex
@@ -37,7 +37,8 @@ defmodule Sentry.Test.Assertions do
   @type_to_pop %{
     event: &Sentry.Test.pop_sentry_reports/0,
     transaction: &Sentry.Test.pop_sentry_transactions/0,
-    log: &Sentry.Test.pop_sentry_logs/0
+    log: &Sentry.Test.pop_sentry_logs/0,
+    metric: &Sentry.Test.pop_sentry_metrics/0
   }
 
   @doc """
@@ -93,9 +94,9 @@ defmodule Sentry.Test.Assertions do
   @doc since: "12.1.0"
   def assert_sentry_report(type_or_item, criteria)
 
-  @spec assert_sentry_report(:event | :transaction | :log, keyword()) ::
-          Sentry.Event.t() | Sentry.Transaction.t() | Sentry.LogEvent.t()
-  def assert_sentry_report(type, criteria) when type in [:event, :transaction, :log] do
+  @spec assert_sentry_report(:event | :transaction | :log | :metric, keyword()) ::
+          Sentry.Event.t() | Sentry.Transaction.t() | Sentry.LogEvent.t() | Sentry.Metric.t()
+  def assert_sentry_report(type, criteria) when type in [:event, :transaction, :log, :metric] do
     items = pop_for_type(type)
     label = type_label(type)
 
@@ -170,6 +171,7 @@ defmodule Sentry.Test.Assertions do
   defp type_label(:event), do: "event"
   defp type_label(:transaction), do: "transaction"
   defp type_label(:log), do: "log"
+  defp type_label(:metric), do: "metric"
 
   defp unwrap_single!([single], _label), do: single
   defp unwrap_single!(item, _label) when is_map(item), do: item

--- a/lib/sentry/test/assertions.ex
+++ b/lib/sentry/test/assertions.ex
@@ -1,0 +1,274 @@
+defmodule Sentry.Test.Assertions do
+  @moduledoc """
+  ExUnit assertion helpers for testing Sentry reports.
+
+  These helpers work with data collected by `Sentry.Test` and reduce
+  boilerplate when asserting on captured events, transactions, and logs.
+
+  ## Usage
+
+      import Sentry.Test.Assertions
+
+  ## Examples
+
+  Assert that exactly one event was captured with specific fields:
+
+      assert_sentry_report(:event, level: :error, message: %{formatted: "hello"})
+
+  Assert a transaction:
+
+      assert_sentry_report(:transaction, transaction: "my_span")
+
+  Use the log shorthand:
+
+      assert_sentry_log(:info, "User session started")
+      assert_sentry_log(:info, ~r/session started/, trace_id: "abc123")
+
+  Find a specific event among many:
+
+      events = Sentry.Test.pop_sentry_reports()
+      event = find_sentry_report!(events, message: %{formatted: ~r/hello/})
+
+  """
+  @moduledoc since: "12.1.0"
+
+  import ExUnit.Assertions, only: [flunk: 1]
+
+  @type_to_pop %{
+    event: &Sentry.Test.pop_sentry_reports/0,
+    transaction: &Sentry.Test.pop_sentry_transactions/0,
+    log: &Sentry.Test.pop_sentry_logs/0
+  }
+
+  @doc """
+  Asserts that a report matches the given criteria.
+
+  This function has two forms:
+
+  ## Auto-pop by type
+
+  When the first argument is a type atom (`:event`, `:transaction`, or `:log`),
+  it pops collected items internally — no need to call `pop_sentry_reports/0`
+  yourself. Asserts that exactly one item was captured and validates it.
+
+    * `:event` — pops from `Sentry.Test.pop_sentry_reports/0`
+    * `:transaction` — pops from `Sentry.Test.pop_sentry_transactions/0`
+    * `:log` — pops from `Sentry.Test.pop_sentry_logs/0`
+
+  ## Explicit data
+
+  When the first argument is a map or single-element list, it validates the
+  item against the criteria directly. Use this with data from envelope
+  collection helpers.
+
+  ## Criteria
+
+  Each key-value pair in `criteria` is checked against the item:
+
+    * **Regex** — matches with `=~/2`
+    * **Plain map** (not a struct) — recursive subset match: every key
+      in the expected map must exist in the actual value with a matching value
+    * **Any other value** — compared with `==/2`
+
+  Atom keys are resolved with a string-key fallback, so atom-key criteria
+  also work on decoded JSON maps.
+
+  Returns the matched item for further assertions.
+
+  ## Examples
+
+      event = assert_sentry_report(:event,
+        level: :error,
+        source: :plug,
+        message: %{formatted: "hello"}
+      )
+
+      assert_sentry_report(:transaction, transaction: "test_span")
+
+      # With explicit data from envelope collection:
+      [event] = collect_envelopes(ref, 1) |> extract_events()
+      assert_sentry_report(event, "tags" => %{"oban_queue" => "default"})
+
+  """
+  @doc since: "12.1.0"
+  def assert_sentry_report(type_or_item, criteria)
+
+  @spec assert_sentry_report(:event | :transaction | :log, keyword()) ::
+          Sentry.Event.t() | Sentry.Transaction.t() | Sentry.LogEvent.t()
+  def assert_sentry_report(type, criteria) when type in [:event, :transaction, :log] do
+    items = pop_for_type(type)
+    label = type_label(type)
+
+    item = unwrap_single!(items, label)
+    assert_fields!(item, criteria, label)
+    item
+  end
+
+  @spec assert_sentry_report(map() | [map()], keyword() | [{binary(), term()}]) :: map()
+  def assert_sentry_report(item_or_list, criteria)
+      when (is_map(item_or_list) or is_list(item_or_list)) and
+             (is_list(criteria) or is_map(criteria)) do
+    item = unwrap_single!(item_or_list, "report")
+    assert_fields!(item, criteria, "report")
+    item
+  end
+
+  @doc """
+  Asserts that a log was captured matching the given level and body pattern.
+
+  Pops all collected logs and finds the first one matching `level` and
+  `body_pattern`. This uses find semantics (not assert-exactly-1) because
+  logs often come in batches.
+
+  The optional third argument is a keyword list of extra criteria to match
+  on any `Sentry.LogEvent` field.
+
+  Returns the matched log event.
+
+  ## Examples
+
+      assert_sentry_log(:info, "User session started")
+      assert_sentry_log(:error, ~r/connection refused/)
+      assert_sentry_log(:info, "User session started", trace_id: "abc123")
+      assert_sentry_log(:info, "User session started", attributes: %{id: 312})
+
+  """
+  @doc since: "12.1.0"
+  @spec assert_sentry_log(Sentry.LogEvent.level(), String.t() | Regex.t(), keyword()) ::
+          Sentry.LogEvent.t()
+  def assert_sentry_log(level, body_pattern, extra_criteria \\ [])
+      when is_atom(level) and (is_binary(body_pattern) or is_struct(body_pattern, Regex)) do
+    criteria = [level: level, body: body_pattern] ++ extra_criteria
+    logs = Sentry.Test.pop_sentry_logs()
+    find_item!(logs, criteria, "log")
+  end
+
+  @doc """
+  Finds the first item in `items` that matches all `criteria`.
+
+  Raises with a descriptive error if no match is found. Works with both
+  structs (atom keys) and decoded JSON maps (string keys).
+
+  ## Examples
+
+      events = Sentry.Test.pop_sentry_reports()
+      event = find_sentry_report!(events, message: %{formatted: ~r/hello/})
+
+  """
+  @doc since: "12.1.0"
+  @spec find_sentry_report!([map()], keyword() | [{binary(), term()}]) :: map()
+  def find_sentry_report!(items, criteria) when is_list(items) do
+    find_item!(items, criteria, "report")
+  end
+
+  # --- Private helpers ---
+
+  defp pop_for_type(type) do
+    Map.fetch!(@type_to_pop, type).()
+  end
+
+  defp type_label(:event), do: "event"
+  defp type_label(:transaction), do: "transaction"
+  defp type_label(:log), do: "log"
+
+  defp unwrap_single!([single], _label), do: single
+  defp unwrap_single!(item, _label) when is_map(item), do: item
+
+  defp unwrap_single!([], label) do
+    flunk("""
+    Expected exactly 1 Sentry #{label}, got 0.
+
+    Make sure setup_sentry/1 was called and the event was sent with result: :sync.\
+    """)
+  end
+
+  defp unwrap_single!(list, label) when is_list(list) do
+    flunk("""
+    Expected exactly 1 Sentry #{label}, got #{length(list)}.
+
+    Use find_sentry_report!/2 to search within multiple items.\
+    """)
+  end
+
+  defp assert_fields!(item, criteria, label) do
+    mismatches =
+      Enum.reduce(criteria, [], fn {key, expected}, acc ->
+        actual = get_field(item, key)
+
+        if match_value?(actual, expected) do
+          acc
+        else
+          [{key, expected, actual} | acc]
+        end
+      end)
+
+    unless mismatches == [] do
+      flunk(format_mismatch_error(Enum.reverse(mismatches), label))
+    end
+  end
+
+  defp find_item!(items, criteria, label) do
+    Enum.find(items, fn item ->
+      Enum.all?(criteria, fn {key, expected} ->
+        match_value?(get_field(item, key), expected)
+      end)
+    end) || flunk(format_find_error(items, criteria, label))
+  end
+
+  defp get_field(data, key) when is_atom(key) do
+    case Map.fetch(data, key) do
+      {:ok, value} -> value
+      :error -> Map.get(data, to_string(key))
+    end
+  end
+
+  defp get_field(data, key) when is_binary(key) do
+    case Map.fetch(data, key) do
+      {:ok, value} ->
+        value
+
+      :error ->
+        try do
+          Map.get(data, String.to_existing_atom(key))
+        rescue
+          ArgumentError -> nil
+        end
+    end
+  end
+
+  defp match_value?(actual, %Regex{} = expected) do
+    is_binary(actual) and actual =~ expected
+  end
+
+  defp match_value?(actual, expected) when is_map(expected) and not is_struct(expected) do
+    is_map(actual) and
+      Enum.all?(expected, fn {k, v} ->
+        match_value?(get_field(actual, k), v)
+      end)
+  end
+
+  defp match_value?(actual, expected) do
+    actual == expected
+  end
+
+  defp format_mismatch_error(mismatches, label) do
+    fields =
+      Enum.map_join(mismatches, "\n\n", fn {key, expected, actual} ->
+        """
+          #{inspect(key)}
+            expected: #{inspect(expected, limit: 5, printable_limit: 100)}
+            got:      #{inspect(actual, limit: 5, printable_limit: 100)}\
+        """
+      end)
+
+    "Sentry #{label} assertion failed:\n\n#{fields}"
+  end
+
+  defp format_find_error(items, criteria, label) do
+    """
+    No matching Sentry #{label} found in #{length(items)} item(s).
+
+    Criteria: #{inspect(criteria, limit: 10, printable_limit: 200)}\
+    """
+  end
+end

--- a/test/mix/sentry.send_test_event_test.exs
+++ b/test/mix/sentry.send_test_event_test.exs
@@ -2,10 +2,13 @@ defmodule Mix.Tasks.Sentry.SendTestEventTest do
   use Sentry.Case
 
   import ExUnit.CaptureIO
+  import Sentry.Test.Assertions
   import Sentry.TestHelpers
 
+  alias Sentry.Test, as: SentryTest
+
   setup do
-    setup_bypass()
+    SentryTest.setup_sentry()
   end
 
   test "prints if :dsn is not set" do
@@ -26,12 +29,6 @@ defmodule Mix.Tasks.Sentry.SendTestEventTest do
   end
 
   test "sends event successfully when configured to", %{bypass: bypass} do
-    Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
-      {:ok, body, conn} = Plug.Conn.read_body(conn)
-      assert body =~ "Testing sending Sentry event"
-      Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-    end)
-
     put_test_config(
       environment_name: "test",
       finch_pool_opts: []
@@ -41,6 +38,10 @@ defmodule Mix.Tasks.Sentry.SendTestEventTest do
       capture_io(fn ->
         Mix.Tasks.Sentry.SendTestEvent.run([])
       end)
+
+    assert_sentry_report(:event,
+      original_exception: %RuntimeError{message: "Testing sending Sentry event"}
+    )
 
     assert output =~ """
            Client configuration:
@@ -53,7 +54,7 @@ defmodule Mix.Tasks.Sentry.SendTestEventTest do
 
     assert output =~ "Sending test event..."
     assert output =~ "Test event sent"
-    assert output =~ "Event ID: 340"
+    assert output =~ ~r/Event ID: [0-9a-f]+/
   end
 
   @tag :capture_log

--- a/test/plug_capture_test.exs
+++ b/test/plug_capture_test.exs
@@ -2,7 +2,9 @@ defmodule Sentry.PlugCaptureTest do
   use Sentry.Case
   import Plug.Test
 
-  import Sentry.TestHelpers
+  import Sentry.Test.Assertions
+
+  alias Sentry.Test, as: SentryTest
 
   defmodule PhoenixController do
     use Phoenix.Controller
@@ -55,49 +57,36 @@ defmodule Sentry.PlugCaptureTest do
   end
 
   setup do
-    setup_bypass()
+    SentryTest.setup_sentry()
   end
 
   describe "with a Plug application" do
-    test "sends error to Sentry and uses Sentry.PlugContext to fill in context", %{
-      bypass: bypass
-    } do
-      Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-
-        event = decode_event_from_envelope!(body)
-
-        assert event["request"]["url"] == "http://www.example.com/error_route"
-        assert event["request"]["method"] == "GET"
-        assert event["request"]["query_string"] == ""
-        assert event["request"]["data"] == %{}
-        Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-      end)
-
+    test "sends error to Sentry and uses Sentry.PlugContext to fill in context" do
       assert_raise(Plug.Conn.WrapperError, "** (RuntimeError) Error", fn ->
         conn(:get, "/error_route")
         |> call_plug_app()
       end)
+
+      assert_sentry_report(:event,
+        request: %{
+          url: "http://www.example.com/error_route",
+          method: "GET",
+          query_string: "",
+          data: %{}
+        }
+      )
     end
 
-    test "sends throws to Sentry", %{bypass: bypass} do
-      Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-        _event = decode_event_from_envelope!(body)
-        Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-      end)
-
+    test "sends throws to Sentry" do
       catch_throw(conn(:get, "/throw_route") |> call_plug_app())
+
+      assert_sentry_report(:event, [])
     end
 
-    test "sends exits to Sentry", %{bypass: bypass} do
-      Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-        _event = decode_event_from_envelope!(body)
-        Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-      end)
-
+    test "sends exits to Sentry" do
       catch_exit(conn(:get, "/exit_route") |> call_plug_app())
+
+      assert_sentry_report(:event, [])
     end
 
     test "does not send error on unmatched routes", %{bypass: _bypass} do
@@ -107,18 +96,14 @@ defmodule Sentry.PlugCaptureTest do
       end
     end
 
-    test "can render feedback form", %{bypass: bypass} do
-      Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-        _event = decode_event_from_envelope!(body)
-        Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-      end)
-
+    test "can render feedback form" do
       conn = conn(:get, "/error_route")
 
       assert_raise Plug.Conn.WrapperError, "** (RuntimeError) Error", fn ->
         call_plug_app(conn)
       end
+
+      assert_sentry_report(:event, [])
 
       assert_received {:plug_conn, :sent}
       {event_id, _} = Sentry.get_last_event_id_and_source()
@@ -143,52 +128,38 @@ defmodule Sentry.PlugCaptureTest do
       :ok
     end
 
-    test "reports raised exceptions", %{bypass: bypass} do
-      Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-
-        event = decode_event_from_envelope!(body)
-
-        assert event["culprit"] == "Sentry.PlugCaptureTest.PhoenixController.error/2"
-
-        assert List.first(event["exception"])["type"] == "RuntimeError"
-        assert List.first(event["exception"])["value"] == "PhoenixError"
-
-        Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-      end)
-
+    test "reports raised exceptions" do
       assert_raise RuntimeError, "PhoenixError", fn ->
         conn(:get, "/error_route")
         |> call_phoenix_endpoint()
       end
+
+      event =
+        assert_sentry_report(:event,
+          culprit: "Sentry.PlugCaptureTest.PhoenixController.error/2"
+        )
+
+      assert [exception] = event.exception
+      assert exception.type == "RuntimeError"
+      assert exception.value == "PhoenixError"
     end
 
-    test "reports exits", %{bypass: bypass} do
-      Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-
-        event = decode_event_from_envelope!(body)
-
-        assert event["culprit"] == "Sentry.PlugCaptureTest.PhoenixController.exit/2"
-        assert event["message"]["formatted"] == "Uncaught exit - :test"
-        Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-      end)
-
+    test "reports exits" do
       catch_exit(conn(:get, "/exit_route") |> call_phoenix_endpoint())
+
+      assert_sentry_report(:event,
+        culprit: "Sentry.PlugCaptureTest.PhoenixController.exit/2",
+        message: %{formatted: "Uncaught exit - :test"}
+      )
     end
 
-    test "reports throws", %{bypass: bypass} do
-      Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-
-        event = decode_event_from_envelope!(body)
-
-        assert event["culprit"] == "Sentry.PlugCaptureTest.PhoenixController.throw/2"
-        assert event["message"]["formatted"] == "Uncaught throw - :test"
-        Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-      end)
-
+    test "reports throws" do
       catch_throw(conn(:get, "/throw_route") |> call_phoenix_endpoint())
+
+      assert_sentry_report(:event,
+        culprit: "Sentry.PlugCaptureTest.PhoenixController.throw/2",
+        message: %{formatted: "Uncaught throw - :test"}
+      )
     end
 
     test "does not send Phoenix.Router.NoRouteError" do
@@ -196,45 +167,29 @@ defmodule Sentry.PlugCaptureTest do
       |> call_phoenix_endpoint()
     end
 
-    test "scrubs Phoenix.ActionClauseError", %{bypass: bypass} do
-      test_pid = self()
-      ref = make_ref()
-
-      Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-        send(test_pid, {ref, body})
-        Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-      end)
-
+    test "scrubs Phoenix.ActionClauseError" do
       assert_raise Phoenix.ActionClauseError, fn ->
         conn(:get, "/action_clause_error?password=secret")
         |> Plug.Conn.put_req_header("authorization", "yes")
         |> call_phoenix_endpoint()
       end
 
-      assert_receive {^ref, sentry_body}
-      event = decode_event_from_envelope!(sentry_body)
+      event =
+        assert_sentry_report(:event,
+          culprit: "Sentry.PlugCaptureTest.PhoenixController.action_clause_error/2"
+        )
 
-      assert event["culprit"] ==
-               "Sentry.PlugCaptureTest.PhoenixController.action_clause_error/2"
-
-      assert [exception] = event["exception"]
-      assert exception["type"] == "Phoenix.ActionClauseError"
-      assert exception["value"] =~ ~s(params: %{"password" => "*********"})
+      assert [exception] = event.exception
+      assert exception.type == "Phoenix.ActionClauseError"
+      assert exception.value =~ ~s(params: %{"password" => "*********"})
     end
 
-    test "can render feedback form in Phoenix ErrorView", %{bypass: bypass} do
-      Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-
-        _event = decode_event_from_envelope!(body)
-
-        Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-      end)
-
+    test "can render feedback form in Phoenix ErrorView" do
       conn = conn(:get, "/error_route")
 
       assert_raise RuntimeError, "PhoenixError", fn -> call_phoenix_endpoint(conn) end
+
+      assert_sentry_report(:event, [])
 
       {event_id, _} = Sentry.get_last_event_id_and_source()
 
@@ -245,22 +200,19 @@ defmodule Sentry.PlugCaptureTest do
       assert body =~ ~s{"title":"Testing"}
     end
 
-    test "handles Erlang error in Plug.Conn.WrapperError", %{bypass: bypass} do
-      Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-        event = decode_event_from_envelope!(body)
-        assert event["culprit"] == "Sentry.PlugCaptureTest.PhoenixController.assigns/2"
-        Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-      end)
-
+    test "handles Erlang error in Plug.Conn.WrapperError" do
       assert_raise KeyError, fn ->
         conn(:get, "/assigns_route")
         |> Plug.Conn.put_req_header("throw", "throw")
         |> call_phoenix_endpoint()
       end
+
+      assert_sentry_report(:event,
+        culprit: "Sentry.PlugCaptureTest.PhoenixController.assigns/2"
+      )
     end
 
-    test "modifies conn with custom scrubber", %{bypass: bypass} do
+    test "modifies conn with custom scrubber" do
       Application.put_env(:sentry, PhoenixEndpointWithScrubber,
         render_errors: [view: Sentry.ErrorView, accepts: ~w(html)]
       )
@@ -268,32 +220,23 @@ defmodule Sentry.PlugCaptureTest do
       pid = start_supervised!(PhoenixEndpointWithScrubber)
       Process.link(pid)
 
-      Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-
-        event = decode_event_from_envelope!(body)
-
-        assert event["culprit"] == "Sentry.PlugCaptureTest.PhoenixController.error/2"
-
-        assert List.first(event["exception"])["type"] == "RuntimeError"
-        assert List.first(event["exception"])["value"] == "PhoenixError"
-
-        Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-      end)
-
       assert_raise RuntimeError, "PhoenixError", fn ->
         conn(:get, "/error_route")
         |> Plug.run([{PhoenixEndpointWithScrubber, []}])
       end
+
+      event =
+        assert_sentry_report(:event,
+          culprit: "Sentry.PlugCaptureTest.PhoenixController.error/2"
+        )
+
+      assert [exception] = event.exception
+      assert exception.type == "RuntimeError"
+      assert exception.value == "PhoenixError"
     end
   end
 
   defp call_plug_app(conn), do: Plug.run(conn, [{Sentry.ExamplePlugApplication, []}])
 
   defp call_phoenix_endpoint(conn), do: Plug.run(conn, [{PhoenixEndpoint, []}])
-
-  defp decode_event_from_envelope!(envelope) do
-    assert [{%{"type" => "event"}, event}] = decode_envelope!(envelope)
-    event
-  end
 end

--- a/test/sentry/client_test.exs
+++ b/test/sentry/client_test.exs
@@ -231,7 +231,7 @@ defmodule Sentry.ClientTest do
       assert {:ok, _} = Client.send_event(event, result: :sync)
 
       assert_sentry_report(
-        SentryTest.collect_envelopes(ref, 1) |> SentryTest.extract_events(),
+        SentryTest.collect_sentry_events(ref, 1),
         %{"extra" => %{"key" => "value"}, "user" => %{"id" => 1}}
       )
     end

--- a/test/sentry/client_test.exs
+++ b/test/sentry/client_test.exs
@@ -2,9 +2,11 @@ defmodule Sentry.ClientTest do
   use Sentry.Case
 
   import ExUnit.CaptureLog
+  import Sentry.Test.Assertions
   import Sentry.TestHelpers
 
   alias Sentry.{Client, Event}
+  alias Sentry.Test, as: SentryTest
 
   describe "render_event/1" do
     test "transforms structs into maps" do
@@ -187,25 +189,17 @@ defmodule Sentry.ClientTest do
 
   describe "send_event/2" do
     setup do
-      setup_bypass()
+      SentryTest.setup_sentry()
     end
 
-    test "respects the :sample_rate option", %{bypass: bypass} do
-      # Always sends with sample rate of 1.
-      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-        Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-      end)
-
-      assert {:ok, "340"} = Client.send_event(Event.create_event([]), sample_rate: 1.0)
+    test "respects the :sample_rate option" do
+      assert {:ok, _} = Client.send_event(Event.create_event([]), sample_rate: 1.0)
+      assert_sentry_report(:event, [])
 
       # Never sends with sample rate of 0.
       assert :unsampled = Client.send_event(Event.create_event([]), sample_rate: 0.0)
 
       # Either sends or doesn't with :sample_rate of 0.5.
-      Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
-        Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-      end)
-
       for _ <- 1..10 do
         event = Event.create_event(message: "Unique: #{System.unique_integer()}")
         result = Client.send_event(event, sample_rate: 0.5)
@@ -214,16 +208,9 @@ defmodule Sentry.ClientTest do
     end
 
     test "calls anonymous :before_send callback", %{bypass: bypass} do
-      Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
-        assert {:ok, body, conn} = Plug.Conn.read_body(conn)
-
-        assert [{%{"type" => "event"}, event}] = decode_envelope!(body)
-
-        assert event["extra"] == %{"key" => "value"}
-        assert event["user"]["id"] == 1
-
-        Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-      end)
+      # Per-test before_send overrides the collecting wrapper installed by
+      # setup_sentry, so use an envelope collector to inspect the wire payload.
+      ref = SentryTest.setup_bypass_envelope_collector(bypass, type: "event")
 
       put_test_config(
         before_send: fn %Event{} = event ->
@@ -242,6 +229,11 @@ defmodule Sentry.ClientTest do
       Logger.metadata(key: "value", user_id: 1)
 
       assert {:ok, _} = Client.send_event(event, result: :sync)
+
+      assert_sentry_report(
+        SentryTest.collect_envelopes(ref, 1) |> SentryTest.extract_events(),
+        %{"extra" => %{"key" => "value"}, "user" => %{"id" => 1}}
+      )
     end
 
     test "if :before_send callback returns falsey, the event is not sent" do
@@ -290,12 +282,7 @@ defmodule Sentry.ClientTest do
       assert Sentry.get_last_event_id_and_source() == {event.event_id, event.source}
     end
 
-    test "calls anonymous :after_send_event callback synchronously",
-         %{bypass: bypass} do
-      Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
-        Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-      end)
-
+    test "calls anonymous :after_send_event callback synchronously" do
       test_pid = self()
       ref = make_ref()
 
@@ -306,6 +293,8 @@ defmodule Sentry.ClientTest do
       event = Event.create_event(message: "Something went wrong")
       assert {:ok, _} = Client.send_event(event, result: :sync)
       assert_received {^ref, ^event, {:ok, _id}}
+
+      assert_sentry_report(:event, message: %{formatted: "Something went wrong"})
     end
 
     test "logs API errors at the configured level", %{bypass: bypass} do
@@ -404,7 +393,7 @@ defmodule Sentry.ClientTest do
              }
     end
 
-    test "dedupes events", %{bypass: bypass} do
+    test "dedupes events" do
       put_test_config(dedup_events: true)
 
       {:current_stacktrace, stacktrace} = Process.info(self(), :current_stacktrace)
@@ -425,11 +414,7 @@ defmodule Sentry.ClientTest do
       ]
 
       for {event, dup_event} <- events do
-        Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-          Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-        end)
-
-        assert {:ok, "340"} = Client.send_event(event, [])
+        assert {:ok, _} = Client.send_event(event, [])
 
         log =
           capture_log(fn ->
@@ -437,6 +422,7 @@ defmodule Sentry.ClientTest do
           end)
 
         assert log =~ "Event dropped due to being a duplicate of a previously-captured event."
+        find_sentry_report!(SentryTest.pop_sentry_reports(), event_id: event.event_id)
       end
     end
   end

--- a/test/sentry/integrations/oban/cron_test.exs
+++ b/test/sentry/integrations/oban/cron_test.exs
@@ -2,7 +2,10 @@ defmodule Sentry.Integrations.Oban.CronTest do
   alias Sentry.Integrations.CheckInIDMappings
   use Sentry.Case, async: false
 
+  import Sentry.Test.Assertions
   import Sentry.TestHelpers
+
+  alias Sentry.Test, as: SentryTest
 
   setup context do
     opts = context[:attach_opts] || []
@@ -12,7 +15,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
   end
 
   setup do
-    setup_bypass(dedup_events: false, environment_name: "test")
+    SentryTest.setup_sentry(dedup_events: false, environment_name: "test")
   end
 
   for event_type <- [:start, :stop, :exception] do
@@ -63,34 +66,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
   end
 
   test "captures start events with monitor config", %{bypass: bypass} do
-    test_pid = self()
-    ref = make_ref()
-
-    Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-      {:ok, body, conn} = Plug.Conn.read_body(conn)
-      assert [{headers, check_in_body}] = decode_envelope!(body)
-      id = CheckInIDMappings.lookup_or_insert_new(123)
-
-      assert headers["type"] == "check_in"
-
-      assert check_in_body["check_in_id"] == id
-      assert check_in_body["status"] == "in_progress"
-      assert check_in_body["monitor_slug"] == "sentry-my-worker"
-      assert check_in_body["duration"] == nil
-      assert check_in_body["environment"] == "test"
-
-      assert check_in_body["monitor_config"] == %{
-               "schedule" => %{
-                 "type" => "interval",
-                 "value" => 1,
-                 "unit" => "day"
-               }
-             }
-
-      send(test_pid, {ref, :done})
-
-      Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-    end)
+    ref = SentryTest.setup_bypass_envelope_collector(bypass, type: "check_in")
 
     :telemetry.execute([:oban, :job, :start], %{}, %{
       job: %Oban.Job{
@@ -100,7 +76,25 @@ defmodule Sentry.Integrations.Oban.CronTest do
       }
     })
 
-    assert_receive {^ref, :done}, 1000
+    assert [[{headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+    id = CheckInIDMappings.lookup_or_insert_new(123)
+
+    assert headers["type"] == "check_in"
+
+    assert_sentry_report(check_in_body,
+      check_in_id: id,
+      status: "in_progress",
+      monitor_slug: "sentry-my-worker",
+      duration: nil,
+      environment: "test",
+      monitor_config: %{
+        "schedule" => %{
+          "type" => "interval",
+          "value" => 1,
+          "unit" => "day"
+        }
+      }
+    )
   end
 
   for {oban_state, expected_status} <- [
@@ -120,34 +114,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
       ] do
     test "captures stop events with monitor config and state of #{inspect(oban_state)} and frequency of #{frequency}",
          %{bypass: bypass} do
-      test_pid = self()
-      ref = make_ref()
-
-      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-        assert [{headers, check_in_body}] = decode_envelope!(body)
-        id = CheckInIDMappings.lookup_or_insert_new(942)
-
-        assert headers["type"] == "check_in"
-        assert check_in_body["check_in_id"] == id
-        assert check_in_body["status"] == unquote(expected_status)
-        assert check_in_body["monitor_slug"] == "sentry-my-worker"
-        assert check_in_body["duration"] == 12.099
-        assert check_in_body["environment"] == "test"
-
-        assert check_in_body["monitor_config"] == %{
-                 "schedule" => %{
-                   "type" => "interval",
-                   "value" => 1,
-                   "unit" => unquote(expected_unit)
-                 },
-                 "timezone" => "Europe/Rome"
-               }
-
-        send(test_pid, {ref, :done})
-
-        Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-      end)
+      ref = SentryTest.setup_bypass_envelope_collector(bypass, type: "check_in")
 
       duration = System.convert_time_unit(12_099, :millisecond, :native)
 
@@ -160,39 +127,31 @@ defmodule Sentry.Integrations.Oban.CronTest do
         }
       })
 
-      assert_receive {^ref, :done}, 1000
-    end
-  end
-
-  test "captures exception events with monitor config", %{bypass: bypass} do
-    test_pid = self()
-    ref = make_ref()
-
-    Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-      {:ok, body, conn} = Plug.Conn.read_body(conn)
-      assert [{headers, check_in_body}] = decode_envelope!(body)
+      assert [[{headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
       id = CheckInIDMappings.lookup_or_insert_new(942)
 
       assert headers["type"] == "check_in"
 
-      assert check_in_body["check_in_id"] == id
-      assert check_in_body["status"] == "error"
-      assert check_in_body["monitor_slug"] == "sentry-my-worker"
-      assert check_in_body["duration"] == 12.099
-      assert check_in_body["environment"] == "test"
+      assert_sentry_report(check_in_body,
+        check_in_id: id,
+        status: unquote(expected_status),
+        monitor_slug: "sentry-my-worker",
+        duration: 12.099,
+        environment: "test",
+        monitor_config: %{
+          "schedule" => %{
+            "type" => "interval",
+            "value" => 1,
+            "unit" => unquote(expected_unit)
+          },
+          "timezone" => "Europe/Rome"
+        }
+      )
+    end
+  end
 
-      assert check_in_body["monitor_config"] == %{
-               "schedule" => %{
-                 "type" => "crontab",
-                 "value" => "* 1 1 1 1"
-               },
-               "timezone" => "Europe/Rome"
-             }
-
-      send(test_pid, {ref, :done})
-
-      Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-    end)
+  test "captures exception events with monitor config", %{bypass: bypass} do
+    ref = SentryTest.setup_bypass_envelope_collector(bypass, type: "check_in")
 
     duration = System.convert_time_unit(12_099, :millisecond, :native)
 
@@ -205,7 +164,25 @@ defmodule Sentry.Integrations.Oban.CronTest do
       }
     })
 
-    assert_receive {^ref, :done}, 1000
+    assert [[{headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+    id = CheckInIDMappings.lookup_or_insert_new(942)
+
+    assert headers["type"] == "check_in"
+
+    assert_sentry_report(check_in_body,
+      check_in_id: id,
+      status: "error",
+      monitor_slug: "sentry-my-worker",
+      duration: 12.099,
+      environment: "test",
+      monitor_config: %{
+        "schedule" => %{
+          "type" => "crontab",
+          "value" => "* 1 1 1 1"
+        },
+        "timezone" => "Europe/Rome"
+      }
+    )
   end
 
   test "uses default monitor configuration in Sentry's config if present", %{bypass: bypass} do
@@ -219,28 +196,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
       ]
     )
 
-    test_pid = self()
-    ref = make_ref()
-
-    Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-      {:ok, body, conn} = Plug.Conn.read_body(conn)
-      assert [{_headers, check_in_body}] = decode_envelope!(body)
-
-      assert check_in_body["monitor_config"] == %{
-               "checkin_margin" => 10,
-               "failure_issue_threshold" => 84,
-               "max_runtime" => 42,
-               "schedule" => %{
-                 "type" => "crontab",
-                 "value" => "* 1 1 1 1"
-               },
-               "timezone" => "Europe/Rome"
-             }
-
-      send(test_pid, {ref, :done})
-
-      Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-    end)
+    ref = SentryTest.setup_bypass_envelope_collector(bypass, type: "check_in")
 
     :telemetry.execute([:oban, :job, :exception], %{duration: 0}, %{
       state: :success,
@@ -251,23 +207,26 @@ defmodule Sentry.Integrations.Oban.CronTest do
       }
     })
 
-    assert_receive {^ref, :done}, 1000
+    assert [[{_headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+
+    assert_sentry_report(check_in_body,
+      monitor_config: %{
+        "checkin_margin" => 10,
+        "failure_issue_threshold" => 84,
+        "max_runtime" => 42,
+        "schedule" => %{
+          "type" => "crontab",
+          "value" => "* 1 1 1 1"
+        },
+        "timezone" => "Europe/Rome"
+      }
+    )
   end
 
   @tag attach_opts: [monitor_slug_generator: {__MODULE__, :custom_name_generator}]
   test "monitor_slug is not affected if the custom monitor_name_generator does not target the worker",
        %{bypass: bypass} do
-    test_pid = self()
-    ref = make_ref()
-
-    Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-      {:ok, body, conn} = Plug.Conn.read_body(conn)
-      assert [{_headers, check_in_body}] = decode_envelope!(body)
-      assert check_in_body["monitor_slug"] == "sentry-my-worker"
-      send(test_pid, {ref, :done})
-
-      Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-    end)
+    ref = SentryTest.setup_bypass_envelope_collector(bypass, type: "check_in")
 
     :telemetry.execute([:oban, :job, :start], %{}, %{
       job: %Oban.Job{
@@ -277,24 +236,15 @@ defmodule Sentry.Integrations.Oban.CronTest do
       }
     })
 
-    assert_receive {^ref, :done}, 1000
+    assert [[{_headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+    assert_sentry_report(check_in_body, monitor_slug: "sentry-my-worker")
   end
 
   @tag attach_opts: [monitor_slug_generator: {__MODULE__, :custom_name_generator}]
   test "monitor_slug is set based on the custom monitor_name_generator if it targets the worker",
        %{bypass: bypass} do
     client_name = "my-client"
-    test_pid = self()
-    ref = make_ref()
-
-    Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-      {:ok, body, conn} = Plug.Conn.read_body(conn)
-      assert [{_headers, check_in_body}] = decode_envelope!(body)
-      assert check_in_body["monitor_slug"] == "sentry-client-worker-my-client"
-      send(test_pid, {ref, :done})
-
-      Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-    end)
+    ref = SentryTest.setup_bypass_envelope_collector(bypass, type: "check_in")
 
     :telemetry.execute([:oban, :job, :start], %{}, %{
       job: %Oban.Job{
@@ -305,25 +255,12 @@ defmodule Sentry.Integrations.Oban.CronTest do
       }
     })
 
-    assert_receive {^ref, :done}, 1000
+    assert [[{_headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+    assert_sentry_report(check_in_body, monitor_slug: "sentry-client-worker-my-client")
   end
 
   test "custom options overide job metadata", %{bypass: bypass} do
-    test_pid = self()
-    ref = make_ref()
-
-    Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-      {:ok, body, conn} = Plug.Conn.read_body(conn)
-      assert [{_headers, check_in_body}] = decode_envelope!(body)
-
-      assert check_in_body["monitor_slug"] == "this-is-a-custom-slug-123"
-      assert check_in_body["monitor_config"]["schedule"]["type"] == "interval"
-      assert check_in_body["monitor_config"]["timezone"] == "Europe/Rome"
-
-      send(test_pid, {ref, :done})
-
-      Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-    end)
+    ref = SentryTest.setup_bypass_envelope_collector(bypass, type: "check_in")
 
     defmodule WorkerWithCustomOptions do
       use Oban.Worker
@@ -351,7 +288,15 @@ defmodule Sentry.Integrations.Oban.CronTest do
       }
     })
 
-    assert_receive {^ref, :done}, 1000
+    assert [[{_headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+
+    assert_sentry_report(check_in_body,
+      monitor_slug: "this-is-a-custom-slug-123",
+      monitor_config: %{
+        "schedule" => %{"type" => "interval"},
+        "timezone" => "Europe/Rome"
+      }
+    )
   end
 
   def custom_name_generator(%Oban.Job{worker: "Sentry.ClientWorker", args: %{"client" => client}}) do

--- a/test/sentry/integrations/oban/cron_test.exs
+++ b/test/sentry/integrations/oban/cron_test.exs
@@ -76,10 +76,8 @@ defmodule Sentry.Integrations.Oban.CronTest do
       }
     })
 
-    assert [[{headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+    [check_in_body] = SentryTest.collect_sentry_check_ins(ref, 1)
     id = CheckInIDMappings.lookup_or_insert_new(123)
-
-    assert headers["type"] == "check_in"
 
     assert_sentry_report(check_in_body,
       check_in_id: id,
@@ -127,10 +125,8 @@ defmodule Sentry.Integrations.Oban.CronTest do
         }
       })
 
-      assert [[{headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+      [check_in_body] = SentryTest.collect_sentry_check_ins(ref, 1)
       id = CheckInIDMappings.lookup_or_insert_new(942)
-
-      assert headers["type"] == "check_in"
 
       assert_sentry_report(check_in_body,
         check_in_id: id,
@@ -164,10 +160,8 @@ defmodule Sentry.Integrations.Oban.CronTest do
       }
     })
 
-    assert [[{headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+    [check_in_body] = SentryTest.collect_sentry_check_ins(ref, 1)
     id = CheckInIDMappings.lookup_or_insert_new(942)
-
-    assert headers["type"] == "check_in"
 
     assert_sentry_report(check_in_body,
       check_in_id: id,
@@ -207,7 +201,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
       }
     })
 
-    assert [[{_headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+    [check_in_body] = SentryTest.collect_sentry_check_ins(ref, 1)
 
     assert_sentry_report(check_in_body,
       monitor_config: %{
@@ -236,7 +230,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
       }
     })
 
-    assert [[{_headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+    [check_in_body] = SentryTest.collect_sentry_check_ins(ref, 1)
     assert_sentry_report(check_in_body, monitor_slug: "sentry-my-worker")
   end
 
@@ -255,7 +249,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
       }
     })
 
-    assert [[{_headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+    [check_in_body] = SentryTest.collect_sentry_check_ins(ref, 1)
     assert_sentry_report(check_in_body, monitor_slug: "sentry-client-worker-my-client")
   end
 
@@ -288,7 +282,7 @@ defmodule Sentry.Integrations.Oban.CronTest do
       }
     })
 
-    assert [[{_headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+    [check_in_body] = SentryTest.collect_sentry_check_ins(ref, 1)
 
     assert_sentry_report(check_in_body,
       monitor_slug: "this-is-a-custom-slug-123",

--- a/test/sentry/integrations/oban/error_reporter_test.exs
+++ b/test/sentry/integrations/oban/error_reporter_test.exs
@@ -2,9 +2,10 @@ defmodule Sentry.Integrations.Oban.ErrorReporterTest do
   use ExUnit.Case, async: true
 
   import ExUnit.CaptureLog
-  import Sentry.TestHelpers
+  import Sentry.Test.Assertions
 
   alias Sentry.Integrations.Oban.ErrorReporter
+  alias Sentry.Test, as: SentryTest
 
   defmodule MyWorker do
     use Oban.Worker
@@ -17,35 +18,32 @@ defmodule Sentry.Integrations.Oban.ErrorReporterTest do
 
   describe "handle_event/4" do
     setup do
-      setup_bypass()
+      SentryTest.setup_sentry()
     end
 
-    test "reports the correct error to Sentry", %{bypass: bypass} do
-      ref = setup_bypass_envelope_collector(bypass, type: "event")
-
+    test "reports the correct error to Sentry" do
       emit_telemetry_for_failed_job(:error, %RuntimeError{message: "oops"}, [])
 
-      assert [event] = collect_envelopes(ref, 1) |> extract_events()
-      assert [%{"stacktrace" => %{"frames" => [stacktrace]}} = exception] = event["exception"]
+      event =
+        assert_sentry_report(:event,
+          tags: %{
+            "oban_queue" => "default",
+            "oban_state" => "available",
+            "oban_worker" => @worker_as_string
+          },
+          fingerprint: [@worker_as_string, "{{ default }}"]
+        )
 
-      assert exception["type"] == "RuntimeError"
-      assert exception["value"] == "oops"
-      assert exception["mechanism"]["handled"] == true
-      assert stacktrace["module"] == "Elixir.Sentry.Integrations.Oban.ErrorReporterTest.MyWorker"
-
-      assert stacktrace["function"] ==
-               "Sentry.Integrations.Oban.ErrorReporterTest.MyWorker.process/1"
-
-      assert event["tags"]["oban_queue"] == "default"
-      assert event["tags"]["oban_state"] == "available"
-      assert event["tags"]["oban_worker"] == "Sentry.Integrations.Oban.ErrorReporterTest.MyWorker"
-
-      assert event["fingerprint"] == [@worker_as_string, "{{ default }}"]
+      assert [exception] = event.exception
+      assert exception.type == "RuntimeError"
+      assert exception.value == "oops"
+      assert exception.mechanism.handled == true
+      assert [stacktrace] = exception.stacktrace.frames
+      assert stacktrace.module == MyWorker
+      assert stacktrace.function == "#{@worker_as_string}.process/1"
     end
 
-    test "unwraps Oban.PerformErrors and reports the wrapped error", %{bypass: bypass} do
-      ref = setup_bypass_envelope_collector(bypass, type: "event")
-
+    test "unwraps Oban.PerformErrors and reports the wrapped error" do
       emit_telemetry_for_failed_job(
         :error,
         %Oban.PerformError{
@@ -54,147 +52,119 @@ defmodule Sentry.Integrations.Oban.ErrorReporterTest do
         []
       )
 
-      assert [event] = collect_envelopes(ref, 1) |> extract_events()
-      assert [%{"stacktrace" => %{"frames" => [stacktrace]}} = exception] = event["exception"]
+      event =
+        assert_sentry_report(:event,
+          tags: %{
+            "oban_queue" => "default",
+            "oban_state" => "available",
+            "oban_worker" => @worker_as_string
+          },
+          fingerprint: [@worker_as_string, "{{ default }}"]
+        )
 
-      assert exception["type"] == "RuntimeError"
-      assert exception["value"] == "oops"
-      assert exception["mechanism"]["handled"] == true
-      assert stacktrace["module"] == "Elixir.Sentry.Integrations.Oban.ErrorReporterTest.MyWorker"
-
-      assert stacktrace["function"] ==
-               "Sentry.Integrations.Oban.ErrorReporterTest.MyWorker.process/1"
-
-      assert event["tags"]["oban_queue"] == "default"
-      assert event["tags"]["oban_state"] == "available"
-      assert event["tags"]["oban_worker"] == "Sentry.Integrations.Oban.ErrorReporterTest.MyWorker"
-
-      assert event["fingerprint"] == [@worker_as_string, "{{ default }}"]
+      assert [exception] = event.exception
+      assert exception.type == "RuntimeError"
+      assert exception.value == "oops"
+      assert exception.mechanism.handled == true
+      assert [stacktrace] = exception.stacktrace.frames
+      assert stacktrace.module == MyWorker
+      assert stacktrace.function == "#{@worker_as_string}.process/1"
     end
 
-    test "reports normalized non-exception errors to Sentry", %{bypass: bypass} do
-      ref = setup_bypass_envelope_collector(bypass, type: "event")
-
+    test "reports normalized non-exception errors to Sentry" do
       emit_telemetry_for_failed_job(:error, :undef, [])
 
-      assert [event] = collect_envelopes(ref, 1) |> extract_events()
+      event =
+        assert_sentry_report(:event,
+          message: nil,
+          tags: %{
+            "oban_queue" => "default",
+            "oban_state" => "available",
+            "oban_worker" => @worker_as_string
+          },
+          fingerprint: [@worker_as_string, "{{ default }}"]
+        )
 
-      assert event["message"] == nil
+      assert [exception] = event.exception
+      assert exception.type == "UndefinedFunctionError"
 
-      assert [%{"stacktrace" => %{"frames" => [stacktrace]}} = exception] = event["exception"]
-
-      assert exception["type"] == "UndefinedFunctionError"
-
-      assert exception["value"] ==
+      assert exception.value ==
                "function #{@worker_as_string}.process/1 is undefined or private"
 
-      assert exception["mechanism"]["handled"] == true
-      assert stacktrace["module"] == "Elixir.Sentry.Integrations.Oban.ErrorReporterTest.MyWorker"
-      assert stacktrace["function"] == "#{@worker_as_string}.process/1"
-
-      assert event["tags"]["oban_queue"] == "default"
-      assert event["tags"]["oban_state"] == "available"
-      assert event["tags"]["oban_worker"] == @worker_as_string
-
-      assert event["fingerprint"] == [@worker_as_string, "{{ default }}"]
+      assert exception.mechanism.handled == true
+      assert [stacktrace] = exception.stacktrace.frames
+      assert stacktrace.module == MyWorker
+      assert stacktrace.function == "#{@worker_as_string}.process/1"
     end
 
-    test "reports exits to Sentry", %{bypass: bypass} do
-      ref = setup_bypass_envelope_collector(bypass, type: "event")
-
+    test "reports exits to Sentry" do
       emit_telemetry_for_failed_job(:exit, :oops, [])
 
-      assert [event] = collect_envelopes(ref, 1) |> extract_events()
-
-      assert event["message"]["message"] == "Oban job #{@worker_as_string} exited: %s"
-      assert event["message"]["params"] == [":oops"]
-      assert event["message"]["formatted"] == "Oban job #{@worker_as_string} exited: :oops"
-
-      assert event["exception"] == []
-
-      assert event["tags"]["oban_queue"] == "default"
-      assert event["tags"]["oban_state"] == "available"
-      assert event["tags"]["oban_worker"] == @worker_as_string
-
-      assert event["fingerprint"] == [@worker_as_string, "{{ default }}"]
+      assert_sentry_report(:event,
+        message: %{
+          message: "Oban job #{@worker_as_string} exited: %s",
+          params: [":oops"],
+          formatted: "Oban job #{@worker_as_string} exited: :oops"
+        },
+        exception: [],
+        tags: %{
+          "oban_queue" => "default",
+          "oban_state" => "available",
+          "oban_worker" => @worker_as_string
+        },
+        fingerprint: [@worker_as_string, "{{ default }}"]
+      )
     end
 
-    test "reports throws to Sentry", %{bypass: bypass} do
-      ref = setup_bypass_envelope_collector(bypass, type: "event")
-
+    test "reports throws to Sentry" do
       emit_telemetry_for_failed_job(:throw, :this_was_not_caught, [])
 
-      assert [event] = collect_envelopes(ref, 1) |> extract_events()
-
-      assert event["message"]["message"] ==
-               "Oban job #{@worker_as_string} exited with an uncaught throw: %s"
-
-      assert event["message"]["params"] == [":this_was_not_caught"]
-
-      assert event["message"]["formatted"] ==
-               "Oban job #{@worker_as_string} exited with an uncaught throw: :this_was_not_caught"
-
-      assert event["exception"] == []
-
-      assert event["tags"]["oban_queue"] == "default"
-      assert event["tags"]["oban_state"] == "available"
-      assert event["tags"]["oban_worker"] == @worker_as_string
-
-      assert event["fingerprint"] == [@worker_as_string, "{{ default }}"]
+      assert_sentry_report(:event,
+        message: %{
+          message: "Oban job #{@worker_as_string} exited with an uncaught throw: %s",
+          params: [":this_was_not_caught"],
+          formatted:
+            "Oban job #{@worker_as_string} exited with an uncaught throw: :this_was_not_caught"
+        },
+        exception: [],
+        tags: %{
+          "oban_queue" => "default",
+          "oban_state" => "available",
+          "oban_worker" => @worker_as_string
+        },
+        fingerprint: [@worker_as_string, "{{ default }}"]
+      )
     end
 
     for reason <- [:cancel, :discard] do
-      test "doesn't report Oban.PerformError with reason #{inspect(reason)}", %{bypass: bypass} do
-        test_pid = self()
-
-        Bypass.stub(bypass, "POST", "/api/1/envelope/", fn conn ->
-          {:ok, body, conn} = Plug.Conn.read_body(conn)
-
-          # Only flag error events as unexpected. Stray transaction envelopes
-          # from background processes (e.g., OpenTelemetry span processor) may
-          # arrive due to concurrent persistent_term DSN writes in async tests.
-          if body =~ ~r/"type":\s*"event"/ do
-            send(test_pid, :unexpected_envelope)
-          end
-
-          Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-        end)
-
+      test "doesn't report Oban.PerformError with reason #{inspect(reason)}" do
         emit_telemetry_for_failed_job(
           :error,
           %Oban.PerformError{reason: {unquote(reason), "nah"}},
           []
         )
 
-        refute_receive :unexpected_envelope, 100
+        assert [] = SentryTest.pop_sentry_reports()
       end
     end
 
-    test "includes custom tags when oban_tags_to_sentry_tags function config option is set and returns non empty map",
-         %{bypass: bypass} do
-      ref = setup_bypass_envelope_collector(bypass, type: "event")
-
+    test "includes custom tags when oban_tags_to_sentry_tags function config option is set and returns non empty map" do
       emit_telemetry_for_failed_job(:error, %RuntimeError{message: "oops"}, [],
         oban_tags_to_sentry_tags: fn _job -> %{custom_tag: "custom_value"} end
       )
 
-      assert [event] = collect_envelopes(ref, 1) |> extract_events()
-      assert event["tags"]["custom_tag"] == "custom_value"
+      assert_sentry_report(:event, tags: %{"custom_tag" => "custom_value"})
     end
 
-    test "handles oban_tags_to_sentry_tags errors gracefully", %{bypass: bypass} do
-      ref = setup_bypass_envelope_collector(bypass, type: "event")
-
+    test "handles oban_tags_to_sentry_tags errors gracefully" do
       emit_telemetry_for_failed_job(:error, %RuntimeError{message: "oops"}, [],
         oban_tags_to_sentry_tags: fn _job -> raise "tag transform error" end
       )
 
-      assert [_event] = collect_envelopes(ref, 1) |> extract_events()
+      assert_sentry_report(:event, [])
     end
 
-    test "handles invalid oban_tags_to_sentry_tags return values gracefully", %{bypass: bypass} do
-      ref = setup_bypass_envelope_collector(bypass, type: "event")
-
+    test "handles invalid oban_tags_to_sentry_tags return values gracefully" do
       test_cases = [
         1,
         "invalid",
@@ -209,45 +179,29 @@ defmodule Sentry.Integrations.Oban.ErrorReporterTest do
         )
       end)
 
-      events = collect_envelopes(ref, length(test_cases)) |> extract_events()
+      events = SentryTest.pop_sentry_reports()
       assert length(events) == length(test_cases)
     end
 
-    test "supports MFA tuple for oban_tags_to_sentry_tags", %{bypass: bypass} do
+    test "supports MFA tuple for oban_tags_to_sentry_tags" do
       defmodule TestTagsTransform do
         def transform(_job), do: %{custom_tag: "custom_value"}
       end
-
-      ref = setup_bypass_envelope_collector(bypass, type: "event")
 
       emit_telemetry_for_failed_job(:error, %RuntimeError{message: "oops"}, [],
         oban_tags_to_sentry_tags: {TestTagsTransform, :transform}
       )
 
-      assert [event] = collect_envelopes(ref, 1) |> extract_events()
-      assert event["tags"]["custom_tag"] == "custom_value"
+      assert_sentry_report(:event, tags: %{"custom_tag" => "custom_value"})
     end
 
-    test "should_report_error_callback skips when callback returns false", %{bypass: bypass} do
+    test "should_report_error_callback skips when callback returns false" do
       job =
         %{"id" => "123", "entity" => "user", "type" => "delete"}
         |> MyWorker.new()
         |> Ecto.Changeset.apply_action!(:validate)
 
       reason = %RuntimeError{message: "oops"}
-      test_pid = self()
-
-      Bypass.stub(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-
-        # Only forward error events. Stray transaction envelopes from
-        # background processes may arrive in async tests.
-        if body =~ ~r/"type":\s*"event"/ do
-          send(test_pid, {:envelope, body})
-        end
-
-        Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-      end)
 
       job_attempt_1 = Map.merge(job, %{attempt: 1, max_attempts: 3})
 
@@ -262,7 +216,7 @@ defmodule Sentry.Integrations.Oban.ErrorReporterTest do
                  end
                )
 
-      refute_receive {:envelope, _}, 100
+      assert [] = SentryTest.pop_sentry_reports()
 
       # Final attempt: callback returns true -> report
       job_attempt_3 = Map.merge(job, %{attempt: 3, max_attempts: 3})
@@ -277,14 +231,12 @@ defmodule Sentry.Integrations.Oban.ErrorReporterTest do
                  end
                )
 
-      assert_receive {:envelope, body}
-      assert [event] = decode_envelope!(body) |> Enum.map(&elem(&1, 1))
-      assert [exception] = event["exception"]
-      assert exception["type"] == "RuntimeError"
-      assert event["tags"]["oban_worker"] == "Sentry.Integrations.Oban.ErrorReporterTest.MyWorker"
+      event = assert_sentry_report(:event, tags: %{"oban_worker" => @worker_as_string})
+      assert [exception] = event.exception
+      assert exception.type == "RuntimeError"
     end
 
-    test "should_report_error_callback receives worker module and job", %{bypass: bypass} do
+    test "should_report_error_callback receives worker module and job" do
       job =
         %{"id" => "123", "entity" => "user", "type" => "delete"}
         |> MyWorker.new()
@@ -292,10 +244,6 @@ defmodule Sentry.Integrations.Oban.ErrorReporterTest do
 
       reason = %RuntimeError{message: "oops"}
       test_pid = self()
-
-      Bypass.stub(bypass, "POST", "/api/1/envelope/", fn conn ->
-        Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-      end)
 
       assert :ok =
                ErrorReporter.handle_event(
@@ -313,23 +261,18 @@ defmodule Sentry.Integrations.Oban.ErrorReporterTest do
       assert received_job == job
     end
 
-    test "should_report_error_callback reports when callback returns true", %{bypass: bypass} do
-      ref = setup_bypass_envelope_collector(bypass, type: "event")
-
+    test "should_report_error_callback reports when callback returns true" do
       emit_telemetry_for_failed_job(:error, %RuntimeError{message: "oops"}, [],
         should_report_error_callback: fn _worker, _job -> true end
       )
 
-      assert [event] = collect_envelopes(ref, 1) |> extract_events()
-      assert [exception] = event["exception"]
-      assert exception["type"] == "RuntimeError"
-      assert exception["value"] == "oops"
+      event = assert_sentry_report(:event, [])
+      assert [exception] = event.exception
+      assert exception.type == "RuntimeError"
+      assert exception.value == "oops"
     end
 
-    test "should_report_error_callback handles errors gracefully and defaults to reporting",
-         %{bypass: bypass} do
-      ref = setup_bypass_envelope_collector(bypass, type: "event")
-
+    test "should_report_error_callback handles errors gracefully and defaults to reporting" do
       log =
         capture_log(fn ->
           emit_telemetry_for_failed_job(:error, %RuntimeError{message: "oops"}, [],
@@ -341,10 +284,10 @@ defmodule Sentry.Integrations.Oban.ErrorReporterTest do
       assert log =~ "Sentry.Integrations.Oban.ErrorReporterTest.MyWorker"
       assert log =~ "callback error"
 
-      assert [event] = collect_envelopes(ref, 1) |> extract_events()
-      assert [exception] = event["exception"]
-      assert exception["type"] == "RuntimeError"
-      assert exception["value"] == "oops"
+      event = assert_sentry_report(:event, [])
+      assert [exception] = event.exception
+      assert exception.type == "RuntimeError"
+      assert exception.value == "oops"
     end
   end
 

--- a/test/sentry/integrations/quantum/cron_test.exs
+++ b/test/sentry/integrations/quantum/cron_test.exs
@@ -54,10 +54,8 @@ defmodule Sentry.Integrations.Quantum.CronTest do
       telemetry_span_context: span_ref
     })
 
-    assert [[{headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+    [check_in_body] = SentryTest.collect_sentry_check_ins(ref, 1)
     id = CheckInIDMappings.lookup_or_insert_new("quantum-#{:erlang.phash2(span_ref)}")
-
-    assert headers["type"] == "check_in"
 
     assert_sentry_report(check_in_body,
       check_in_id: id,
@@ -91,10 +89,8 @@ defmodule Sentry.Integrations.Quantum.CronTest do
       telemetry_span_context: span_ref
     })
 
-    assert [[{headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+    [check_in_body] = SentryTest.collect_sentry_check_ins(ref, 1)
     id = CheckInIDMappings.lookup_or_insert_new("quantum-#{:erlang.phash2(span_ref)}")
-
-    assert headers["type"] == "check_in"
 
     assert_sentry_report(check_in_body,
       check_in_id: id,
@@ -127,10 +123,8 @@ defmodule Sentry.Integrations.Quantum.CronTest do
       telemetry_span_context: span_ref
     })
 
-    assert [[{headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+    [check_in_body] = SentryTest.collect_sentry_check_ins(ref, 1)
     id = CheckInIDMappings.lookup_or_insert_new("quantum-#{:erlang.phash2(span_ref)}")
-
-    assert headers["type"] == "check_in"
 
     assert_sentry_report(check_in_body,
       check_in_id: id,
@@ -167,7 +161,7 @@ defmodule Sentry.Integrations.Quantum.CronTest do
         telemetry_span_context: span_ref
       })
 
-      assert [[{_headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+      [check_in_body] = SentryTest.collect_sentry_check_ins(ref, 1)
       assert_sentry_report(check_in_body, monitor_slug: unquote(expected_slug))
     end
   end
@@ -183,7 +177,7 @@ defmodule Sentry.Integrations.Quantum.CronTest do
       telemetry_span_context: span_ref
     })
 
-    assert [[{_headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+    [check_in_body] = SentryTest.collect_sentry_check_ins(ref, 1)
     assert_sentry_report(check_in_body, monitor_slug: "quantum-generic-job")
   end
 
@@ -204,8 +198,7 @@ defmodule Sentry.Integrations.Quantum.CronTest do
       telemetry_span_context: span_ref
     })
 
-    assert [[{_start_headers, start_body}], [{_stop_headers, stop_body}]] =
-             SentryTest.collect_envelopes(ref, 2)
+    [start_body, stop_body] = SentryTest.collect_sentry_check_ins(ref, 2)
 
     assert_sentry_report(start_body, check_in_id: id)
     assert_sentry_report(stop_body, check_in_id: id)

--- a/test/sentry/integrations/quantum/cron_test.exs
+++ b/test/sentry/integrations/quantum/cron_test.exs
@@ -2,7 +2,10 @@ defmodule Sentry.Integrations.Quantum.CronTest do
   use Sentry.Case, async: false
 
   alias Sentry.Integrations.CheckInIDMappings
-  import Sentry.TestHelpers
+
+  import Sentry.Test.Assertions
+
+  alias Sentry.Test, as: SentryTest
 
   defmodule Scheduler do
     use Quantum, otp_app: :sentry
@@ -13,7 +16,7 @@ defmodule Sentry.Integrations.Quantum.CronTest do
   end
 
   setup do
-    setup_bypass(dedup_events: false, environment_name: "test")
+    SentryTest.setup_sentry(dedup_events: false, environment_name: "test")
   end
 
   for event_type <- [:start, :stop, :exception] do
@@ -39,34 +42,8 @@ defmodule Sentry.Integrations.Quantum.CronTest do
   end
 
   test "captures start events with monitor config", %{bypass: bypass} do
-    test_pid = self()
-    ref = make_ref()
-
-    Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-      {:ok, body, conn} = Plug.Conn.read_body(conn)
-      assert [{headers, check_in_body}] = decode_envelope!(body)
-      id = CheckInIDMappings.lookup_or_insert_new("quantum-#{:erlang.phash2(ref)}")
-
-      assert headers["type"] == "check_in"
-
-      assert check_in_body["check_in_id"] == id
-      assert check_in_body["status"] == "in_progress"
-      assert check_in_body["monitor_slug"] == "quantum-test-job"
-      assert check_in_body["duration"] == nil
-      assert check_in_body["environment"] == "test"
-
-      assert check_in_body["monitor_config"] == %{
-               "schedule" => %{
-                 "type" => "crontab",
-                 "value" => "0 0 * * * *"
-               },
-               "timezone" => "Etc/UTC"
-             }
-
-      send(test_pid, {ref, :done})
-
-      Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-    end)
+    ref = SentryTest.setup_bypass_envelope_collector(bypass, type: "check_in")
+    span_ref = make_ref()
 
     :telemetry.execute([:quantum, :job, :start], %{}, %{
       job:
@@ -74,41 +51,33 @@ defmodule Sentry.Integrations.Quantum.CronTest do
           name: :test_job,
           schedule: Crontab.CronExpression.Parser.parse!("@daily")
         ),
-      telemetry_span_context: ref
+      telemetry_span_context: span_ref
     })
 
-    assert_receive {^ref, :done}, 1000
+    assert [[{headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+    id = CheckInIDMappings.lookup_or_insert_new("quantum-#{:erlang.phash2(span_ref)}")
+
+    assert headers["type"] == "check_in"
+
+    assert_sentry_report(check_in_body,
+      check_in_id: id,
+      status: "in_progress",
+      monitor_slug: "quantum-test-job",
+      duration: nil,
+      environment: "test",
+      monitor_config: %{
+        "schedule" => %{
+          "type" => "crontab",
+          "value" => "0 0 * * * *"
+        },
+        "timezone" => "Etc/UTC"
+      }
+    )
   end
 
   test "captures exception events with monitor config", %{bypass: bypass} do
-    test_pid = self()
-    ref = make_ref()
-
-    Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-      {:ok, body, conn} = Plug.Conn.read_body(conn)
-      assert [{headers, check_in_body}] = decode_envelope!(body)
-      id = CheckInIDMappings.lookup_or_insert_new("quantum-#{:erlang.phash2(ref)}")
-
-      assert headers["type"] == "check_in"
-
-      assert check_in_body["check_in_id"] == id
-      assert check_in_body["status"] == "error"
-      assert check_in_body["monitor_slug"] == "quantum-test-job"
-      assert check_in_body["duration"] == 12.099
-      assert check_in_body["environment"] == "test"
-
-      assert check_in_body["monitor_config"] == %{
-               "schedule" => %{
-                 "type" => "crontab",
-                 "value" => "0 0 * * * *"
-               },
-               "timezone" => "Europe/Rome"
-             }
-
-      send(test_pid, {ref, :done})
-
-      Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-    end)
+    ref = SentryTest.setup_bypass_envelope_collector(bypass, type: "check_in")
+    span_ref = make_ref()
 
     duration = System.convert_time_unit(12_099, :millisecond, :native)
 
@@ -119,41 +88,33 @@ defmodule Sentry.Integrations.Quantum.CronTest do
           schedule: Crontab.CronExpression.Parser.parse!("@daily"),
           timezone: "Europe/Rome"
         ),
-      telemetry_span_context: ref
+      telemetry_span_context: span_ref
     })
 
-    assert_receive {^ref, :done}, 1000
+    assert [[{headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+    id = CheckInIDMappings.lookup_or_insert_new("quantum-#{:erlang.phash2(span_ref)}")
+
+    assert headers["type"] == "check_in"
+
+    assert_sentry_report(check_in_body,
+      check_in_id: id,
+      status: "error",
+      monitor_slug: "quantum-test-job",
+      duration: 12.099,
+      environment: "test",
+      monitor_config: %{
+        "schedule" => %{
+          "type" => "crontab",
+          "value" => "0 0 * * * *"
+        },
+        "timezone" => "Europe/Rome"
+      }
+    )
   end
 
   test "captures stop events with monitor config", %{bypass: bypass} do
-    test_pid = self()
-    ref = make_ref()
-
-    Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-      {:ok, body, conn} = Plug.Conn.read_body(conn)
-      assert [{headers, check_in_body}] = decode_envelope!(body)
-      id = CheckInIDMappings.lookup_or_insert_new("quantum-#{:erlang.phash2(ref)}")
-
-      assert headers["type"] == "check_in"
-
-      assert check_in_body["check_in_id"] == id
-      assert check_in_body["status"] == "ok"
-      assert check_in_body["monitor_slug"] == "quantum-test-job"
-      assert check_in_body["duration"] == 12.099
-      assert check_in_body["environment"] == "test"
-
-      assert check_in_body["monitor_config"] == %{
-               "schedule" => %{
-                 "type" => "crontab",
-                 "value" => "0 0 * * * *"
-               },
-               "timezone" => "Etc/UTC"
-             }
-
-      send(test_pid, {ref, :done})
-
-      Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-    end)
+    ref = SentryTest.setup_bypass_envelope_collector(bypass, type: "check_in")
+    span_ref = make_ref()
 
     duration = System.convert_time_unit(12_099, :millisecond, :native)
 
@@ -163,10 +124,28 @@ defmodule Sentry.Integrations.Quantum.CronTest do
           name: :test_job,
           schedule: Crontab.CronExpression.Parser.parse!("@daily")
         ),
-      telemetry_span_context: ref
+      telemetry_span_context: span_ref
     })
 
-    assert_receive {^ref, :done}, 1000
+    assert [[{headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+    id = CheckInIDMappings.lookup_or_insert_new("quantum-#{:erlang.phash2(span_ref)}")
+
+    assert headers["type"] == "check_in"
+
+    assert_sentry_report(check_in_body,
+      check_in_id: id,
+      status: "ok",
+      monitor_slug: "quantum-test-job",
+      duration: 12.099,
+      environment: "test",
+      monitor_config: %{
+        "schedule" => %{
+          "type" => "crontab",
+          "value" => "0 0 * * * *"
+        },
+        "timezone" => "Etc/UTC"
+      }
+    )
   end
 
   for {job_name, expected_slug} <- [
@@ -174,18 +153,8 @@ defmodule Sentry.Integrations.Quantum.CronTest do
         {MyApp.MyJob, "quantum-my-app-my-job"}
       ] do
     test "works for a job named #{inspect(job_name)}", %{bypass: bypass} do
-      test_pid = self()
-      ref = make_ref()
-
-      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-        assert [{_headers, check_in_body}] = decode_envelope!(body)
-
-        assert check_in_body["monitor_slug"] == unquote(expected_slug)
-        send(test_pid, {ref, :done})
-
-        Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-      end)
+      ref = SentryTest.setup_bypass_envelope_collector(bypass, type: "check_in")
+      span_ref = make_ref()
 
       duration = System.convert_time_unit(12_099, :millisecond, :native)
 
@@ -195,77 +164,50 @@ defmodule Sentry.Integrations.Quantum.CronTest do
             name: unquote(job_name),
             schedule: Crontab.CronExpression.Parser.parse!("@daily")
           ),
-        telemetry_span_context: ref
+        telemetry_span_context: span_ref
       })
 
-      assert_receive {^ref, :done}, 1000
+      assert [[{_headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+      assert_sentry_report(check_in_body, monitor_slug: unquote(expected_slug))
     end
   end
 
   test "works for a job without the name", %{bypass: bypass} do
-    test_pid = self()
-    ref = make_ref()
-
-    Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-      {:ok, body, conn} = Plug.Conn.read_body(conn)
-      assert [{_headers, check_in_body}] = decode_envelope!(body)
-
-      assert check_in_body["monitor_slug"] == "quantum-generic-job"
-      send(test_pid, {ref, :done})
-
-      Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-    end)
+    ref = SentryTest.setup_bypass_envelope_collector(bypass, type: "check_in")
+    span_ref = make_ref()
 
     duration = System.convert_time_unit(12_099, :millisecond, :native)
 
     :telemetry.execute([:quantum, :job, :stop], %{duration: duration}, %{
       job: Scheduler.new_job(schedule: Crontab.CronExpression.Parser.parse!("@daily")),
-      telemetry_span_context: ref
+      telemetry_span_context: span_ref
     })
 
-    assert_receive {^ref, :done}, 1000
+    assert [[{_headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+    assert_sentry_report(check_in_body, monitor_slug: "quantum-generic-job")
   end
 
   test "start event and same ref stop event have same check-in id", %{bypass: bypass} do
-    test_pid = self()
-    ref = make_ref()
-    id = CheckInIDMappings.lookup_or_insert_new("quantum-#{:erlang.phash2(ref)}")
-
-    Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-      {:ok, body, conn} = Plug.Conn.read_body(conn)
-      assert [{_headers, check_in_body}] = decode_envelope!(body)
-
-      assert check_in_body["check_in_id"] == id
-      send(test_pid, {ref, :done})
-
-      Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-    end)
+    ref = SentryTest.setup_bypass_envelope_collector(bypass, type: "check_in")
+    span_ref = make_ref()
+    id = CheckInIDMappings.lookup_or_insert_new("quantum-#{:erlang.phash2(span_ref)}")
 
     :telemetry.execute([:quantum, :job, :start], %{}, %{
       job: Scheduler.new_job(schedule: Crontab.CronExpression.Parser.parse!("@daily")),
-      telemetry_span_context: ref
+      telemetry_span_context: span_ref
     })
-
-    assert_receive {^ref, :done}, 1000
-
-    Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-      {:ok, body, conn} = Plug.Conn.read_body(conn)
-      assert [{_headers, check_in_body}] = decode_envelope!(body)
-
-      assert check_in_body["check_in_id"] == id
-
-      send(test_pid, {ref, :done})
-
-      Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-    end)
 
     duration = System.convert_time_unit(12_099, :millisecond, :native)
 
     :telemetry.execute([:quantum, :job, :stop], %{duration: duration}, %{
       job: Scheduler.new_job(schedule: Crontab.CronExpression.Parser.parse!("@daily")),
-      telemetry_span_context: ref
+      telemetry_span_context: span_ref
     })
 
-    assert_receive {^ref, :done}, 1000
+    assert [[{_start_headers, start_body}], [{_stop_headers, stop_body}]] =
+             SentryTest.collect_envelopes(ref, 2)
+
+    assert_sentry_report(start_body, check_in_id: id)
+    assert_sentry_report(stop_body, check_in_id: id)
   end
 end

--- a/test/sentry/integrations/telemetry_test.exs
+++ b/test/sentry/integrations/telemetry_test.exs
@@ -1,69 +1,55 @@
 defmodule Sentry.Integrations.TelemetryTest do
   use ExUnit.Case, async: true
 
-  import Sentry.TestHelpers
+  import Sentry.Test.Assertions
 
   alias Sentry.Integrations.Telemetry
+  alias Sentry.Test, as: SentryTest
+
+  @tags %{
+    telemetry_handler_id: "my_handler",
+    event_name: "[:my_app, :some_event]"
+  }
 
   describe "handle_event/4" do
     setup do
-      setup_bypass()
+      SentryTest.setup_sentry()
     end
 
-    test "reports errors", %{bypass: bypass} do
-      ref = setup_bypass_envelope_collector(bypass, type: "event")
-
+    test "reports errors" do
       handle_failure_event(:error, %RuntimeError{message: "oops"}, [])
 
-      assert [event] = collect_envelopes(ref, 1) |> extract_events()
+      event = assert_sentry_report(:event, tags: @tags)
 
-      assert event["tags"] == %{
-               "telemetry_handler_id" => "my_handler",
-               "event_name" => "[:my_app, :some_event]"
-             }
-
-      assert [exception] = event["exception"]
-      assert exception["type"] == "RuntimeError"
-      assert exception["value"] == "oops"
+      assert [exception] = event.exception
+      assert exception.type == "RuntimeError"
+      assert exception.value == "oops"
     end
 
-    test "reports Erlang errors (normalized)", %{bypass: bypass} do
-      ref = setup_bypass_envelope_collector(bypass, type: "event")
-
+    test "reports Erlang errors (normalized)" do
       handle_failure_event(:error, {:badmap, :foo}, [])
 
-      assert [event] = collect_envelopes(ref, 1) |> extract_events()
+      event = assert_sentry_report(:event, tags: @tags)
 
-      assert event["tags"] == %{
-               "telemetry_handler_id" => "my_handler",
-               "event_name" => "[:my_app, :some_event]"
-             }
-
-      assert [exception] = event["exception"]
-      assert exception["type"] == "BadMapError"
-      assert exception["value"] =~ "expected a map, got:"
-      assert exception["value"] =~ ":foo"
+      assert [exception] = event.exception
+      assert exception.type == "BadMapError"
+      assert exception.value =~ "expected a map, got:"
+      assert exception.value =~ ":foo"
     end
 
     for kind <- [:throw, :exit] do
-      test "reports #{kind}s", %{bypass: bypass} do
-        ref = setup_bypass_envelope_collector(bypass, type: "event")
-
+      test "reports #{kind}s" do
         handle_failure_event(unquote(kind), :foo, [])
 
-        assert [event] = collect_envelopes(ref, 1) |> extract_events()
-
-        assert event["message"]["message"] == "Telemetry handler %s failed"
-        assert event["message"]["formatted"] == "Telemetry handler my_handler failed"
-
-        assert event["tags"] == %{
-                 "telemetry_handler_id" => "my_handler",
-                 "event_name" => "[:my_app, :some_event]"
-               }
-
-        assert event["extra"] == %{"kind" => inspect(unquote(kind)), "reason" => ":foo"}
-
-        assert event["exception"] == []
+        assert_sentry_report(:event,
+          message: %{
+            message: "Telemetry handler %s failed",
+            formatted: "Telemetry handler my_handler failed"
+          },
+          tags: @tags,
+          extra: %{kind: inspect(unquote(kind)), reason: ":foo"},
+          exception: []
+        )
       end
     end
   end

--- a/test/sentry/metrics_integration_test.exs
+++ b/test/sentry/metrics_integration_test.exs
@@ -2,6 +2,7 @@ defmodule Sentry.MetricsIntegrationTest do
   use Sentry.Case, async: false
 
   import Sentry.TestHelpers
+  import Sentry.Test.Assertions
 
   alias Sentry.{Metrics, TelemetryProcessor}
   alias Sentry.Telemetry.Buffer
@@ -73,8 +74,8 @@ defmodule Sentry.MetricsIntegrationTest do
       Metrics.count("keep.me", 15)
       Metrics.count("drop.me", 5)
 
-      [batch] = collect_sentry_metric_items(ctx.ref, 1)
-      assert %{"items" => [%{"name" => "keep.me", "value" => 15}]} = batch
+      [%{"items" => [metric]}] = collect_sentry_metric_items(ctx.ref, 1)
+      assert_sentry_report(metric, name: "keep.me", value: 15)
 
       # The dropped metric should not produce an envelope
       ref = ctx.ref
@@ -90,9 +91,8 @@ defmodule Sentry.MetricsIntegrationTest do
 
       Metrics.count("test.metric", 5)
 
-      [batch] = collect_sentry_metric_items(ctx.ref, 1)
-      [metric] = batch["items"]
-      assert metric["value"] == 10
+      [%{"items" => [metric]}] = collect_sentry_metric_items(ctx.ref, 1)
+      assert_sentry_report(metric, value: 10)
     end
   end
 
@@ -100,20 +100,21 @@ defmodule Sentry.MetricsIntegrationTest do
     test "metrics include all required fields", ctx do
       Metrics.count("test.counter", 42, unit: "request", attributes: %{method: "GET"})
 
-      [[{header, payload}]] = collect_envelopes(ctx.ref, 1)
+      [[{header, %{"items" => [metric]} = payload}]] = collect_envelopes(ctx.ref, 1)
       assert header["content_type"] == "application/vnd.sentry.items.trace-metric+json"
 
-      %{"items" => [metric]} = payload
-      assert metric["type"] == "counter"
-      assert metric["name"] == "test.counter"
-      assert metric["value"] == 42
-      assert metric["unit"] == "request"
-      assert metric["timestamp"]
+      assert_sentry_report(metric,
+        type: "counter",
+        name: "test.counter",
+        value: 42,
+        unit: "request",
+        attributes: %{
+          :"sentry.sdk.name" => %{value: "sentry.elixir"},
+          method: %{value: "GET"}
+        }
+      )
 
-      # Check default attributes
-      attrs = metric["attributes"]
-      assert attrs["sentry.sdk.name"]["value"] == "sentry.elixir"
-      assert attrs["method"]["value"] == "GET"
+      assert payload["items"] |> hd() |> Map.get("timestamp")
     end
 
     test "metrics include environment and release", ctx do
@@ -121,12 +122,14 @@ defmodule Sentry.MetricsIntegrationTest do
 
       Metrics.gauge("memory.usage", 1024)
 
-      [batch] = collect_sentry_metric_items(ctx.ref, 1)
-      [metric] = batch["items"]
+      [%{"items" => [metric]}] = collect_sentry_metric_items(ctx.ref, 1)
 
-      attrs = metric["attributes"]
-      assert attrs["sentry.environment"]["value"] == "production"
-      assert attrs["sentry.release"]["value"] == "1.0.0"
+      assert_sentry_report(metric,
+        attributes: %{
+          :"sentry.environment" => %{value: "production"},
+          :"sentry.release" => %{value: "1.0.0"}
+        }
+      )
     end
 
     test "all three metric types are supported", ctx do
@@ -135,11 +138,11 @@ defmodule Sentry.MetricsIntegrationTest do
       Metrics.distribution("distribution.metric", 3.14)
 
       batches = collect_sentry_metric_items(ctx.ref, 3)
+      metrics = Enum.flat_map(batches, fn %{"items" => items} -> items end)
 
-      types = Enum.map(batches, fn %{"items" => [metric]} -> metric["type"] end)
-      assert "counter" in types
-      assert "gauge" in types
-      assert "distribution" in types
+      find_sentry_report!(metrics, type: "counter")
+      find_sentry_report!(metrics, type: "gauge")
+      find_sentry_report!(metrics, type: "distribution")
     end
   end
 end

--- a/test/sentry/metrics_integration_test.exs
+++ b/test/sentry/metrics_integration_test.exs
@@ -8,14 +8,8 @@ defmodule Sentry.MetricsIntegrationTest do
 
   setup context do
     bypass = Bypass.open()
-    test_pid = self()
-    ref = make_ref()
 
-    Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
-      {:ok, body, conn} = Plug.Conn.read_body(conn)
-      send(test_pid, {ref, body})
-      Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-    end)
+    ref = setup_bypass_envelope_collector(bypass)
 
     stop_supervised!(context.telemetry_processor)
 
@@ -38,13 +32,11 @@ defmodule Sentry.MetricsIntegrationTest do
       Metrics.count("metric.1", 1)
       Metrics.gauge("metric.2", 100)
 
-      bodies = collect_envelope_bodies(ctx.ref, 2)
-      items = Enum.map(bodies, &decode_envelope!/1)
-      assert length(items) == 2
+      batches = collect_sentry_metric_items(ctx.ref, 2)
+      assert length(batches) == 2
 
-      for [{header, payload}] <- items do
-        assert header["type"] == "trace_metric"
-        assert %{"items" => [%{"type" => _}]} = payload
+      for batch <- batches do
+        assert %{"items" => [%{"type" => _}]} = batch
       end
     end
 
@@ -67,8 +59,8 @@ defmodule Sentry.MetricsIntegrationTest do
 
       assert Buffer.size(buffer) == 0
 
-      bodies = collect_envelope_bodies(ctx.ref, 3)
-      assert length(bodies) == 3
+      batches = collect_sentry_metric_items(ctx.ref, 3)
+      assert length(batches) == 3
     end
 
     test "applies before_send_metric callback", ctx do
@@ -81,20 +73,12 @@ defmodule Sentry.MetricsIntegrationTest do
       Metrics.count("keep.me", 15)
       Metrics.count("drop.me", 5)
 
-      bodies = collect_envelope_bodies(ctx.ref, 1)
-      assert length(bodies) == 1
-
-      [items] = Enum.map(bodies, &decode_envelope!/1)
-
-      assert [
-               {%{"type" => "trace_metric"},
-                %{"items" => [%{"name" => "keep.me", "value" => 15}]}}
-             ] =
-               items
+      [batch] = collect_sentry_metric_items(ctx.ref, 1)
+      assert %{"items" => [%{"name" => "keep.me", "value" => 15}]} = batch
 
       # The dropped metric should not produce an envelope
       ref = ctx.ref
-      refute_receive {^ref, _body}, 200
+      refute_receive {:bypass_envelope, ^ref, _body}, 200
     end
 
     test "callback can modify metrics before sending", ctx do
@@ -106,9 +90,8 @@ defmodule Sentry.MetricsIntegrationTest do
 
       Metrics.count("test.metric", 5)
 
-      bodies = collect_envelope_bodies(ctx.ref, 1)
-      [items] = Enum.map(bodies, &decode_envelope!/1)
-      [{%{"type" => "trace_metric"}, %{"items" => [metric]}}] = items
+      [batch] = collect_sentry_metric_items(ctx.ref, 1)
+      [metric] = batch["items"]
       assert metric["value"] == 10
     end
   end
@@ -117,12 +100,7 @@ defmodule Sentry.MetricsIntegrationTest do
     test "metrics include all required fields", ctx do
       Metrics.count("test.counter", 42, unit: "request", attributes: %{method: "GET"})
 
-      bodies = collect_envelope_bodies(ctx.ref, 1)
-      [items] = Enum.map(bodies, &decode_envelope!/1)
-      [{header, payload}] = items
-
-      assert header["type"] == "trace_metric"
-
+      [[{header, payload}]] = collect_envelopes(ctx.ref, 1)
       assert header["content_type"] == "application/vnd.sentry.items.trace-metric+json"
 
       %{"items" => [metric]} = payload
@@ -143,9 +121,8 @@ defmodule Sentry.MetricsIntegrationTest do
 
       Metrics.gauge("memory.usage", 1024)
 
-      bodies = collect_envelope_bodies(ctx.ref, 1)
-      [items] = Enum.map(bodies, &decode_envelope!/1)
-      [{_header, %{"items" => [metric]}}] = items
+      [batch] = collect_sentry_metric_items(ctx.ref, 1)
+      [metric] = batch["items"]
 
       attrs = metric["attributes"]
       assert attrs["sentry.environment"]["value"] == "production"
@@ -157,29 +134,12 @@ defmodule Sentry.MetricsIntegrationTest do
       Metrics.gauge("gauge.metric", 100)
       Metrics.distribution("distribution.metric", 3.14)
 
-      bodies = collect_envelope_bodies(ctx.ref, 3)
-      items = Enum.flat_map(bodies, &decode_envelope!/1)
+      batches = collect_sentry_metric_items(ctx.ref, 3)
 
-      types = Enum.map(items, fn {_header, %{"items" => [metric]}} -> metric["type"] end)
+      types = Enum.map(batches, fn %{"items" => [metric]} -> metric["type"] end)
       assert "counter" in types
       assert "gauge" in types
       assert "distribution" in types
-    end
-  end
-
-  # Helper functions
-
-  defp collect_envelope_bodies(ref, expected_count) do
-    collect_envelope_bodies(ref, expected_count, [])
-  end
-
-  defp collect_envelope_bodies(_ref, 0, acc), do: Enum.reverse(acc)
-
-  defp collect_envelope_bodies(ref, remaining, acc) do
-    receive do
-      {^ref, body} -> collect_envelope_bodies(ref, remaining - 1, [body | acc])
-    after
-      2000 -> Enum.reverse(acc)
     end
   end
 end

--- a/test/sentry/opentelemetry/span_processor_test.exs
+++ b/test/sentry/opentelemetry/span_processor_test.exs
@@ -44,7 +44,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
 
     TestEndpoint.child_instrumented_function("one")
 
-    [tx] = collect_envelopes(ref, 1) |> extract_transactions()
+    [tx] = collect_sentry_transactions(ref, 1)
 
     assert tx["event_id"]
     assert tx["environment"] == "test"
@@ -64,7 +64,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
 
     TestEndpoint.instrumented_function()
 
-    [tx] = collect_envelopes(ref, 1) |> extract_transactions()
+    [tx] = collect_sentry_transactions(ref, 1)
 
     assert_valid_iso8601(tx["timestamp"])
     assert_valid_iso8601(tx["start_timestamp"])
@@ -105,7 +105,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
 
     TestEndpoint.instrumented_function()
 
-    [tx] = collect_envelopes(ref, 1) |> extract_transactions()
+    [tx] = collect_sentry_transactions(ref, 1)
 
     assert SpanStorage.get_root_span(tx["contexts"]["trace"]["span_id"], table_name: table_name) ==
              nil
@@ -168,7 +168,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
 
       TestEndpoint.instrumented_function()
 
-      [tx] = collect_envelopes(ref, 1) |> extract_transactions()
+      [tx] = collect_sentry_transactions(ref, 1)
       assert length(tx["spans"]) == 2
 
       [child_span_one, child_span_two] = tx["spans"]
@@ -190,7 +190,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
       end)
 
       Process.sleep(200)
-      transactions = collect_envelopes(ref, 100, timeout: 500) |> extract_transactions()
+      transactions = collect_sentry_transactions(ref, 100, timeout: 500)
 
       Enum.each(transactions, fn tx ->
         assert length(tx["spans"]) == 2
@@ -225,7 +225,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
         end
       end
 
-      [tx] = collect_envelopes(ref, 1) |> extract_transactions()
+      [tx] = collect_sentry_transactions(ref, 1)
 
       assert length(tx["spans"]) == 4
 
@@ -248,7 +248,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
 
       TestEndpoint.child_instrumented_function("standalone")
 
-      [tx] = collect_envelopes(ref, 1) |> extract_transactions()
+      [tx] = collect_sentry_transactions(ref, 1)
 
       assert length(tx["spans"]) == 0
       assert tx["transaction"] == "child_instrumented_function_standalone"
@@ -277,7 +277,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
       Enum.each(tasks, &Task.await/1)
 
       Process.sleep(200)
-      transactions = collect_envelopes(ref, 100, timeout: 500) |> extract_transactions()
+      transactions = collect_sentry_transactions(ref, 100, timeout: 500)
 
       Enum.each(transactions, fn tx ->
         assert length(tx["spans"]) == 1
@@ -315,7 +315,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
       end
 
       Process.sleep(200)
-      transactions = collect_envelopes(ref, 100, timeout: 500) |> extract_transactions()
+      transactions = collect_sentry_transactions(ref, 100, timeout: 500)
 
       Enum.each(transactions, fn tx ->
         trace_id = tx["contexts"]["trace"]["trace_id"]
@@ -380,7 +380,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
       end
 
       # Should capture the HTTP request span as a transaction root despite having an external parent
-      [tx] = collect_envelopes(ref, 1) |> extract_transactions()
+      [tx] = collect_sentry_transactions(ref, 1)
 
       # Verify transaction properties
       assert tx["transaction"] == "POST /api/users"
@@ -449,7 +449,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
       end
 
       # Should capture the HTTP request span as a transaction
-      [tx] = collect_envelopes(ref, 1) |> extract_transactions()
+      [tx] = collect_sentry_transactions(ref, 1)
 
       # Verify the HTTP server span was removed from storage
       # (even though it was stored as a child span due to having a remote parent)
@@ -489,7 +489,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
         Process.sleep(1)
       end
 
-      assert_sentry_report(collect_envelopes(ref, 1) |> extract_transactions(),
+      assert_sentry_report(collect_sentry_transactions(ref, 1),
         contexts: %{"trace" => %{"op" => "http.server", "description" => "GET /api/users"}}
       )
     end
@@ -509,7 +509,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
         Process.sleep(1)
       end
 
-      assert_sentry_report(collect_envelopes(ref, 1) |> extract_transactions(),
+      assert_sentry_report(collect_sentry_transactions(ref, 1),
         contexts: %{"trace" => %{"op" => "http.server", "description" => "GET"}}
       )
     end
@@ -530,7 +530,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
         Process.sleep(1)
       end
 
-      assert_sentry_report(collect_envelopes(ref, 1) |> extract_transactions(),
+      assert_sentry_report(collect_sentry_transactions(ref, 1),
         contexts: %{"trace" => %{"op" => "http.client", "description" => "GET /external/api"}}
       )
     end
@@ -552,7 +552,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
         Process.sleep(1)
       end
 
-      assert_sentry_report(collect_envelopes(ref, 1) |> extract_transactions(),
+      assert_sentry_report(collect_sentry_transactions(ref, 1),
         contexts: %{
           "trace" => %{
             "op" => "http.server",
@@ -578,7 +578,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
         Process.sleep(1)
       end
 
-      assert_sentry_report(collect_envelopes(ref, 1) |> extract_transactions(),
+      assert_sentry_report(collect_sentry_transactions(ref, 1),
         contexts: %{
           "trace" => %{"op" => "db", "description" => "SELECT * FROM users WHERE id = $1"}
         }
@@ -600,7 +600,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
         Process.sleep(1)
       end
 
-      assert_sentry_report(collect_envelopes(ref, 1) |> extract_transactions(),
+      assert_sentry_report(collect_sentry_transactions(ref, 1),
         contexts: %{"trace" => %{"op" => "db", "description" => nil}}
       )
     end
@@ -621,7 +621,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
         Process.sleep(1)
       end
 
-      assert_sentry_report(collect_envelopes(ref, 1) |> extract_transactions(),
+      assert_sentry_report(collect_sentry_transactions(ref, 1),
         contexts: %{
           "trace" => %{"op" => "queue.process", "description" => "MyApp.Workers.EmailWorker"}
         },
@@ -639,7 +639,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
         Process.sleep(1)
       end
 
-      assert_sentry_report(collect_envelopes(ref, 1) |> extract_transactions(),
+      assert_sentry_report(collect_sentry_transactions(ref, 1),
         contexts: %{"trace" => %{"op" => "custom_operation", "description" => "custom_operation"}}
       )
     end
@@ -662,7 +662,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
         end
       end
 
-      [tx] = collect_envelopes(ref, 1) |> extract_transactions()
+      [tx] = collect_sentry_transactions(ref, 1)
 
       assert length(tx["spans"]) == 1
       [child_span] = tx["spans"]
@@ -689,7 +689,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
         end
       end
 
-      [tx] = collect_envelopes(ref, 1) |> extract_transactions()
+      [tx] = collect_sentry_transactions(ref, 1)
 
       assert length(tx["spans"]) == 1
       [child_span] = tx["spans"]
@@ -868,7 +868,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
       end
 
       Process.sleep(200)
-      transactions = collect_envelopes(ref, 100, timeout: 500) |> extract_transactions()
+      transactions = collect_sentry_transactions(ref, 100, timeout: 500)
 
       linked_tx = find_sentry_report!(transactions, transaction: "GET /api/linked")
 
@@ -906,7 +906,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
       end
 
       Process.sleep(200)
-      transactions = collect_envelopes(ref, 100, timeout: 500) |> extract_transactions()
+      transactions = collect_sentry_transactions(ref, 100, timeout: 500)
 
       linked_tx = find_sentry_report!(transactions, transaction: "GET /api/linked")
 
@@ -939,7 +939,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
       end
 
       Process.sleep(200)
-      transactions = collect_envelopes(ref, 100, timeout: 500) |> extract_transactions()
+      transactions = collect_sentry_transactions(ref, 100, timeout: 500)
 
       parent_tx = find_sentry_report!(transactions, transaction: "GET /api/parent")
 
@@ -971,7 +971,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
         end
       end
 
-      [tx] = collect_envelopes(ref, 1) |> extract_transactions()
+      [tx] = collect_sentry_transactions(ref, 1)
 
       refute Map.has_key?(tx["contexts"]["trace"], "links")
       assert [child_span] = tx["spans"]
@@ -1008,7 +1008,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
       end
 
       Process.sleep(200)
-      transactions = collect_envelopes(ref, 100, timeout: 500) |> extract_transactions()
+      transactions = collect_sentry_transactions(ref, 100, timeout: 500)
 
       linked_tx = find_sentry_report!(transactions, transaction: "GET /api/multi-linked")
 

--- a/test/sentry/opentelemetry/span_processor_test.exs
+++ b/test/sentry/opentelemetry/span_processor_test.exs
@@ -8,6 +8,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
   require OpenTelemetry.SemConv.ClientAttributes, as: ClientAttributes
   require OpenTelemetry.SemConv.Incubating.MessagingAttributes, as: MessagingAttributes
 
+  import Sentry.Test.Assertions
   import Sentry.TestHelpers
 
   alias Sentry.OpenTelemetry.SpanStorage
@@ -488,10 +489,9 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
         Process.sleep(1)
       end
 
-      [tx] = collect_envelopes(ref, 1) |> extract_transactions()
-
-      assert tx["contexts"]["trace"]["op"] == "http.server"
-      assert tx["contexts"]["trace"]["description"] == "GET /api/users"
+      assert_sentry_report(collect_envelopes(ref, 1) |> extract_transactions(),
+        contexts: %{"trace" => %{"op" => "http.server", "description" => "GET /api/users"}}
+      )
     end
 
     @tag span_storage: true
@@ -509,10 +509,9 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
         Process.sleep(1)
       end
 
-      [tx] = collect_envelopes(ref, 1) |> extract_transactions()
-
-      assert tx["contexts"]["trace"]["op"] == "http.server"
-      assert tx["contexts"]["trace"]["description"] == "GET"
+      assert_sentry_report(collect_envelopes(ref, 1) |> extract_transactions(),
+        contexts: %{"trace" => %{"op" => "http.server", "description" => "GET"}}
+      )
     end
 
     @tag span_storage: true
@@ -531,10 +530,9 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
         Process.sleep(1)
       end
 
-      [tx] = collect_envelopes(ref, 1) |> extract_transactions()
-
-      assert tx["contexts"]["trace"]["op"] == "http.client"
-      assert tx["contexts"]["trace"]["description"] == "GET /external/api"
+      assert_sentry_report(collect_envelopes(ref, 1) |> extract_transactions(),
+        contexts: %{"trace" => %{"op" => "http.client", "description" => "GET /external/api"}}
+      )
     end
 
     @tag span_storage: true
@@ -554,10 +552,14 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
         Process.sleep(1)
       end
 
-      [tx] = collect_envelopes(ref, 1) |> extract_transactions()
-
-      assert tx["contexts"]["trace"]["op"] == "http.server"
-      assert tx["contexts"]["trace"]["description"] == "POST /api/login from 192.168.1.100"
+      assert_sentry_report(collect_envelopes(ref, 1) |> extract_transactions(),
+        contexts: %{
+          "trace" => %{
+            "op" => "http.server",
+            "description" => "POST /api/login from 192.168.1.100"
+          }
+        }
+      )
     end
 
     @tag span_storage: true
@@ -576,10 +578,11 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
         Process.sleep(1)
       end
 
-      [tx] = collect_envelopes(ref, 1) |> extract_transactions()
-
-      assert tx["contexts"]["trace"]["op"] == "db"
-      assert tx["contexts"]["trace"]["description"] == "SELECT * FROM users WHERE id = $1"
+      assert_sentry_report(collect_envelopes(ref, 1) |> extract_transactions(),
+        contexts: %{
+          "trace" => %{"op" => "db", "description" => "SELECT * FROM users WHERE id = $1"}
+        }
+      )
     end
 
     @tag span_storage: true
@@ -597,10 +600,9 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
         Process.sleep(1)
       end
 
-      [tx] = collect_envelopes(ref, 1) |> extract_transactions()
-
-      assert tx["contexts"]["trace"]["op"] == "db"
-      assert tx["contexts"]["trace"]["description"] == nil
+      assert_sentry_report(collect_envelopes(ref, 1) |> extract_transactions(),
+        contexts: %{"trace" => %{"op" => "db", "description" => nil}}
+      )
     end
 
     @tag span_storage: true
@@ -619,11 +621,12 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
         Process.sleep(1)
       end
 
-      [tx] = collect_envelopes(ref, 1) |> extract_transactions()
-
-      assert tx["contexts"]["trace"]["op"] == "queue.process"
-      assert tx["contexts"]["trace"]["description"] == "MyApp.Workers.EmailWorker"
-      assert tx["transaction"] == "MyApp.Workers.EmailWorker"
+      assert_sentry_report(collect_envelopes(ref, 1) |> extract_transactions(),
+        contexts: %{
+          "trace" => %{"op" => "queue.process", "description" => "MyApp.Workers.EmailWorker"}
+        },
+        transaction: "MyApp.Workers.EmailWorker"
+      )
     end
 
     @tag span_storage: true
@@ -636,10 +639,9 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
         Process.sleep(1)
       end
 
-      [tx] = collect_envelopes(ref, 1) |> extract_transactions()
-
-      assert tx["contexts"]["trace"]["op"] == "custom_operation"
-      assert tx["contexts"]["trace"]["description"] == "custom_operation"
+      assert_sentry_report(collect_envelopes(ref, 1) |> extract_transactions(),
+        contexts: %{"trace" => %{"op" => "custom_operation", "description" => "custom_operation"}}
+      )
     end
 
     @tag span_storage: true
@@ -868,10 +870,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
       Process.sleep(200)
       transactions = collect_envelopes(ref, 100, timeout: 500) |> extract_transactions()
 
-      linked_tx =
-        Enum.find(transactions, fn tx -> tx["transaction"] == "GET /api/linked" end)
-
-      assert linked_tx != nil
+      linked_tx = find_sentry_report!(transactions, transaction: "GET /api/linked")
 
       trace_links = linked_tx["contexts"]["trace"]["links"]
       assert is_list(trace_links)
@@ -909,8 +908,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
       Process.sleep(200)
       transactions = collect_envelopes(ref, 100, timeout: 500) |> extract_transactions()
 
-      linked_tx =
-        Enum.find(transactions, fn tx -> tx["transaction"] == "GET /api/linked" end)
+      linked_tx = find_sentry_report!(transactions, transaction: "GET /api/linked")
 
       [span_link] = linked_tx["contexts"]["trace"]["links"]
       assert span_link["attributes"] == %{"my.key" => "my.value"}
@@ -943,8 +941,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
       Process.sleep(200)
       transactions = collect_envelopes(ref, 100, timeout: 500) |> extract_transactions()
 
-      parent_tx =
-        Enum.find(transactions, fn tx -> tx["transaction"] == "GET /api/parent" end)
+      parent_tx = find_sentry_report!(transactions, transaction: "GET /api/parent")
 
       assert length(parent_tx["spans"]) == 1
       [child_span] = parent_tx["spans"]
@@ -1013,8 +1010,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
       Process.sleep(200)
       transactions = collect_envelopes(ref, 100, timeout: 500) |> extract_transactions()
 
-      linked_tx =
-        Enum.find(transactions, fn tx -> tx["transaction"] == "GET /api/multi-linked" end)
+      linked_tx = find_sentry_report!(transactions, transaction: "GET /api/multi-linked")
 
       trace_links = linked_tx["contexts"]["trace"]["links"]
       assert length(trace_links) == 2

--- a/test/sentry/test/assertions_test.exs
+++ b/test/sentry/test/assertions_test.exs
@@ -1,0 +1,346 @@
+defmodule Sentry.Test.AssertionsTest do
+  use ExUnit.Case, async: true
+
+  import Sentry.Test.Assertions
+
+  alias Sentry.Test, as: SentryTest
+
+  # All tests use direct ETS insertion to isolate assertion logic from the
+  # event collection pipeline. This avoids stray events from background
+  # processes (TelemetryProcessor scheduler) that can bleed in during
+  # full suite runs.
+
+  describe "assert_sentry_report/2 auto-pop with :event" do
+    setup do
+      SentryTest.setup_sentry()
+    end
+
+    test "pops exactly 1 event and validates criteria" do
+      insert_event(level: :error, message: msg("hello"))
+
+      event =
+        assert_sentry_report(:event,
+          level: :error,
+          message: %{formatted: "hello"}
+        )
+
+      assert %Sentry.Event{} = event
+    end
+
+    test "validates nested map subset matching" do
+      insert_event(level: :error, tags: %{env: "test", region: "us"})
+
+      assert_sentry_report(:event, tags: %{env: "test"})
+    end
+
+    test "validates regex matching" do
+      insert_event(level: :error, message: msg("hello world"))
+
+      assert_sentry_report(:event, message: %{formatted: ~r/hello/})
+    end
+
+    test "returns the matched item for further assertions" do
+      insert_event(
+        level: :error,
+        original_exception: %RuntimeError{message: "boom"}
+      )
+
+      event = assert_sentry_report(:event, level: :error)
+      assert event.original_exception == %RuntimeError{message: "boom"}
+    end
+
+    test "fails when 0 items captured" do
+      assert_raise ExUnit.AssertionError, ~r/Expected exactly 1 Sentry event, got 0/, fn ->
+        assert_sentry_report(:event, level: :error)
+      end
+    end
+
+    test "fails when 2+ items captured" do
+      insert_event(level: :error, message: msg("first"))
+      insert_event(level: :error, message: msg("second"))
+
+      assert_raise ExUnit.AssertionError, ~r/Expected exactly 1 Sentry event, got 2/, fn ->
+        assert_sentry_report(:event, level: :error)
+      end
+    end
+
+    test "fails on field mismatch with clear error" do
+      insert_event(level: :error)
+
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_sentry_report(:event, level: :warning)
+        end
+
+      assert error.message =~ "Sentry event assertion failed"
+      assert error.message =~ ":level"
+      assert error.message =~ "expected:"
+      assert error.message =~ ":warning"
+    end
+  end
+
+  describe "assert_sentry_report/2 auto-pop with :transaction" do
+    setup do
+      SentryTest.setup_sentry()
+    end
+
+    test "pops exactly 1 transaction and validates criteria" do
+      insert_transaction(span_id: "parent-312")
+
+      assert_sentry_report(:transaction, span_id: "parent-312")
+    end
+  end
+
+  describe "assert_sentry_report/2 auto-pop with :log" do
+    setup do
+      SentryTest.setup_sentry()
+    end
+
+    test "pops exactly 1 log and validates criteria" do
+      insert_log_event(:info, "test log message")
+
+      assert_sentry_report(:log, body: "test log message", level: :info)
+    end
+  end
+
+  describe "assert_sentry_report/2 with explicit data" do
+    test "validates a struct with atom-key criteria" do
+      event = build_event(level: :error, message: msg("hello"))
+
+      result = assert_sentry_report(event, level: :error, message: %{formatted: "hello"})
+      assert result == event
+    end
+
+    test "validates a JSON map with string-key criteria" do
+      json_map = %{
+        "level" => "error",
+        "message" => %{"formatted" => "hello"},
+        "tags" => %{"env" => "test", "region" => "us"}
+      }
+
+      assert_sentry_report(json_map, [{"level", "error"}, {"tags", %{"env" => "test"}}])
+    end
+
+    test "atom-key criteria works on JSON maps via fallback" do
+      json_map = %{"level" => "error", "message" => %{"formatted" => "hello"}}
+
+      assert_sentry_report(json_map, level: "error")
+    end
+
+    test "unwraps a single-element list" do
+      json_map = %{"level" => "error"}
+
+      assert_sentry_report([json_map], [{"level", "error"}])
+    end
+
+    test "fails on multi-element list" do
+      items = [%{"level" => "error"}, %{"level" => "warning"}]
+
+      assert_raise ExUnit.AssertionError, ~r/Expected exactly 1 Sentry report, got 2/, fn ->
+        assert_sentry_report(items, [{"level", "error"}])
+      end
+    end
+
+    test "fails on empty list" do
+      assert_raise ExUnit.AssertionError, ~r/Expected exactly 1 Sentry report, got 0/, fn ->
+        assert_sentry_report([], [{"level", "error"}])
+      end
+    end
+  end
+
+  describe "assert_sentry_log/2,3" do
+    setup do
+      SentryTest.setup_sentry()
+    end
+
+    test "finds matching log by level and exact body" do
+      insert_log_event(:info, "User session started")
+
+      log = assert_sentry_log(:info, "User session started")
+      assert %Sentry.LogEvent{} = log
+      assert log.body == "User session started"
+    end
+
+    test "finds matching log by level and regex body" do
+      insert_log_event(:info, "User session started for user 42")
+
+      log = assert_sentry_log(:info, ~r/session started/)
+      assert log.body == "User session started for user 42"
+    end
+
+    test "supports extra criteria" do
+      insert_log_event(:info, "test message", trace_id: "abc123")
+
+      log = assert_sentry_log(:info, "test message", trace_id: "abc123")
+      assert log.trace_id == "abc123"
+    end
+
+    test "fails when no matching log found" do
+      insert_log_event(:info, "other message")
+
+      assert_raise ExUnit.AssertionError, ~r/No matching Sentry log found/, fn ->
+        assert_sentry_log(:error, "nonexistent message")
+      end
+    end
+
+    test "skips logs that don't match level" do
+      insert_log_event(:info, "hello")
+
+      assert_raise ExUnit.AssertionError, ~r/No matching Sentry log found/, fn ->
+        assert_sentry_log(:error, "hello")
+      end
+    end
+  end
+
+  describe "find_sentry_report!/2" do
+    setup do
+      SentryTest.setup_sentry()
+    end
+
+    test "finds first matching item in a list of structs" do
+      insert_event(level: :error, message: msg("first"))
+      insert_event(level: :error, message: msg("second"))
+
+      events = SentryTest.pop_sentry_reports()
+      event = find_sentry_report!(events, message: %{formatted: "second"})
+
+      assert event.message.formatted == "second"
+    end
+
+    test "finds with regex matching" do
+      insert_event(level: :error, message: msg("hello world"))
+      insert_event(level: :error, message: msg("goodbye world"))
+
+      events = SentryTest.pop_sentry_reports()
+      event = find_sentry_report!(events, message: %{formatted: ~r/goodbye/})
+
+      assert event.message.formatted == "goodbye world"
+    end
+
+    test "works with JSON maps and string keys" do
+      items = [
+        %{"level" => "error", "message" => %{"formatted" => "first"}},
+        %{"level" => "warning", "message" => %{"formatted" => "second"}}
+      ]
+
+      item = find_sentry_report!(items, [{"level", "warning"}])
+      assert item["message"]["formatted"] == "second"
+    end
+
+    test "atom keys work on JSON maps via fallback" do
+      items = [
+        %{"level" => "error"},
+        %{"level" => "warning"}
+      ]
+
+      item = find_sentry_report!(items, level: "warning")
+      assert item["level"] == "warning"
+    end
+
+    test "fails with descriptive error when no match" do
+      insert_event(level: :error, message: msg("hello"))
+
+      events = SentryTest.pop_sentry_reports()
+
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          find_sentry_report!(events, message: %{formatted: "nonexistent"})
+        end
+
+      assert error.message =~ "No matching Sentry report found"
+      assert error.message =~ "1 item(s)"
+    end
+
+    test "fails on empty list" do
+      assert_raise ExUnit.AssertionError, ~r/No matching Sentry report found in 0 item/, fn ->
+        find_sentry_report!([], level: :error)
+      end
+    end
+  end
+
+  describe "integration with real event pipeline" do
+    setup do
+      SentryTest.setup_sentry()
+    end
+
+    test "assert_sentry_report works with captured events" do
+      Sentry.capture_message("integration test", result: :sync)
+
+      events = SentryTest.pop_sentry_reports()
+      event = find_sentry_report!(events, message: %{formatted: "integration test"})
+      assert event.level == :error
+    end
+
+    test "assert_sentry_report works with captured transactions" do
+      tx =
+        Sentry.Transaction.new(%{
+          span_id: "int-test-span",
+          start_timestamp: "2025-01-01T00:00:00Z",
+          timestamp: "2025-01-02T02:03:00Z",
+          contexts: %{trace: %{trace_id: "trace-int", span_id: "int-test-span"}},
+          spans: []
+        })
+
+      Sentry.send_transaction(tx, result: :sync)
+
+      txs = SentryTest.pop_sentry_transactions()
+      found = find_sentry_report!(txs, span_id: "int-test-span")
+      assert %Sentry.Transaction{} = found
+    end
+  end
+
+  # Test helpers — direct ETS insertion for isolation
+
+  defp msg(text) do
+    %Sentry.Interfaces.Message{formatted: text}
+  end
+
+  defp build_event(attrs) do
+    defaults = %{
+      event_id: Sentry.UUID.uuid4_hex(),
+      timestamp: DateTime.utc_now() |> DateTime.to_iso8601(),
+      platform: :elixir
+    }
+
+    struct!(Sentry.Event, Map.merge(defaults, Map.new(attrs)))
+  end
+
+  defp insert_event(attrs) do
+    event = build_event(attrs)
+    table = Process.get(:sentry_test_collector)
+    :ets.insert(table, {System.unique_integer([:monotonic]), event})
+    event
+  end
+
+  defp insert_transaction(attrs) do
+    defaults = %{
+      event_id: Sentry.UUID.uuid4_hex(),
+      span_id: "default-span",
+      start_timestamp: "2025-01-01T00:00:00Z",
+      timestamp: "2025-01-02T02:03:00Z",
+      contexts: %{trace: %{trace_id: "trace-default", span_id: "default-span"}},
+      spans: [],
+      platform: "elixir"
+    }
+
+    tx = struct!(Sentry.Transaction, Map.merge(defaults, Map.new(attrs)))
+    table = Process.get(:sentry_test_collector)
+    :ets.insert(table, {System.unique_integer([:monotonic]), tx})
+    tx
+  end
+
+  defp insert_log_event(level, body, extra \\ []) do
+    log_event =
+      struct!(
+        Sentry.LogEvent,
+        Keyword.merge(
+          [level: level, body: body, timestamp: System.system_time(:microsecond) / 1_000_000],
+          extra
+        )
+      )
+
+    table = Process.get(:sentry_test_collector)
+    :ets.insert(table, {System.unique_integer([:monotonic]), log_event})
+    log_event
+  end
+end

--- a/test/sentry/test/assertions_test.exs
+++ b/test/sentry/test/assertions_test.exs
@@ -258,6 +258,50 @@ defmodule Sentry.Test.AssertionsTest do
     end
   end
 
+  describe "assert_sentry_report/2 auto-pop with :metric" do
+    setup do
+      SentryTest.setup_sentry()
+    end
+
+    test "pops exactly 1 metric and validates criteria" do
+      insert_metric(type: :counter, name: "button.clicks", value: 1)
+
+      assert_sentry_report(:metric, type: :counter, name: "button.clicks", value: 1)
+    end
+
+    test "validates nested map subset matching" do
+      insert_metric(type: :gauge, name: "memory.usage", value: 512, attributes: %{pool: "main"})
+
+      assert_sentry_report(:metric, attributes: %{pool: "main"})
+    end
+
+    test "returns the matched item for further assertions" do
+      insert_metric(type: :distribution, name: "response.time", value: 42.5, unit: "millisecond")
+
+      metric = assert_sentry_report(:metric, name: "response.time")
+      assert metric.type == :distribution
+      assert metric.unit == "millisecond"
+    end
+
+    test "fails when 0 metrics captured" do
+      assert_raise ExUnit.AssertionError, ~r/Expected exactly 1 Sentry metric, got 0/, fn ->
+        assert_sentry_report(:metric, name: "button.clicks")
+      end
+    end
+
+    test "fails on field mismatch with clear error" do
+      insert_metric(type: :counter, name: "button.clicks", value: 1)
+
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_sentry_report(:metric, type: :gauge)
+        end
+
+      assert error.message =~ "Sentry metric assertion failed"
+      assert error.message =~ ":type"
+    end
+  end
+
   describe "integration with real event pipeline" do
     setup do
       SentryTest.setup_sentry()
@@ -342,5 +386,19 @@ defmodule Sentry.Test.AssertionsTest do
     table = Process.get(:sentry_test_collector)
     :ets.insert(table, {System.unique_integer([:monotonic]), log_event})
     log_event
+  end
+
+  defp insert_metric(attrs) do
+    defaults = [
+      type: :counter,
+      name: "test.metric",
+      value: 1,
+      timestamp: System.system_time(:nanosecond) / 1_000_000_000
+    ]
+
+    metric = struct!(Sentry.Metric, Keyword.merge(defaults, attrs))
+    table = Process.get(:sentry_test_collector)
+    :ets.insert(table, {System.unique_integer([:monotonic]), metric})
+    metric
   end
 end

--- a/test/sentry/test_test.exs
+++ b/test/sentry/test_test.exs
@@ -1,6 +1,8 @@
 defmodule Sentry.TestTest do
   use Sentry.Case, async: false
 
+  import Sentry.Test.Assertions
+
   alias Sentry.Test, as: SentryTest
 
   describe "setup_sentry/1" do
@@ -240,12 +242,7 @@ defmodule Sentry.TestTest do
 
       Sentry.TelemetryProcessor.flush()
 
-      logs = SentryTest.pop_sentry_logs()
-
-      # Filter for our specific message since the logger handler is global and may
-      # pick up log events from other concurrent async tests.
-      assert %Sentry.LogEvent{body: "pop_sentry_logs test message", level: :info} =
-               Enum.find(logs, &(&1.body == "pop_sentry_logs test message"))
+      assert_sentry_log(:info, "pop_sentry_logs test message")
     end
   end
 end

--- a/test/sentry_test.exs
+++ b/test/sentry_test.exs
@@ -2,7 +2,10 @@ defmodule SentryTest do
   use Sentry.Case
 
   import ExUnit.CaptureLog
+  import Sentry.Test.Assertions
   import Sentry.TestHelpers
+
+  alias Sentry.Test, as: SentryTest
 
   defmodule TestFilter do
     @behaviour Sentry.EventFilter
@@ -12,16 +15,10 @@ defmodule SentryTest do
   end
 
   setup do
-    setup_bypass(dedup_events: false)
+    SentryTest.setup_sentry(dedup_events: false)
   end
 
-  test "excludes events properly", %{bypass: bypass} do
-    Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
-      {:ok, body, conn} = Plug.Conn.read_body(conn)
-      assert body =~ "RuntimeError"
-      Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-    end)
-
+  test "excludes events properly" do
     put_test_config(filter: TestFilter)
 
     assert {:ok, _} =
@@ -40,6 +37,10 @@ defmodule SentryTest do
 
     assert {:ok, _} =
              Sentry.capture_message("RuntimeError: error", event_source: :plug, result: :sync)
+
+    events = SentryTest.pop_sentry_reports()
+    assert length(events) == 2
+    find_sentry_report!(events, original_exception: %RuntimeError{message: "error"})
   end
 
   @tag :capture_log
@@ -59,13 +60,10 @@ defmodule SentryTest do
     Bypass.pass(bypass)
   end
 
-  test "sets last_event_id_and_source when an event is sent", %{bypass: bypass} do
-    Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
-      Plug.Conn.send_resp(conn, 200, ~s<{"id": "340"}>)
-    end)
-
+  test "sets last_event_id_and_source when an event is sent" do
     Sentry.capture_message("test")
 
+    assert_sentry_report(:event, message: %{formatted: "test"})
     assert {event_id, nil} = Sentry.get_last_event_id_and_source()
     assert is_binary(event_id)
   end

--- a/test/sentry_test.exs
+++ b/test/sentry_test.exs
@@ -77,13 +77,9 @@ defmodule SentryTest do
     assert log =~ "Cannot report event without message or exception: %Sentry.Event{"
   end
 
-  test "doesn't incur into infinite logging loops because we prevent that", %{bypass: bypass} do
+  test "doesn't incur into infinite logging loops because we prevent that" do
     put_test_config(dedup_events: true)
     message_to_report = "Hello #{System.unique_integer([:positive])}"
-
-    Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
-      Plug.Conn.send_resp(conn, 200, ~s<{"id": "340"}>)
-    end)
 
     :ok =
       :logger.add_handler(:sentry_handler, Sentry.LoggerHandler, %{
@@ -95,7 +91,7 @@ defmodule SentryTest do
     end)
 
     # First one is reported correctly as it has no duplicates
-    assert {:ok, "340"} = Sentry.capture_message(message_to_report)
+    assert {:ok, _} = Sentry.capture_message(message_to_report)
 
     log =
       capture_log(fn ->
@@ -143,33 +139,9 @@ defmodule SentryTest do
   describe "send_check_in/1" do
     test "posts a check-in with all the explicit arguments", %{bypass: bypass} do
       put_test_config(environment_name: "test", release: "1.3.2")
+      ref = SentryTest.setup_bypass_envelope_collector(bypass, type: "check_in")
 
-      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-        assert [{headers, check_in_body}] = decode_envelope!(body)
-
-        assert headers["type"] == "check_in"
-        assert Map.has_key?(headers, "length")
-
-        assert check_in_body["status"] == "in_progress"
-        assert check_in_body["monitor_slug"] == "my-slug"
-        assert check_in_body["duration"] == 123.2
-        assert check_in_body["release"] == "1.3.2"
-        assert check_in_body["environment"] == "test"
-
-        assert check_in_body["monitor_config"] == %{
-                 "schedule" => %{"type" => "crontab", "value" => "0 * * * *"},
-                 "checkin_margin" => 5,
-                 "max_runtime" => 30,
-                 "failure_issue_threshold" => 2,
-                 "recovery_threshold" => 2,
-                 "timezone" => "America/Los_Angeles"
-               }
-
-        Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-      end)
-
-      assert {:ok, "1923"} =
+      assert {:ok, _} =
                Sentry.capture_check_in(
                  status: :in_progress,
                  monitor_slug: "my-slug",
@@ -186,28 +158,47 @@ defmodule SentryTest do
                    timezone: "America/Los_Angeles"
                  ]
                )
+
+      [[{headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
+
+      assert headers["type"] == "check_in"
+      assert Map.has_key?(headers, "length")
+
+      assert_sentry_report(check_in_body,
+        status: "in_progress",
+        monitor_slug: "my-slug",
+        duration: 123.2,
+        release: "1.3.2",
+        environment: "test",
+        monitor_config: %{
+          "schedule" => %{"type" => "crontab", "value" => "0 * * * *"},
+          "checkin_margin" => 5,
+          "max_runtime" => 30,
+          "failure_issue_threshold" => 2,
+          "recovery_threshold" => 2,
+          "timezone" => "America/Los_Angeles"
+        }
+      )
     end
 
     test "posts a check-in with default arguments", %{bypass: bypass} do
       put_test_config(environment_name: "test", release: "1.3.2")
+      ref = SentryTest.setup_bypass_envelope_collector(bypass, type: "check_in")
 
-      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-        assert [{headers, check_in_body}] = decode_envelope!(body)
+      assert {:ok, _} = Sentry.capture_check_in(status: :ok, monitor_slug: "default-slug")
 
-        assert headers["type"] == "check_in"
-        assert Map.has_key?(headers, "length")
+      [[{headers, check_in_body}]] = SentryTest.collect_envelopes(ref, 1)
 
-        assert check_in_body["status"] == "ok"
-        assert check_in_body["monitor_slug"] == "default-slug"
-        assert Map.fetch!(check_in_body, "duration") == nil
-        assert Map.fetch!(check_in_body, "release") == "1.3.2"
-        assert Map.fetch!(check_in_body, "environment") == "test"
+      assert headers["type"] == "check_in"
+      assert Map.has_key?(headers, "length")
 
-        Plug.Conn.send_resp(conn, 200, ~s<{"id": "1923"}>)
-      end)
-
-      assert {:ok, "1923"} = Sentry.capture_check_in(status: :ok, monitor_slug: "default-slug")
+      assert_sentry_report(check_in_body,
+        status: "ok",
+        monitor_slug: "default-slug",
+        duration: nil,
+        release: "1.3.2",
+        environment: "test"
+      )
     end
   end
 
@@ -252,22 +243,10 @@ defmodule SentryTest do
       {:ok, transaction: transaction}
     end
 
-    test "sends transaction to Sentry when configured properly", %{
-      bypass: bypass,
-      transaction: transaction
-    } do
-      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-        assert [{headers, transaction_body}] = decode_envelope!(body)
+    test "sends transaction to Sentry when configured properly", %{transaction: transaction} do
+      assert {:ok, _} = Sentry.send_transaction(transaction)
 
-        assert headers["type"] == "transaction"
-        assert Map.has_key?(headers, "length")
-        assert transaction_body["transaction"] == "test-transaction"
-
-        Plug.Conn.send_resp(conn, 200, ~s<{"id": "340"}>)
-      end)
-
-      assert {:ok, "340"} = Sentry.send_transaction(transaction)
+      assert_sentry_report(:transaction, transaction: "test-transaction")
     end
 
     test "validates options", %{transaction: transaction} do
@@ -282,15 +261,10 @@ defmodule SentryTest do
       assert :ignored = Sentry.send_transaction(transaction)
     end
 
-    test "respects sample_rate option", %{bypass: bypass, transaction: transaction} do
-      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-        assert [{headers, _transaction_body}] = decode_envelope!(body)
-        assert headers["type"] == "transaction"
-        Plug.Conn.send_resp(conn, 200, ~s<{"id": "340"}>)
-      end)
+    test "respects sample_rate option", %{transaction: transaction} do
+      assert {:ok, _} = Sentry.send_transaction(transaction, sample_rate: 1.0)
 
-      assert {:ok, "340"} = Sentry.send_transaction(transaction, sample_rate: 1.0)
+      assert_sentry_report(:transaction, transaction: "test-transaction")
     end
 
     test "supports before_send option", %{bypass: bypass, transaction: transaction} do
@@ -298,34 +272,29 @@ defmodule SentryTest do
       assert :excluded =
                Sentry.send_transaction(transaction, before_send: fn _transaction -> false end)
 
-      # Modify transaction
-      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
+      # Modify transaction — passing before_send as a per-call option bypasses
+      # the collecting callback installed by setup_sentry, so use the envelope
+      # collector to assert on the wire payload instead.
+      ref = SentryTest.setup_bypass_envelope_collector(bypass, type: "transaction")
 
-        assert [{headers, transaction_body}] = decode_envelope!(body)
-        assert headers["type"] == "transaction"
-        assert transaction_body["transaction"] == "modified-transaction"
-
-        Plug.Conn.send_resp(conn, 200, ~s<{"id": "340"}>)
-      end)
-
-      assert {:ok, "340"} =
+      assert {:ok, _} =
                Sentry.send_transaction(
                  transaction,
                  before_send: fn transaction ->
                    %{transaction | transaction: "modified-transaction"}
                  end
                )
+
+      assert_sentry_report(
+        SentryTest.collect_envelopes(ref, 1) |> SentryTest.extract_transactions(),
+        transaction: "modified-transaction"
+      )
     end
 
-    test "supports after_send_event option", %{bypass: bypass, transaction: transaction} do
+    test "supports after_send_event option", %{transaction: transaction} do
       parent = self()
 
-      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-        Plug.Conn.send_resp(conn, 200, ~s<{"id": "340"}>)
-      end)
-
-      assert {:ok, "340"} =
+      assert {:ok, id} =
                Sentry.send_transaction(
                  transaction,
                  after_send_event: fn transaction, {:ok, id} ->
@@ -333,10 +302,10 @@ defmodule SentryTest do
                  end
                )
 
-      assert_receive {:after_send, "test-transaction", "340"}
+      assert_receive {:after_send, "test-transaction", ^id}
     end
 
-    test "includes release in transaction payload when configured", %{bypass: bypass} do
+    test "includes release in transaction payload when configured" do
       put_test_config(release: "1.9.123")
 
       transaction =
@@ -350,17 +319,12 @@ defmodule SentryTest do
           }
         })
 
-      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-        assert [{_headers, transaction_body}] = decode_envelope!(body)
+      assert {:ok, _} = Sentry.send_transaction(transaction)
 
-        assert transaction_body["transaction"] == "transaction-with-release"
-        assert transaction_body["release"] == "1.9.123"
-
-        Plug.Conn.send_resp(conn, 200, ~s<{"id": "340"}>)
-      end)
-
-      assert {:ok, "340"} = Sentry.send_transaction(transaction)
+      assert_sentry_report(:transaction,
+        transaction: "transaction-with-release",
+        release: "1.9.123"
+      )
     end
   end
 

--- a/test/sentry_test.exs
+++ b/test/sentry_test.exs
@@ -286,7 +286,7 @@ defmodule SentryTest do
                )
 
       assert_sentry_report(
-        SentryTest.collect_envelopes(ref, 1) |> SentryTest.extract_transactions(),
+        SentryTest.collect_sentry_transactions(ref, 1),
         transaction: "modified-transaction"
       )
     end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -92,6 +92,18 @@ defmodule Sentry.TestHelpers do
   defdelegate extract_events(envelope_items_list), to: Sentry.Test
   defdelegate extract_transactions(envelope_items_list), to: Sentry.Test
   defdelegate extract_log_items(envelope_items_list), to: Sentry.Test
+  defdelegate extract_check_ins(envelope_items_list), to: Sentry.Test
+  defdelegate extract_metric_items(envelope_items_list), to: Sentry.Test
+  defdelegate collect_sentry_events(ref, count), to: Sentry.Test
+  defdelegate collect_sentry_events(ref, count, opts), to: Sentry.Test
+  defdelegate collect_sentry_transactions(ref, count), to: Sentry.Test
+  defdelegate collect_sentry_transactions(ref, count, opts), to: Sentry.Test
+  defdelegate collect_sentry_logs(ref, count), to: Sentry.Test
+  defdelegate collect_sentry_logs(ref, count, opts), to: Sentry.Test
+  defdelegate collect_sentry_check_ins(ref, count), to: Sentry.Test
+  defdelegate collect_sentry_check_ins(ref, count, opts), to: Sentry.Test
+  defdelegate collect_sentry_metric_items(ref, count), to: Sentry.Test
+  defdelegate collect_sentry_metric_items(ref, count, opts), to: Sentry.Test
 
   def setup_bypass_envelope_collector(bypass, opts \\ []),
     do: Sentry.Test.setup_bypass_envelope_collector(bypass, opts)

--- a/test_integrations/phoenix_app/test/phoenix_app/repo_test.exs
+++ b/test_integrations/phoenix_app/test/phoenix_app/repo_test.exs
@@ -14,7 +14,7 @@ defmodule PhoenixApp.RepoTest do
 
     Repo.all(User) |> Enum.map(& &1.id)
 
-    assert [tx] = collect_envelopes(ref, 1) |> extract_transactions()
+    assert [tx] = collect_sentry_transactions(ref, 1)
 
     assert tx["transaction_info"] == %{"source" => "custom"}
 

--- a/test_integrations/phoenix_app/test/support/test_helpers.ex
+++ b/test_integrations/phoenix_app/test/support/test_helpers.ex
@@ -58,6 +58,18 @@ defmodule Sentry.TestHelpers do
   defdelegate extract_events(envelope_items_list), to: Sentry.Test
   defdelegate extract_transactions(envelope_items_list), to: Sentry.Test
   defdelegate extract_log_items(envelope_items_list), to: Sentry.Test
+  defdelegate extract_check_ins(envelope_items_list), to: Sentry.Test
+  defdelegate extract_metric_items(envelope_items_list), to: Sentry.Test
+  defdelegate collect_sentry_events(ref, count), to: Sentry.Test
+  defdelegate collect_sentry_events(ref, count, opts), to: Sentry.Test
+  defdelegate collect_sentry_transactions(ref, count), to: Sentry.Test
+  defdelegate collect_sentry_transactions(ref, count, opts), to: Sentry.Test
+  defdelegate collect_sentry_logs(ref, count), to: Sentry.Test
+  defdelegate collect_sentry_logs(ref, count, opts), to: Sentry.Test
+  defdelegate collect_sentry_check_ins(ref, count), to: Sentry.Test
+  defdelegate collect_sentry_check_ins(ref, count, opts), to: Sentry.Test
+  defdelegate collect_sentry_metric_items(ref, count), to: Sentry.Test
+  defdelegate collect_sentry_metric_items(ref, count, opts), to: Sentry.Test
 
   def setup_bypass_envelope_collector(bypass, opts \\ []),
     do: Sentry.Test.setup_bypass_envelope_collector(bypass, opts)


### PR DESCRIPTION
This branch introduces `Sentry.Test.Assertions`, a new module of ExUnit assertion helpers that reduce boilerplate when validating captured Sentry events, transactions, logs, and metrics in tests. It also adds high-level envelope collection helpers to `Sentry.Test` that replace the previous `collect_envelopes + extract_*` pipelines.

---

## New Module: `Sentry.Test.Assertions`

**File:** `lib/sentry/test/assertions.ex`

Three public functions are provided:

| Function | Purpose |
|----------|---------|
| `assert_sentry_report/2` | Assert exactly one event/transaction/log/metric was captured and matches criteria |
| `assert_sentry_log/3` | Assert a log matching level + body pattern (find semantics, not exactly-one) |
| `find_sentry_report!/2` | Find the first matching item in a list |

### Matching rules

- **Regex** — matched with `=~`
- **Plain map** — recursive subset match (every key in expected must exist with a matching value)
- **Any other value** — compared with `==`
- Atom keys fall back to string keys and vice versa, so assertions work on both Sentry structs and decoded JSON maps.

---

## Examples

### Basic event assertion

```elixir
defmodule MyAppTest do
  use ExUnit.Case, async: true
  import Sentry.Test.Assertions

  setup :start_collecting_sentry_reports

  test "captures a runtime error" do
    capture_sentry_exception(RuntimeError, "something went wrong")

    assert_sentry_report(:event,
      level: :error,
      message: %{formatted: "something went wrong"}
    )
  end
end
```

### Regex matching

```elixir
test "captures a plug error" do
  # exact string or regex both work
  assert_sentry_report(:event, message: %{formatted: ~r/went wrong/})
end
```

### Nested map subset matching (partial tags)

```elixir
test "event includes expected tags" do
  # passes as long as env: "prod" is present — other tags are ignored
  assert_sentry_report(:event, tags: %{env: "prod"})
end
```

### Chaining further assertions on the returned value

```elixir
test "captures the original exception" do
  trigger_error()

  event = assert_sentry_report(:event, level: :error)

  # assert_sentry_report returns the matched item for further checks
  assert event.original_exception == %RuntimeError{message: "boom"}
  assert event.source == :plug
end
```

### Transaction assertion

```elixir
test "records an OTel span as a Sentry transaction" do
  run_traced_job()

  assert_sentry_report(:transaction, transaction: "my_queue.worker")
end
```

### Log assertion

```elixir
test "logs a warning at the expected level" do
  trigger_warning()

  # find semantics — works even when multiple logs are emitted
  log = assert_sentry_log(:warning, ~r/deprecated/)
  assert log.attributes[:module] == MyModule
end
```

### Extra criteria on logs

```elixir
test "log carries the correct trace id" do
  assert_sentry_log(:info, "session started", trace_id: "abc123")
end
```

### Asserting on raw envelope data (HTTP-level tests)

```elixir
test "event sent over HTTP has the right tags" do
  ref = setup_bypass_envelope_collector(bypass)

  trigger_error()

  [event] = collect_sentry_events(ref, 1)

  # works on decoded JSON maps — string keys, atom-key criteria, both fine
  assert_sentry_report(event, "tags" => %{"oban_queue" => "default"})
end
```

### Metric assertion (struct-level)

```elixir
setup do
  Sentry.Test.setup_sentry(enable_metrics: true)
end

test "records a counter metric" do
  Sentry.Metrics.count("button.clicks", 1, attributes: %{button: "submit"})

  metric = assert_sentry_report(:metric, type: :counter, name: "button.clicks")
  assert metric.attributes[:button] == "submit"
end
```

### Metric assertion (HTTP envelope level)

```elixir
test "metric batch is sent with correct fields" do
  ref = setup_bypass_envelope_collector(bypass, type: "trace_metric")

  Sentry.Metrics.gauge("memory.usage", 1024, unit: "megabyte")

  [batch] = collect_sentry_metric_items(ref, 1)
  [metric] = batch["items"]
  assert metric["name"] == "memory.usage"
  assert metric["type"] == "gauge"
  assert metric["unit"] == "megabyte"
end
```

### Finding one event among many

```elixir
test "captures multiple events but only one is the interesting one" do
  trigger_many_errors()

  events = Sentry.Test.pop_sentry_reports()

  event = find_sentry_report!(events, message: %{formatted: ~r/interesting/})
  assert event.level == :error
end
```
