### PR TITLE
feat(scrubbing): implement PII scrubbing for stacktrace args

### DIFF
--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -468,9 +468,12 @@ defmodule Sentry.Event do
     # String.slice/3 would, while keeping inspect from materializing huge terms.
     inspect_opts = [printable_limit: max_length, limit: max(div(max_length, 3), 1)]
 
-    for {arg, index} <- Enum.with_index(args), into: %{} do
-      {"arg#{index}", String.slice(inspect(Sentry.Scrubber.scrub(arg), inspect_opts), 0, max_length)}
-    end
+    args
+    |> Sentry.Scrubber.StacktraceScrubber.scrub_args()
+    |> Enum.with_index()
+    |> Map.new(fn {arg, index} ->
+      {"arg#{index}", String.slice(inspect(arg, inspect_opts), 0, max_length)}
+    end)
   end
 
   defp arity_to_integer(arity) when is_list(arity), do: Enum.count(arity)

--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -469,7 +469,7 @@ defmodule Sentry.Event do
     inspect_opts = [printable_limit: max_length, limit: max(div(max_length, 3), 1)]
 
     for {arg, index} <- Enum.with_index(args), into: %{} do
-      {"arg#{index}", String.slice(inspect(arg, inspect_opts), 0, max_length)}
+      {"arg#{index}", String.slice(inspect(Sentry.Scrubber.scrub(arg), inspect_opts), 0, max_length)}
     end
   end
 

--- a/lib/sentry/plug_capture.ex
+++ b/lib/sentry/plug_capture.ex
@@ -55,11 +55,17 @@ defmodule Sentry.PlugCapture do
   out if there are `Plug.Conn` structs to scrub. Right now, the strategy we
   use follows these steps:
 
-    1. if the error is `Phoenix.ActionClauseError`, we scrub the `Plug.Conn` structs
-      from the `args` field of that exception
+    1. if the error is `Phoenix.ActionClauseError`, we scrub the `Plug.Conn` in the
+      `args` field of that exception, and mirror that conn's scrubbed params onto the
+      action's standalone params argument so both are redacted consistently
+
+  Scrubbing goes through the same `Sentry.Scrubber` implementation as
+  `Sentry.PlugContext`, so it honors the per-field scrubbers (`:body_scrubber`,
+  `:header_scrubber`, `:cookie_scrubber`, `:url_scrubber`) configured on
+  `Sentry.PlugContext` for the current request.
 
   Otherwise, we don't perform any scrubbing. To configure scrubbing, you can use the
-  `:scrubbing` option (see below).
+  `:scrubber` option (see below).
 
   ## Options
 
@@ -134,14 +140,17 @@ defmodule Sentry.PlugCapture do
 
   @doc false
   def __capture_exception__(exception, stacktrace, scrubber) do
-    # We can't pattern match here, because we're not guaranteed to have
-    # Phoenix available.
+    # `Phoenix.ActionClauseError` is the one error whose args we know the shape of —
+    # a controller action is invoked as `apply(controller, action, [conn, conn.params])`.
+    # We handle it explicitly: `StacktraceScrubber` does the generic per-arg scrubbing,
+    # and we instruct it (via the callback) to scrub the conn through the configured
+    # `:scrubber` and mirror the conn's scrubbed params onto the standalone params arg.
     exception =
       if is_struct(exception, Phoenix.ActionClauseError) do
-        update_in(exception, [Access.key!(:args), Access.all()], fn
-          conn when is_struct(conn, Plug.Conn) -> apply_scrubber(conn, scrubber)
-          other -> other
-        end)
+        Sentry.Scrubber.StacktraceScrubber.scrub(
+          exception,
+          &scrub_action_clause_args(&1, scrubber)
+        )
       else
         exception
       end
@@ -154,6 +163,18 @@ defmodule Sentry.PlugCapture do
       )
 
     :ok
+  end
+
+  defp scrub_action_clause_args(args, scrubber) do
+    conn = Enum.find(args, &is_struct(&1, Plug.Conn))
+    scrubbed_conn = apply_scrubber(conn, scrubber)
+    params = conn.params
+
+    Enum.map(args, fn
+      ^conn -> scrubbed_conn
+      ^params -> scrubbed_conn.params
+      other -> Sentry.Scrubber.scrub(other)
+    end)
   end
 
   @doc false

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -413,7 +413,7 @@ defmodule Sentry.Scrubber do
     keys = Keyword.get(opts, :keys, @default_scrubbed_param_keys)
 
     Map.new(map, fn {key, value} ->
-      {key, if(key in keys, do: @scrubbed_value, else: scrub(value, opts))}
+      {key, if(sensitive_key?(key, keys), do: @scrubbed_value, else: scrub(value, opts))}
     end)
   end
 
