### PR TITLE
fix(oban): don't assume stacktrace is always a list

### DIFF
--- a/lib/sentry/integrations/oban/error_reporter.ex
+++ b/lib/sentry/integrations/oban/error_reporter.ex
@@ -31,6 +31,8 @@ defmodule Sentry.Integrations.Oban.ErrorReporter do
         %{job: job, kind: kind, reason: reason, stacktrace: stacktrace} = _metadata,
         config
       ) do
+    stacktrace = if is_list(stacktrace), do: stacktrace, else: []
+
     if report?(reason) and should_report?(job, config) do
       report(job, kind, reason, stacktrace, config)
     else

--- a/test/sentry/integrations/oban/error_reporter_test.exs
+++ b/test/sentry/integrations/oban/error_reporter_test.exs
@@ -148,6 +148,11 @@ defmodule Sentry.Integrations.Oban.ErrorReporterTest do
       end
     end
 
+    # See https://github.com/getsentry/sentry-elixir/issues/1063
+    test "does not crash when stacktrace metadata is not a list" do
+      emit_telemetry_for_failed_job(:exit, :user_stopped, :user_stopped)
+    end
+
     test "includes custom tags when oban_tags_to_sentry_tags function config option is set and returns non empty map" do
       emit_telemetry_for_failed_job(:error, %RuntimeError{message: "oops"}, [],
         oban_tags_to_sentry_tags: fn _job -> %{custom_tag: "custom_value"} end


### PR DESCRIPTION
Fixes #1063 

I haven't figured out where this is coming from, but here's a fix 😄 