### PR TITLE
fix(live_view_hook): handle Bandit.TransportError and URI struct in connect_info

### DIFF
--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -298,7 +298,12 @@ defmodule Sentry.Client do
     |> update_if_present(:breadcrumbs, fn bcs -> Enum.map(bcs, &Map.from_struct/1) end)
     |> update_if_present(:sdk, &Map.from_struct/1)
     |> update_if_present(:message, &sanitize_message(&1, json_library))
-    |> update_if_present(:request, &(&1 |> Map.from_struct() |> remove_nils()))
+    |> update_if_present(:request, fn req ->
+      req
+      |> Map.from_struct()
+      |> remove_nils()
+      |> sanitize_non_jsonable_values(json_library)
+    end)
     |> update_if_present(:extra, &sanitize_non_jsonable_values(&1, json_library))
     |> update_if_present(:user, &sanitize_non_jsonable_values(&1, json_library))
     |> update_if_present(:tags, &sanitize_non_jsonable_values(&1, json_library))

--- a/lib/sentry/live_view_hook.ex
+++ b/lib/sentry/live_view_hook.ex
@@ -156,7 +156,10 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     defp on_mount(params, %Phoenix.LiveView.Socket{} = socket) do
       Context.set_extra_context(%{socket_id: socket.id})
-      Context.set_request_context(%{url: socket.host_uri})
+
+      if uri = socket.host_uri do
+        Context.set_request_context(%{url: URI.to_string(uri)})
+      end
 
       Context.add_breadcrumb(%{
         category: "web.live_view.mount",
@@ -231,8 +234,15 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     defp get_connect_info_if_root(socket, key) do
       case socket.parent_pid do
-        nil -> get_connect_info(socket, key)
-        pid when is_pid(pid) -> nil
+        nil ->
+          try do
+            get_connect_info(socket, key)
+          rescue
+            _ -> nil
+          end
+
+        pid when is_pid(pid) ->
+          nil
       end
     end
 

--- a/lib/sentry/live_view_hook.ex
+++ b/lib/sentry/live_view_hook.ex
@@ -12,12 +12,21 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       * The user agent and user's IP address
       * Breadcrumbs for events that happen within LiveView
 
-    To make this module work best, you'll need to fetch information from the LiveView's
-    WebSocket. You can do that when calling the `socket/3` macro in your Phoenix endpoint.
-    For example:
+    To get the most complete request context, you'll need to fetch information from
+    the LiveView's WebSocket. You can do that when calling the `socket/3` macro in your
+    Phoenix endpoint. For example:
 
         socket "/live", Phoenix.LiveView.Socket,
           websocket: [connect_info: [:peer_data, :uri, :user_agent]]
+
+    Each key in `connect_info` enriches the Sentry context as follows:
+
+      * `:uri` — overrides the request URL with the WebSocket connect URI
+      * `:user_agent` — adds the user agent to extra context
+      * `:peer_data` — adds the client's IP address to user context
+
+    The hook still works when these keys are omitted, but the corresponding context
+    fields will not be populated.
 
     ## Examples
 
@@ -157,8 +166,12 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     defp on_mount(params, %Phoenix.LiveView.Socket{} = socket) do
       Context.set_extra_context(%{socket_id: socket.id})
 
-      if uri = socket.host_uri do
-        Context.set_request_context(%{url: URI.to_string(uri)})
+      case socket.host_uri do
+        %URI{} = uri ->
+          Context.set_request_context(%{url: URI.to_string(uri)})
+
+        _ ->
+          :ok
       end
 
       Context.add_breadcrumb(%{
@@ -235,6 +248,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     defp get_connect_info_if_root(socket, key) do
       case socket.parent_pid do
         nil ->
+          # Bandit raises when the transport is already closed (e.g. client disconnect
+          # during mount). Because Bandit is an optional dependency, we rescue broadly
+          # rather than matching on Bandit.TransportError directly.
           try do
             get_connect_info(socket, key)
           rescue

--- a/test/sentry/client_test.exs
+++ b/test/sentry/client_test.exs
@@ -52,6 +52,14 @@ defmodule Sentry.ClientTest do
              }
     end
 
+    test "safely inspects non-JSON-encodable values in :request" do
+      event =
+        Event.create_event(request: %{url: %URI{scheme: "http", host: "example.com", port: 80}})
+
+      rendered = Client.render_event(event)
+      assert rendered.request.url == inspect(%URI{scheme: "http", host: "example.com", port: 80})
+    end
+
     test "safely inspects terms that cannot be converted to JSON" do
       event =
         Event.create_event(

--- a/test/sentry/live_view_hook_test.exs
+++ b/test/sentry/live_view_hook_test.exs
@@ -129,6 +129,14 @@ defmodule SentryTest.Endpoint do
   plug SentryTest.Router
 end
 
+defmodule SentryTest.EndpointNoUri do
+  use Phoenix.Endpoint, otp_app: :sentry
+
+  socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [:peer_data, :user_agent]]
+
+  plug SentryTest.Router
+end
+
 defmodule Sentry.LiveViewHookTest do
   use Sentry.Case, async: false
 
@@ -314,6 +322,66 @@ defmodule Sentry.LiveViewHookTest do
                "other" => "not-redacted"
              }
            }
+  end
+
+  defp get_sentry_context(view) do
+    {:dictionary, pdict} = Process.info(view.pid, :dictionary)
+
+    assert {:ok, sentry_context} =
+             pdict
+             |> Keyword.fetch!(:"$logger_metadata$")
+             |> Map.fetch(Sentry.Context.__logger_metadata_key__())
+
+    sentry_context
+  end
+end
+
+defmodule Sentry.LiveViewHookNoUriTest do
+  use Sentry.Case, async: false
+
+  import ExUnit.CaptureLog
+  import Phoenix.ConnTest
+  import Phoenix.LiveViewTest
+
+  @endpoint SentryTest.EndpointNoUri
+
+  setup_all do
+    Application.put_env(:sentry, SentryTest.EndpointNoUri,
+      secret_key_base: "TMnue44VMTf1VmyD6SYKR30cqKpHluHOFZGXcVkC33hKVVKTVZ1HBQLLLLLLLLLL",
+      live_view: [signing_salt: "F8ftIAbYdeTzhwgl"]
+    )
+
+    pid = start_supervised!(SentryTest.EndpointNoUri)
+    Process.link(pid)
+    :ok
+  end
+
+  setup do
+    %{conn: build_conn()}
+  end
+
+  test "stores string URL when :uri is not in connect_info", %{conn: conn} do
+    conn = Plug.Conn.put_req_header(conn, "user-agent", "sentry-testing 1.0")
+
+    {:ok, view, html} = live(conn, "/hook_test")
+    assert html =~ "<h1>Testing Sentry hooks</h1>"
+
+    context = get_sentry_context(view)
+
+    assert is_binary(context.request.url)
+    assert context.request.url == "http://www.example.com/hook_test"
+    assert context.extra.user_agent == "sentry-testing 1.0"
+  end
+
+  test "does not log a Sentry error when connect_info is unavailable", %{conn: conn} do
+    conn = Plug.Conn.put_req_header(conn, "user-agent", "sentry-testing 1.0")
+
+    logs =
+      capture_log(fn ->
+        {:ok, _view, _html} = live(conn, "/hook_test")
+      end)
+
+    refute logs =~ "Sentry.LiveView.on_mount hook errored out"
   end
 
   defp get_sentry_context(view) do


### PR DESCRIPTION
## Summary

Fixes two related issues in `Sentry.LiveViewHook` that affect Bandit + LiveView production deployments:

1. **#1025** — `on_mount` crashes with `Bandit.TransportError` when the client disconnects during mount.
2. **#1040** — LiveView hooks silently swallow errors because `%URI{}` structs in `connect_info` fail JSON encoding.

## Changes

### `lib/sentry/live_view_hook.ex`

- **Bandit disconnect safety**: Wrap `get_connect_info(socket, key)` in `get_connect_info_if_root/2` with a `try/rescue` that returns `nil` on any transport error. This mirrors the existing defensive pattern in `Sentry.PlugContext` (see `remote_port/1`).
- **URI struct normalization**: Convert `socket.host_uri` to a string with `URI.to_string/1` before storing it in Sentry request context. Previously, when `:uri` was omitted from `connect_info`, the raw `%URI{}` struct remained in context and caused JSON encoding to fail later in the pipeline.

### `lib/sentry/client.ex`

- **Defense-in-depth**: Run `sanitize_non_jsonable_values/2` on the `:request` field during event rendering, consistent with how `:extra`, `:user`, and `:tags` are already sanitized.

### Tests

- Added `SentryTest.EndpointNoUri` and `Sentry.LiveViewHookNoUriTest` to verify hook behavior when `:uri` is absent from `connect_info`.
- Added regression test for `Client.render_event/1` sanitizing non-JSON-encodable values in `:request`.

## Verification

- `mix test` — 813 tests, 0 failures
- `mix format --check-formatted` — clean
- `mix compile --warnings-as-errors` — clean

## Related Issues

- Closes #1025
- Closes #1040