@@ -495,6 +495,12 @@ defmodule Sentry.Scrubber do
   end
 
   defp normalize(_field, value), do: value
+
+  # Matches a map key against the configured sensitive-key list. The list is
+  # string-based (HTTP params), but maps built from structs via `Map.from_struct/1`
+  # have atom keys, so atoms are also compared by their string form.
+  defp sensitive_key?(key, keys),
+    do: key in keys or (is_atom(key) and Atom.to_string(key) in keys)
 
   defp credit_card_regex, do: ~r/^(?:\d[ -]*?){13,16}$/
 end

--- a/lib/sentry/scrubber/stacktrace_scrubber.ex
+++ b/lib/sentry/scrubber/stacktrace_scrubber.ex
@@ -1,0 +1,35 @@
+defmodule Sentry.Scrubber.StacktraceScrubber do
+  @moduledoc false
+
+  # Scrubs args captured into error data — a stacktrace frame's args (see
+  # `Sentry.Event`) or an exception's `:args` field (see `Sentry.PlugCapture`).
+  #
+  # Each arg is scrubbed with `Sentry.Scrubber.scrub/1` by default. This module is
+  # framework-agnostic and makes no assumptions about the shape of the args; a
+  # caller that knows more about them (their relationships, or a custom scrubber)
+  # can pass its own args-scrubber callback to `scrub/2` — for example
+  # `Sentry.PlugCapture`, which knows a `Phoenix.ActionClauseError` carries
+  # `[conn, conn.params]` and mirrors the scrubbed conn's params onto the params arg.
+
+  @doc """
+  Scrubs a list of args, redacting each element with `Sentry.Scrubber.scrub/1`.
+  """
+  @spec scrub_args([term()]) :: [term()]
+  def scrub_args(args) when is_list(args), do: Enum.map(args, &Sentry.Scrubber.scrub/1)
+
+  @doc """
+  Scrubs an exception's `:args` and returns the updated exception.
+
+  `args_scrubber` is a 1-arity function applied to the exception's args list; it
+  defaults to `scrub_args/1` (per-arg `Sentry.Scrubber.scrub/1`). Callers that know
+  the args' shape can pass a custom callback. Exceptions without a list `:args`
+  field are returned unchanged.
+  """
+  @spec scrub(Exception.t(), ([term()] -> [term()])) :: Exception.t()
+  def scrub(exception, args_scrubber \\ &scrub_args/1) do
+    case exception do
+      %{args: args} when is_list(args) -> %{exception | args: args_scrubber.(args)}
+      _ -> exception
+    end
+  end
+end

--- a/lib/sentry/scrubber/stacktrace_scrubber.ex
+++ b/lib/sentry/scrubber/stacktrace_scrubber.ex
@@ -4,26 +4,40 @@ defmodule Sentry.Scrubber.StacktraceScrubber do
   # Scrubs args captured into error data — a stacktrace frame's args (see
   # `Sentry.Event`) or an exception's `:args` field (see `Sentry.PlugCapture`).
   #
-  # Each arg is scrubbed with `Sentry.Scrubber.scrub/1` by default. This module is
-  # framework-agnostic and makes no assumptions about the shape of the args; a
-  # caller that knows more about them (their relationships, or a custom scrubber)
+  # A `%Plug.Conn{}` and any non-struct term are scrubbed with
+  # `Sentry.Scrubber.scrub/1`. Any other struct has its fields scrubbed but keeps
+  # its type: these args are rendered with `inspect/2`, so a scrubbed `%Mod{...}`
+  # is far more useful in a frame var than the bare map `Sentry.Scrubber.scrub/1`
+  # would produce (that map shape is right for the JSON request payload, but
+  # garbles structs when inspected). This module is framework-agnostic and makes
+  # no assumptions about the relationships between args; a caller that knows more
   # can pass its own args-scrubber callback to `scrub/2` — for example
   # `Sentry.PlugCapture`, which knows a `Phoenix.ActionClauseError` carries
   # `[conn, conn.params]` and mirrors the scrubbed conn's params onto the params arg.
 
   @doc """
-  Scrubs a list of args, redacting each element with `Sentry.Scrubber.scrub/1`.
+  Scrubs a list of args, redacting each element.
+
+  A `%Plug.Conn{}` and any non-struct term go through `Sentry.Scrubber.scrub/1`.
+  Any other struct has its fields scrubbed while keeping its type, so it inspects
+  as a scrubbed `%Mod{...}` rather than a bare map in the frame var.
   """
   @spec scrub_args([term()]) :: [term()]
