### PR TITLE
chore: Allow usage of hackney 4.x

### DIFF
--- a/lib/mix/tasks/sentry.install.ex
+++ b/lib/mix/tasks/sentry.install.ex
@@ -43,7 +43,7 @@ if Code.ensure_loaded?(Igniter) do
     def info(_argv, _composing_task) do
       %Igniter.Mix.Task.Info{
         group: :sentry,
-        adds_deps: [{:jason, "~> 1.2"}, {:hackney, "~> 1.8"}],
+        adds_deps: [{:jason, "~> 1.2"}, {:hackney, ">= 1.8.0 and < 5.0.0"}],
         example: __MODULE__.Docs.example(),
         schema: [dsn: :string],
         defaults: [dsn: "<your_dsn>"]

--- a/mix.exs
+++ b/mix.exs
@@ -98,7 +98,7 @@ defmodule Sentry.Mixfile do
     [
       {:nimble_options, "~> 1.0"},
       # Optional dependencies
-      {:hackney, "~> 1.8", optional: true},
+      {:hackney, ">= 1.8.0 and < 5.0.0", optional: true},
       {:finch, "~> 0.21", optional: true},
       {:jason, "~> 1.1", optional: true},
       {:phoenix, "~> 1.6", optional: true},


### PR DESCRIPTION
### Description

Hackney has update several major versions in 2026, including security fixes. Looking at the hackney adapter, none of their breaking changes effect the sentry code.