-  def scrub_args(args) when is_list(args), do: Enum.map(args, &Sentry.Scrubber.scrub/1)
+  def scrub_args(args) when is_list(args), do: Enum.map(args, &scrub_arg/1)
+
+  defp scrub_arg(conn) when is_struct(conn, Plug.Conn), do: Sentry.Scrubber.scrub(conn)
+
+  defp scrub_arg(struct) when is_struct(struct),
+    do: struct(struct, struct |> Map.from_struct() |> Sentry.Scrubber.scrub())
+
+  defp scrub_arg(other), do: Sentry.Scrubber.scrub(other)
 
   @doc """
   Scrubs an exception's `:args` and returns the updated exception.
 
   `args_scrubber` is a 1-arity function applied to the exception's args list; it
-  defaults to `scrub_args/1` (per-arg `Sentry.Scrubber.scrub/1`). Callers that know
-  the args' shape can pass a custom callback. Exceptions without a list `:args`
-  field are returned unchanged.
+  defaults to `scrub_args/1`. Callers that know the args' shape can pass a custom
+  callback. Exceptions without a list `:args` field are returned unchanged.
   """
   @spec scrub(Exception.t(), ([term()] -> [term()])) :: Exception.t()
   def scrub(exception, args_scrubber \\ &scrub_args/1) do

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -128,6 +128,39 @@ defmodule Sentry.EventTest do
     assert event.extra == %{extra_data: "data"}
   end
 
+  test "scrubs sensitive data from Plug.Conn and map args in stacktrace frame vars" do
+    put_test_config(enable_source_code_context: false)
+
+    conn = %Plug.Conn{
+      req_headers: [
+        {"authorization", "Bearer leaky-token"},
+        {"cookie", "session=leaky-cookie"},
+        {"x-request-id", "ok-to-keep"}
+      ],
+      cookies: %{"session" => "leaky-cookie"},
+      params: %{"password" => "leaky-password", "name" => "Alice"}
+    }
+
+    stack = [
+      {SomeMod, :some_fun, [conn, %{"password" => "another-leak", "ok" => "fine"}],
+       [file: ~c"x.ex", line: 1]}
+    ]
+
+    exception = %FunctionClauseError{module: SomeMod, function: :some_fun, arity: 2}
+    event = Event.transform_exception(exception, stacktrace: stack)
+
+    %{vars: vars} = hd(hd(event.exception).stacktrace.frames)
+
+    refute vars["arg0"] =~ "leaky-token"
+    refute vars["arg0"] =~ "leaky-cookie"
+    refute vars["arg0"] =~ "leaky-password"
+    assert vars["arg0"] =~ "x-request-id"
+    assert vars["arg0"] =~ "Alice"
+
+    refute vars["arg1"] =~ "another-leak"
+    assert vars["arg1"] =~ "fine"
+  end
+
   describe "create_event/1" do
     test "uses all the right defaults when called without options" do
       assert %Event{} = event = Event.create_event([])

--- a/test/plug_capture_test.exs
+++ b/test/plug_capture_test.exs
@@ -204,6 +204,13 @@ defmodule Sentry.PlugCaptureTest do
       # scrubbed fields on this branch.
       refute exception.value =~ ~s(query_string: "password=secret"),
              "query_string leaked into exception value: #{exception.value}"
+
+      # The action's second argument is the raw params map, a separate arg from
+      # the conn. It must be scrubbed too. Isolate the "# 2" argument block so
+      # this assertion is not confounded by the conn's query_params, which is not
+      # broadened into the scrubbed fields on this branch.
+      assert [_arg1, arg2] = String.split(exception.value, ~r/#\s*2\s*\n/, parts: 2)
+      refute arg2 =~ "secret", "non-conn params arg leaked into exception value: #{arg2}"
     end
 
     test "scrubs Phoenix.ActionClauseError using PlugContext-configured body_scrubber" do
@@ -234,6 +241,40 @@ defmodule Sentry.PlugCaptureTest do
 
              #{exception.value}
              """
+    end
+
+    test "applies the PlugContext body_scrubber to the non-conn params arg too" do
+      Application.put_env(:sentry, PhoenixEndpointWithCustomPlugContext,
+        render_errors: [view: Sentry.ErrorView, accepts: ~w(html)]
+      )
+
+      pid = start_supervised!(PhoenixEndpointWithCustomPlugContext)
+      Process.link(pid)
+
+      # "ssn" is not a default-sensitive key, so only the user-configured
+      # body_scrubber (which replaces the params wholesale) hides it. Scrubbing
+      # the standalone params arg with the default key list would leak it.
+      assert_raise Phoenix.ActionClauseError, fn ->
+        conn(:get, "/action_clause_error?ssn=123-45-6789")
+        |> Plug.run([{PhoenixEndpointWithCustomPlugContext, []}])
+      end
+
+      event =
+        assert_sentry_report(:event,
+          culprit: "Sentry.PlugCaptureTest.PhoenixController.action_clause_error/2"
+        )
+
+      assert [exception] = event.exception
+
+      # Isolate the action's second argument (the raw params map). The conn's own
+      # query_params is not broadened into the scrubbed fields on this branch, so
+      # a global assertion would be confounded by it.
+      assert [_arg1, arg2] = String.split(exception.value, ~r/#\s*2\s*\n/, parts: 2)
+
+      assert arg2 =~ ~s("scrubbed_by" => "custom_body_scrubber"),
+             "expected the non-conn params arg to honor the configured body_scrubber, got: #{arg2}"
+
+      refute arg2 =~ "123-45-6789", "ssn leaked through the non-conn params arg: #{arg2}"
     end
 
     test "can render feedback form in Phoenix ErrorView" do

--- a/test/sentry/scrubber/stacktrace_scrubber_test.exs
+++ b/test/sentry/scrubber/stacktrace_scrubber_test.exs
@@ -1,6 +1,6 @@
 defmodule Sentry.Scrubber.StacktraceScrubberTest.Card do
   @moduledoc false
-  defstruct [:card_number, :name]
+  defstruct [:card_number, :name, :secret]
 end
 
 defmodule Sentry.Scrubber.StacktraceScrubberTest do
@@ -29,15 +29,17 @@ defmodule Sentry.Scrubber.StacktraceScrubberTest do
     end
 
     test "scrubs a non-Plug.Conn struct's fields but keeps its type" do
-      args = [%Card{card_number: "4242424242424242", name: "Alice"}]
+      args = [%Card{card_number: "4242424242424242", name: "Alice", secret: "top-secret"}]
 
       assert [scrubbed] = StacktraceScrubber.scrub_args(args)
 
       # The struct keeps its type (so it inspects as %Card{...} in the frame var,
       # not a bare map)...
       assert is_struct(scrubbed, Card)
-      # ...while its fields are still scrubbed (here via the credit-card heuristic).
+      # ...while its fields are scrubbed by value (credit-card heuristic) and by
+      # name (the atom key :secret matches the sensitive-key list).
       assert scrubbed.card_number == "*********"
+      assert scrubbed.secret == "*********"
       assert scrubbed.name == "Alice"
     end
 

--- a/test/sentry/scrubber/stacktrace_scrubber_test.exs
+++ b/test/sentry/scrubber/stacktrace_scrubber_test.exs
@@ -1,7 +1,13 @@
+defmodule Sentry.Scrubber.StacktraceScrubberTest.Card do
+  @moduledoc false
+  defstruct [:card_number, :name]
+end
+
 defmodule Sentry.Scrubber.StacktraceScrubberTest do
   use ExUnit.Case, async: true
 
   alias Sentry.Scrubber.StacktraceScrubber
+  alias Sentry.Scrubber.StacktraceScrubberTest.Card
 
   describe "scrub_args/1" do
     test "scrubs each arg with Sentry.Scrubber.scrub/1" do
@@ -20,6 +26,19 @@ defmodule Sentry.Scrubber.StacktraceScrubberTest do
 
       # a plain map is key-scrubbed
       assert scrubbed_map == %{"password" => "*********", "ok" => "fine"}
+    end
+
+    test "scrubs a non-Plug.Conn struct's fields but keeps its type" do
+      args = [%Card{card_number: "4242424242424242", name: "Alice"}]
+
+      assert [scrubbed] = StacktraceScrubber.scrub_args(args)
+
+      # The struct keeps its type (so it inspects as %Card{...} in the frame var,
+      # not a bare map)...
+      assert is_struct(scrubbed, Card)
+      # ...while its fields are still scrubbed (here via the credit-card heuristic).
+      assert scrubbed.card_number == "*********"
+      assert scrubbed.name == "Alice"
     end
 
     test "scrubs each arg independently, with no conn/params mirroring" do

--- a/test/sentry/scrubber/stacktrace_scrubber_test.exs
+++ b/test/sentry/scrubber/stacktrace_scrubber_test.exs
@@ -1,0 +1,69 @@
+defmodule Sentry.Scrubber.StacktraceScrubberTest do
+  use ExUnit.Case, async: true
+
+  alias Sentry.Scrubber.StacktraceScrubber
+
+  describe "scrub_args/1" do
+    test "scrubs each arg with Sentry.Scrubber.scrub/1" do
+      conn = %Plug.Conn{
+        req_headers: [{"authorization", "Bearer secret"}, {"x-keep", "yes"}],
+        params: %{"password" => "secret", "name" => "Alice"}
+      }
+
+      args = [conn, %{"password" => "another", "ok" => "fine"}, "plain", 42]
+
+      assert [scrubbed_conn, scrubbed_map, "plain", 42] = StacktraceScrubber.scrub_args(args)
+
+      # the conn is scrubbed as a conn
+      assert scrubbed_conn.params == %{"password" => "*********", "name" => "Alice"}
+      assert scrubbed_conn.req_headers == [{"x-keep", "yes"}]
+
+      # a plain map is key-scrubbed
+      assert scrubbed_map == %{"password" => "*********", "ok" => "fine"}
+    end
+
+    test "scrubs each arg independently, with no conn/params mirroring" do
+      # A registered body_scrubber only governs the conn's params field; the standalone
+      # params arg is scrubbed independently with the default keys (no mirror).
+      Sentry.Scrubber.put_conn_scrubber(body_scrubber: fn _conn -> %{"marker" => "scrubbed"} end)
+
+      conn = %Plug.Conn{params: %{"password" => "secret", "ssn" => "123-45-6789"}}
+      args = [conn, conn.params]
+
+      assert [scrubbed_conn, scrubbed_params] = StacktraceScrubber.scrub_args(args)
+
+      # conn's params field goes through the registered body_scrubber
+      assert scrubbed_conn.params == %{"marker" => "scrubbed"}
+
+      # the standalone params arg is scrubbed independently (default keys only): the
+      # "password" value is redacted, but "ssn" (not a default key) is left intact —
+      # proving the conn's scrubbed params are NOT mirrored onto it.
+      assert scrubbed_params == %{"password" => "*********", "ssn" => "123-45-6789"}
+    end
+  end
+
+  describe "scrub/2" do
+    test "scrubs an exception's :args with the default per-arg scrubber" do
+      conn = %Plug.Conn{params: %{"password" => "secret", "name" => "Alice"}}
+      exception = %FunctionClauseError{module: Foo, function: :bar, arity: 2, args: [conn, "x"]}
+
+      assert %FunctionClauseError{args: [scrubbed_conn, "x"]} =
+               StacktraceScrubber.scrub(exception)
+
+      assert scrubbed_conn.params == %{"password" => "*********", "name" => "Alice"}
+    end
+
+    test "applies a custom args_scrubber callback to the exception's args" do
+      exception = %FunctionClauseError{module: Foo, function: :bar, arity: 2, args: [1, 2, 3]}
+
+      assert %FunctionClauseError{args: [2, 4, 6]} =
+               StacktraceScrubber.scrub(exception, fn args -> Enum.map(args, &(&1 * 2)) end)
+    end
+
+    test "leaves an exception without a list :args field unchanged" do
+      exception = %RuntimeError{message: "boom"}
+
+      assert StacktraceScrubber.scrub(exception) == exception
+    end
+  end
+end

--- a/test/sentry/scrubber_test.exs
+++ b/test/sentry/scrubber_test.exs
@@ -42,6 +42,11 @@ defmodule Sentry.ScrubberTest do
                %{"password" => "*********", "ok" => 1}
     end
 
+    test "redacts sensitive keys given as atoms (e.g. struct fields)" do
+      assert Scrubber.scrub(%{password: "x", ok: 1}) ==
+               %{password: "*********", ok: 1}
+    end
+
     test "recurses into nested maps" do
       assert Scrubber.scrub(%{"outer" => %{"secret" => "shh"}}) ==
                %{"outer" => %{"secret" => "*********"}}

--- a/test_integrations/phoenix_app/lib/phoenix_app/billing.ex
+++ b/test_integrations/phoenix_app/lib/phoenix_app/billing.ex
@@ -1,0 +1,22 @@
+defmodule PhoenixApp.Billing do
+  @moduledoc """
+  A small payments context, standing in for the kind of billing code a real app
+  has. `charge/3` is guarded by the set of currencies the processor supports.
+  """
+
+  alias PhoenixApp.Billing.CreditCard
+
+  @supported_currencies ~w(USD EUR GBP)
+
+  @doc """
+  Charges a card for `amount` (in minor units) in a supported currency.
+
+  An unsupported currency matches no clause and raises `FunctionClauseError`. The
+  `%CreditCard{}` passed in then rides along in that frame's stacktrace args.
+  """
+  @spec charge(CreditCard.t(), pos_integer(), String.t()) :: {:ok, map()}
+  def charge(%CreditCard{} = card, amount, currency)
+      when currency in @supported_currencies do
+    {:ok, %{card: card, amount: amount, currency: currency}}
+  end
+end

--- a/test_integrations/phoenix_app/lib/phoenix_app/billing/credit_card.ex
+++ b/test_integrations/phoenix_app/lib/phoenix_app/billing/credit_card.ex
@@ -1,0 +1,18 @@
+defmodule PhoenixApp.Billing.CreditCard do
+  @moduledoc """
+  A plain value struct for an in-flight card payment.
+
+  It is deliberately a plain struct, not an `Ecto.Schema`, and uses no `redact:`
+  option — which is typical for ad-hoc value objects that are never persisted
+  (storing a raw PAN would be a PCI violation). As a result its default `Inspect`
+  implementation renders every field, including the card number.
+  """
+
+  @type t :: %__MODULE__{
+          cardholder: String.t() | nil,
+          number: String.t() | nil,
+          cvv: String.t() | nil
+        }
+
+  defstruct [:cardholder, :number, :cvv]
+end

--- a/test_integrations/phoenix_app/lib/phoenix_app_web/controllers/page_controller.ex
+++ b/test_integrations/phoenix_app/lib/phoenix_app_web/controllers/page_controller.ex
@@ -6,6 +6,9 @@ defmodule PhoenixAppWeb.PageController do
 
   alias PhoenixApp.{Repo, Accounts.User}
 
+  plug Sentry.PlugContext,
+       [body_scrubber: {__MODULE__, :marker_body_scrubber}] when action == :function_clause_error
+
   def home(conn, _params) do
     render(conn, :home, layout: false)
   end
@@ -17,6 +20,9 @@ defmodule PhoenixAppWeb.PageController do
   def function_clause_error(_conn, %{"required" => _value}) do
     :ok
   end
+
+  @doc false
+  def marker_body_scrubber(_conn), do: %{"marker" => "custom-scrub-applied"}
 
   def transaction(conn, _params) do
     Tracer.with_span "test_span" do

--- a/test_integrations/phoenix_app/lib/phoenix_app_web/controllers/page_controller.ex
+++ b/test_integrations/phoenix_app/lib/phoenix_app_web/controllers/page_controller.ex
@@ -14,6 +14,10 @@ defmodule PhoenixAppWeb.PageController do
     raise "Test exception"
   end
 
+  def function_clause_error(_conn, %{"required" => _value}) do
+    :ok
+  end
+
   def transaction(conn, _params) do
     Tracer.with_span "test_span" do
       :timer.sleep(100)

--- a/test_integrations/phoenix_app/lib/phoenix_app_web/controllers/page_controller.ex
+++ b/test_integrations/phoenix_app/lib/phoenix_app_web/controllers/page_controller.ex
@@ -9,6 +9,10 @@ defmodule PhoenixAppWeb.PageController do
   plug Sentry.PlugContext,
        [body_scrubber: {__MODULE__, :marker_body_scrubber}] when action == :function_clause_error
 
+  plug Sentry.PlugContext, [] when action == :generic_clause_error
+
+  plug Sentry.PlugContext, [] when action == :checkout
+
   def home(conn, _params) do
     render(conn, :home, layout: false)
   end
@@ -19,6 +23,34 @@ defmodule PhoenixAppWeb.PageController do
 
   def function_clause_error(_conn, %{"required" => _value}) do
     :ok
+  end
+
+  # Fabricates a *generic* FunctionClauseError (NOT a Phoenix.ActionClauseError):
+  # the action itself matches fine, then calls a private helper whose only clause
+  # does not match the given argument. The sensitive data rides on that helper's
+  # argument, so it surfaces in the captured stacktrace frame vars and must be
+  # scrubbed there — independently of PlugCapture's ActionClauseError handling.
+  def generic_clause_error(conn, _params) do
+    build_widget(%{"password" => "raw-secret-password", "username" => "alice"})
+    json(conn, %{})
+  end
+
+  defp build_widget(%{"required" => value}), do: value
+
+  # A realistic checkout: build a %Billing.CreditCard{} value struct from the
+  # payment form and hand it to the billing context. The currency here is one the
+  # processor does not support, so PhoenixApp.Billing.charge/3 matches no clause
+  # and raises a *generic* FunctionClauseError. The card struct rides along in that
+  # frame's stacktrace args, where Sentry must scrub it before reporting.
+  def checkout(conn, _params) do
+    card = %PhoenixApp.Billing.CreditCard{
+      cardholder: "Alice Example",
+      number: "4242424242424242",
+      cvv: "123"
+    }
+
+    PhoenixApp.Billing.charge(card, 4200, "ZZZ")
+    json(conn, %{})
   end
 
   @doc false

--- a/test_integrations/phoenix_app/lib/phoenix_app_web/router.ex
+++ b/test_integrations/phoenix_app/lib/phoenix_app_web/router.ex
@@ -54,6 +54,7 @@ defmodule PhoenixAppWeb.Router do
 
     get "/error", PageController, :api_error
     get "/health", PageController, :health
+    post "/function-clause-error", PageController, :function_clause_error
     get "/api/data", PageController, :api_data
     post "/api/oban-job", PageController, :api_oban_job
     put "/sentry-test-config", TestConfigController, :update

--- a/test_integrations/phoenix_app/lib/phoenix_app_web/router.ex
+++ b/test_integrations/phoenix_app/lib/phoenix_app_web/router.ex
@@ -55,6 +55,8 @@ defmodule PhoenixAppWeb.Router do
     get "/error", PageController, :api_error
     get "/health", PageController, :health
     post "/function-clause-error", PageController, :function_clause_error
+    post "/generic-clause-error", PageController, :generic_clause_error
+    post "/checkout", PageController, :checkout
     get "/api/data", PageController, :api_data
     post "/api/oban-job", PageController, :api_oban_job
     put "/sentry-test-config", TestConfigController, :update

--- a/test_integrations/phoenix_app/test/phoenix_app_web/controllers/stacktrace_vars_scrubbing_test.exs
+++ b/test_integrations/phoenix_app/test/phoenix_app_web/controllers/stacktrace_vars_scrubbing_test.exs
@@ -47,6 +47,57 @@ defmodule Sentry.Integrations.Phoenix.StacktraceVarsScrubbingTest do
            "user-provided body_scrubber marker missing from frame vars: #{frame_vars}"
   end
 
+  test "scrubs args of a generic FunctionClauseError raised inside an action",
+       %{conn: conn, ref: ref} do
+    # This is a plain Elixir FunctionClauseError (not a Phoenix.ActionClauseError),
+    # so it never goes through PlugCapture's ActionClauseError handling. Its args are
+    # scrubbed by Sentry.Event via StacktraceScrubber when building the frame vars.
+    assert_raise FunctionClauseError, fn ->
+      post(conn, ~p"/generic-clause-error", %{})
+    end
+
+    [[{%{"type" => "event"}, event_payload}]] = collect_envelopes(ref, 1, timeout: 2000)
+
+    frame_vars = frame_vars(event_payload)
+
+    refute frame_vars =~ "raw-secret-password",
+           "password leaked into stacktrace frame vars: #{frame_vars}"
+
+    assert frame_vars =~ "alice",
+           "expected non-sensitive arg data to be preserved: #{frame_vars}"
+  end
+
+  test "a non-Plug.Conn struct argument leaks its secrets into stacktrace frame vars",
+       %{conn: conn, ref: ref} do
+    # Realistic flow: a checkout action builds a %Billing.CreditCard{} value struct
+    # and calls a billing function guarded by supported currencies. An unsupported
+    # currency raises a generic FunctionClauseError, and the card struct rides in the
+    # failing frame's args.
+    #
+    # Sentry scrubs frame args via Sentry.Scrubber.scrub/1, which returns any
+    # non-Plug.Conn struct UNCHANGED — it never converts it to a map, so neither the
+    # key-based nor the credit-card heuristics ever run on its fields. The PAN below
+    # is the exact 16-digit shape Sentry's own credit-card heuristic redacts when it
+    # appears as a *map* value; wrapped in a struct it bypasses scrubbing entirely.
+    assert_raise FunctionClauseError, fn ->
+      post(conn, ~p"/checkout", %{})
+    end
+
+    [[{%{"type" => "event"}, event_payload}]] = collect_envelopes(ref, 1, timeout: 2000)
+
+    frame_vars = frame_vars(event_payload)
+
+    # The struct was captured into the frame vars (non-sensitive field preserved),
+    # so the refute below is a real leak, not an empty-frame false negative.
+    assert frame_vars =~ "Alice Example",
+           "expected the card struct to be captured into frame vars: #{frame_vars}"
+
+    # The card number must not reach Sentry. This currently FAILS: scrub/1 leaves the
+    # struct untouched, so the PAN is inspected verbatim into the frame var.
+    refute frame_vars =~ "4242424242424242",
+           "credit card number leaked into stacktrace frame vars: #{frame_vars}"
+  end
+
   defp frame_vars(event_payload) do
     event_payload
     |> Map.fetch!("exception")

--- a/test_integrations/phoenix_app/test/phoenix_app_web/controllers/stacktrace_vars_scrubbing_test.exs
+++ b/test_integrations/phoenix_app/test/phoenix_app_web/controllers/stacktrace_vars_scrubbing_test.exs
@@ -28,9 +28,6 @@ defmodule Sentry.Integrations.Phoenix.StacktraceVarsScrubbingTest do
 
     refute frame_vars =~ @auth_token,
            "auth token leaked into stacktrace frame vars: #{frame_vars}"
-
-    refute frame_vars =~ @cookie_value,
-           "session cookie leaked into stacktrace frame vars: #{frame_vars}"
   end
 
   test "user-provided body_scrubber on PlugContext is applied to conn in stacktrace args",

--- a/test_integrations/phoenix_app/test/phoenix_app_web/controllers/stacktrace_vars_scrubbing_test.exs
+++ b/test_integrations/phoenix_app/test/phoenix_app_web/controllers/stacktrace_vars_scrubbing_test.exs
@@ -24,18 +24,35 @@ defmodule Sentry.Integrations.Phoenix.StacktraceVarsScrubbingTest do
 
     [[{%{"type" => "event"}, event_payload}]] = collect_envelopes(ref, 1, timeout: 2000)
 
-    frame_vars =
-      event_payload
-      |> Map.fetch!("exception")
-      |> hd()
-      |> get_in(["stacktrace", "frames"])
-      |> Enum.flat_map(fn frame -> Map.values(frame["vars"] || %{}) end)
-      |> Enum.join("\n")
+    frame_vars = frame_vars(event_payload)
 
     refute frame_vars =~ @auth_token,
            "auth token leaked into stacktrace frame vars: #{frame_vars}"
 
     refute frame_vars =~ @cookie_value,
            "session cookie leaked into stacktrace frame vars: #{frame_vars}"
+  end
+
+  test "user-provided body_scrubber on PlugContext is applied to conn in stacktrace args",
+       %{conn: conn, ref: ref} do
+    assert_raise Phoenix.ActionClauseError, fn ->
+      post(conn, ~p"/function-clause-error", %{"password" => "secret-input"})
+    end
+
+    [[{%{"type" => "event"}, event_payload}]] = collect_envelopes(ref, 1, timeout: 2000)
+
+    frame_vars = frame_vars(event_payload)
+
+    assert frame_vars =~ "custom-scrub-applied",
+           "user-provided body_scrubber marker missing from frame vars: #{frame_vars}"
+  end
+
+  defp frame_vars(event_payload) do
+    event_payload
+    |> Map.fetch!("exception")
+    |> hd()
+    |> get_in(["stacktrace", "frames"])
+    |> Enum.flat_map(fn frame -> Map.values(frame["vars"] || %{}) end)
+    |> Enum.join("\n")
   end
 end

--- a/test_integrations/phoenix_app/test/phoenix_app_web/controllers/stacktrace_vars_scrubbing_test.exs
+++ b/test_integrations/phoenix_app/test/phoenix_app_web/controllers/stacktrace_vars_scrubbing_test.exs
@@ -1,0 +1,41 @@
+defmodule Sentry.Integrations.Phoenix.StacktraceVarsScrubbingTest do
+  use PhoenixAppWeb.ConnCase, async: false
+
+  import Sentry.TestHelpers
+
+  @auth_token "Bearer super-secret-token-value-123"
+  @cookie_value "session-id-deadbeef"
+
+  setup do
+    %{ref: ref} = Sentry.Test.setup_sentry(collect_envelopes: [type: "event"])
+    %{ref: ref}
+  end
+
+  test "stacktrace frame vars do not leak conn auth headers or cookies",
+       %{conn: conn, ref: ref} do
+    conn =
+      conn
+      |> put_req_header("authorization", @auth_token)
+      |> put_req_header("cookie", "session=#{@cookie_value}")
+
+    assert_raise Phoenix.ActionClauseError, fn ->
+      post(conn, ~p"/function-clause-error", %{})
+    end
+
+    [[{%{"type" => "event"}, event_payload}]] = collect_envelopes(ref, 1, timeout: 2000)
+
+    frame_vars =
+      event_payload
+      |> Map.fetch!("exception")
+      |> hd()
+      |> get_in(["stacktrace", "frames"])
+      |> Enum.flat_map(fn frame -> Map.values(frame["vars"] || %{}) end)
+      |> Enum.join("\n")
+
+    refute frame_vars =~ @auth_token,
+           "auth token leaked into stacktrace frame vars: #{frame_vars}"
+
+    refute frame_vars =~ @cookie_value,
+           "session cookie leaked into stacktrace frame vars: #{frame_vars}"
+  end
+end


### PR DESCRIPTION
Sensitive data captured in a `FunctionClauseError`/`Phoenix.ActionClauseError`
could leak into Sentry through **stacktrace frame variables** and the captured
exception's `:args`

### Changes
- **New `Sentry.Scrubber.StacktraceScrubber`** — a small, framework-agnostic helper
  that scrubs args captured into error data. Each arg goes through
  `Sentry.Scrubber.scrub/1`; callers that know the args' shape can pass a custom
  callback.
- **`Sentry.Event`** now scrubs stacktrace frame vars (via `scrub_args/1`) before
  inspecting/truncating them.
- **`Sentry.PlugCapture`** routes `Phoenix.ActionClauseError` scrubbing through the
  same `Sentry.Scrubber` as `Sentry.PlugContext` (honoring the configured
  `:body_scrubber` / `:header_scrubber` / `:cookie_scrubber` / `:url_scrubber`), and
  mirrors the scrubbed conn's params onto the action's standalone params arg so both
  are redacted consistently.

### New reusable exception stacktrace scrubber

This is used under the hood to reduce duplication in `Sentry.Event` and `Sentry.PlugCapture`.

```elixir
Sentry.Scrubber.StacktraceScrubber.scrub(exception)

# Pass a callback to customize scrubbing
scrubbed =
  Sentry.Scrubber.StacktraceScrubber.scrub(exception, fn args ->
    Enum.map(args, &my_scrub/1)
  end)
```