### PR TITLE
refa(plug): consolidate access to the plug scrubber

### DIFF
--- a/lib/sentry/live_view_hook.ex
+++ b/lib/sentry/live_view_hook.ex
@@ -56,7 +56,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     LiveView events and `handle_params` calls frequently carry user-submitted
     form data, which may include passwords or other sensitive values. Before
     storing this data in breadcrumbs, this hook scrubs it using
-    `Sentry.Scrubber.scrub_map/2`. URI query strings stored in breadcrumbs are
+    `Sentry.Scrubber.scrub/2`. URI query strings stored in breadcrumbs are
     scrubbed via `Sentry.Scrubber.scrub_url/2`.
 
     To customize the scrubbing logic, pass a `:scrubber` option when attaching
@@ -107,13 +107,13 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     @doc """
     The default scrubber applied to LiveView breadcrumb data.
 
-    Delegates to `Sentry.Scrubber.scrub_map/2` with the default sensitive
+    Delegates to `Sentry.Scrubber.scrub/2` with the default sensitive
     parameter keys.
     """
     @doc since: "13.1.0"
     @spec default_scrubber(map()) :: map()
     def default_scrubber(data) when is_map(data) do
-      Sentry.Scrubber.scrub_map(data)
+      Sentry.Scrubber.scrub(data)
     end
 
     ## Helpers

--- a/lib/sentry/plug_capture.ex
+++ b/lib/sentry/plug_capture.ex
@@ -68,10 +68,11 @@ defmodule Sentry.PlugCapture do
       `Plug.Conn` struct is prepended to `args` before invoking the function,
       so that the final function will be called as `apply(module, function, [conn | args])`.
       The function must return a `Plug.Conn` struct. By default, the built-in
-      scrubber delegates to `Sentry.Scrubber.scrub_conn/1`, which honors any
-      `:body_scrubber`, `:header_scrubber`, and `:cookie_scrubber` configured
-      on `Sentry.PlugContext` for the current request. When no `Sentry.PlugContext`
-      has run, falls back to `Sentry.Scrubber.default_conn_scrubber/1`:
+      scrubber delegates to `Sentry.Scrubber.scrub/1`, which honors any
+      `:body_scrubber`, `:header_scrubber`, `:cookie_scrubber`, or
+      `:url_scrubber` opts configured on `Sentry.PlugContext` for the current
+      request. When no `Sentry.PlugContext` has run, falls back to the
+      defaults defined by `Sentry.Scrubber.scrub/2`:
 
       * scrubs *all* cookies
       * drops sensitive request headers (`authorization`, `authentication`, `cookie`)
@@ -156,7 +157,7 @@ defmodule Sentry.PlugCapture do
   end
 
   @doc false
-  def default_scrubber(conn), do: Sentry.Scrubber.scrub_conn(conn)
+  def default_scrubber(conn), do: Sentry.Scrubber.scrub(conn)
 
   defp apply_scrubber(conn, {mod, fun, args} = _scrubber) do
     case apply(mod, fun, [conn | args]) do

--- a/lib/sentry/plug_capture.ex
+++ b/lib/sentry/plug_capture.ex
@@ -68,11 +68,14 @@ defmodule Sentry.PlugCapture do
       `Plug.Conn` struct is prepended to `args` before invoking the function,
       so that the final function will be called as `apply(module, function, [conn | args])`.
       The function must return a `Plug.Conn` struct. By default, the built-in
-      scrubber does this:
+      scrubber delegates to `Sentry.Scrubber.scrub_conn/1`, which honors any
+      `:body_scrubber`, `:header_scrubber`, and `:cookie_scrubber` configured
+      on `Sentry.PlugContext` for the current request. When no `Sentry.PlugContext`
+      has run, falls back to `Sentry.Scrubber.default_conn_scrubber/1`:
 
       * scrubs *all* cookies
-      * scrubs sensitive headers just like `Sentry.PlugContext.default_header_scrubber/1`
-      * scrubs sensitive body params just like `Sentry.PlugContext.default_body_scrubber/1`
+      * drops sensitive request headers (`authorization`, `authentication`, `cookie`)
+      * scrubs sensitive body params (`password`, `passwd`, `secret`)
 
   """
   defmacro __using__(opts) do
@@ -153,14 +156,7 @@ defmodule Sentry.PlugCapture do
   end
 
   @doc false
-  def default_scrubber(conn) do
-    %{
-      conn
-      | cookies: %{},
-        req_headers: Sentry.PlugContext.default_header_scrubber(conn),
-        params: Sentry.PlugContext.default_body_scrubber(conn)
-    }
-  end
+  def default_scrubber(conn), do: Sentry.Scrubber.scrub_conn(conn)
 
   defp apply_scrubber(conn, {mod, fun, args} = _scrubber) do
     case apply(mod, fun, [conn | args]) do

--- a/lib/sentry/plug_context.ex
+++ b/lib/sentry/plug_context.ex
@@ -148,7 +148,7 @@ defmodule Sentry.PlugContext do
     @impl Plug
     def call(conn, opts) do
       Sentry.Scrubber.put_conn_scrubber(
-        Keyword.take(opts, [:body_scrubber, :header_scrubber, :cookie_scrubber])
+        Keyword.take(opts, [:body_scrubber, :header_scrubber, :cookie_scrubber, :url_scrubber])
       )
 
       request = build_request_interface_data(conn, opts)
@@ -164,8 +164,6 @@ defmodule Sentry.PlugContext do
   @doc false
   @spec build_request_interface_data(Plug.Conn.t(), keyword()) :: Sentry.Context.request_context()
   def build_request_interface_data(conn, opts) do
-    url_scrubber = Keyword.get(opts, :url_scrubber, {__MODULE__, :default_url_scrubber})
-
     remote_address_reader =
       Keyword.get(opts, :remote_address_reader, {__MODULE__, :default_remote_address_reader})
 
@@ -178,7 +176,7 @@ defmodule Sentry.PlugContext do
     scrubbed = Sentry.Scrubber.scrub_conn(conn)
 
     %{
-      url: apply_fun_with_conn(conn, url_scrubber, Plug.Conn.request_url(conn)),
+      url: Sentry.Scrubber.scrub_request_url(conn),
       method: conn.method,
       data: scrubbed.params,
       query_string: conn.query_string,

--- a/lib/sentry/plug_context.ex
+++ b/lib/sentry/plug_context.ex
@@ -266,6 +266,6 @@ defmodule Sentry.PlugContext do
   """
   @spec default_body_scrubber(Plug.Conn.t()) :: map()
   def default_body_scrubber(conn) do
-    Sentry.Scrubber.scrub_map(conn.params)
+    Sentry.Scrubber.scrub(conn.params)
   end
 end

--- a/lib/sentry/plug_context.ex
+++ b/lib/sentry/plug_context.ex
@@ -148,7 +148,13 @@ defmodule Sentry.PlugContext do
 
     @impl Plug
     def call(conn, opts) do
-      conn_scrubber_opts = Keyword.take(opts, Sentry.Scrubber.scrubber_names())
+      conn_scrubber_opts =
+        opts
+        |> Keyword.take(Sentry.Scrubber.scrubber_names())
+        # Preserve PlugContext's historical default of *not* scrubbing the URL:
+        # when no :url_scrubber is configured, fall back to the no-op
+        # default_url_scrubber/1 rather than Sentry.Scrubber's scrubbing default.
+        |> Keyword.put_new(:url_scrubber, {__MODULE__, :default_url_scrubber, []})
 
       Sentry.Scrubber.put_conn_scrubber(conn_scrubber_opts)
 

--- a/lib/sentry/plug_context.ex
+++ b/lib/sentry/plug_context.ex
@@ -148,7 +148,9 @@ defmodule Sentry.PlugContext do
 
     @impl Plug
     def call(conn, opts) do
-      Sentry.Scrubber.put_conn_scrubber(Keyword.take(opts, Sentry.Scrubber.scrubber_names()))
+      conn_scrubber_opts = Keyword.take(opts, Sentry.Scrubber.scrubber_names())
+
+      Sentry.Scrubber.put_conn_scrubber(conn_scrubber_opts)
 
       request = build_request_interface_data(conn, opts)
       Sentry.Context.set_request_context(request)

--- a/lib/sentry/plug_context.ex
+++ b/lib/sentry/plug_context.ex
@@ -147,7 +147,10 @@ defmodule Sentry.PlugContext do
 
     @impl Plug
     def call(conn, opts) do
-      Sentry.Scrubber.put_conn_scrubber({__MODULE__, :scrub_conn, [opts]})
+      Sentry.Scrubber.put_conn_scrubber(
+        Keyword.take(opts, [:body_scrubber, :header_scrubber, :cookie_scrubber])
+      )
+
       request = build_request_interface_data(conn, opts)
       Sentry.Context.set_request_context(request)
       conn
@@ -157,24 +160,6 @@ defmodule Sentry.PlugContext do
   @default_scrubbed_param_keys Sentry.Scrubber.default_param_keys()
   @default_scrubbed_header_keys Sentry.Scrubber.default_header_keys()
   @default_plug_request_id_header "x-request-id"
-
-  @doc false
-  @spec scrub_conn(Plug.Conn.t(), keyword()) :: Plug.Conn.t()
-  def scrub_conn(conn, opts) when is_struct(conn, Plug.Conn) do
-    body_scrubber = Keyword.get(opts, :body_scrubber, {__MODULE__, :default_body_scrubber})
-    header_scrubber = Keyword.get(opts, :header_scrubber, {__MODULE__, :default_header_scrubber})
-    cookie_scrubber = Keyword.get(opts, :cookie_scrubber, {__MODULE__, :default_cookie_scrubber})
-
-    %{
-      conn
-      | cookies: apply_fun_with_conn(conn, cookie_scrubber, %{}),
-        req_headers: headers_to_list(apply_fun_with_conn(conn, header_scrubber, %{})),
-        params: apply_fun_with_conn(conn, body_scrubber, %{})
-    }
-  end
-
-  defp headers_to_list(headers) when is_map(headers), do: Map.to_list(headers)
-  defp headers_to_list(headers) when is_list(headers), do: headers
 
   @doc false
   @spec build_request_interface_data(Plug.Conn.t(), keyword()) :: Sentry.Context.request_context()
@@ -269,12 +254,6 @@ defmodule Sentry.PlugContext do
 
   #{Enum.map_join(@default_scrubbed_header_keys, "\n", &"*  `#{&1}`")}
   """
-  # FIXME: returns a map, but `Plug.Conn.req_headers` is typed as a list of
-  # `{name, value}` tuples. Callers that assign the result back into a conn
-  # (rather than into the request-context map) produce a shape-invalid struct.
-  # Consider returning a list of tuples instead. See `scrub_conn/2` and
-  # `Sentry.Scrubber.scrub_conn/1` for the list-shape-preserving paths used in
-  # the meantime.
   @spec default_header_scrubber(Plug.Conn.t()) :: map()
   def default_header_scrubber(conn) do
     conn.req_headers

--- a/lib/sentry/plug_context.ex
+++ b/lib/sentry/plug_context.ex
@@ -147,9 +147,9 @@ defmodule Sentry.PlugContext do
 
     @impl Plug
     def call(conn, opts) do
+      Sentry.Scrubber.put_conn_scrubber({__MODULE__, :scrub_conn, [opts]})
       request = build_request_interface_data(conn, opts)
       Sentry.Context.set_request_context(request)
-      Sentry.Scrubber.put_conn_scrubber({__MODULE__, :scrub_conn, [opts]})
       conn
     end
   end
@@ -158,20 +158,7 @@ defmodule Sentry.PlugContext do
   @default_scrubbed_header_keys Sentry.Scrubber.default_header_keys()
   @default_plug_request_id_header "x-request-id"
 
-  @doc """
-  Scrubs a `%Plug.Conn{}` using this plug's per-field scrubbers.
-
-  Composes the resolved `:body_scrubber`, `:header_scrubber`, and
-  `:cookie_scrubber` from `opts` (falling back to this module's defaults) and
-  applies them to the corresponding fields of `conn`, returning a scrubbed
-  `%Plug.Conn{}`.
-
-  Registered as the active `Sentry.Scrubber` conn scrubber during `call/2` so
-  that downstream conn scrubbing (e.g. `Sentry.PlugCapture` redacting a conn
-  embedded in `Phoenix.ActionClauseError.args`) honors the same configuration
-  the user passed to `plug Sentry.PlugContext`.
-  """
-  @doc since: "13.1.1"
+  @doc false
   @spec scrub_conn(Plug.Conn.t(), keyword()) :: Plug.Conn.t()
   def scrub_conn(conn, opts) when is_struct(conn, Plug.Conn) do
     body_scrubber = Keyword.get(opts, :body_scrubber, {__MODULE__, :default_body_scrubber})
@@ -192,9 +179,6 @@ defmodule Sentry.PlugContext do
   @doc false
   @spec build_request_interface_data(Plug.Conn.t(), keyword()) :: Sentry.Context.request_context()
   def build_request_interface_data(conn, opts) do
-    body_scrubber = Keyword.get(opts, :body_scrubber, {__MODULE__, :default_body_scrubber})
-    header_scrubber = Keyword.get(opts, :header_scrubber, {__MODULE__, :default_header_scrubber})
-    cookie_scrubber = Keyword.get(opts, :cookie_scrubber, {__MODULE__, :default_cookie_scrubber})
     url_scrubber = Keyword.get(opts, :url_scrubber, {__MODULE__, :default_url_scrubber})
 
     remote_address_reader =
@@ -206,13 +190,15 @@ defmodule Sentry.PlugContext do
       Plug.Conn.fetch_cookies(conn)
       |> Plug.Conn.fetch_query_params()
 
+    scrubbed = Sentry.Scrubber.scrub_conn(conn)
+
     %{
       url: apply_fun_with_conn(conn, url_scrubber, Plug.Conn.request_url(conn)),
       method: conn.method,
-      data: apply_fun_with_conn(conn, body_scrubber, %{}),
+      data: scrubbed.params,
       query_string: conn.query_string,
-      cookies: apply_fun_with_conn(conn, cookie_scrubber, %{}),
-      headers: apply_fun_with_conn(conn, header_scrubber, %{}),
+      cookies: scrubbed.cookies,
+      headers: Map.new(scrubbed.req_headers),
       env: %{
         "REMOTE_ADDR" => apply_fun_with_conn(conn, remote_address_reader, %{}),
         "REMOTE_PORT" => remote_port(conn),

--- a/lib/sentry/plug_context.ex
+++ b/lib/sentry/plug_context.ex
@@ -149,6 +149,7 @@ defmodule Sentry.PlugContext do
     def call(conn, opts) do
       request = build_request_interface_data(conn, opts)
       Sentry.Context.set_request_context(request)
+      Sentry.Scrubber.put_conn_scrubber({__MODULE__, :scrub_conn, [opts]})
       conn
     end
   end
@@ -156,6 +157,37 @@ defmodule Sentry.PlugContext do
   @default_scrubbed_param_keys Sentry.Scrubber.default_param_keys()
   @default_scrubbed_header_keys Sentry.Scrubber.default_header_keys()
   @default_plug_request_id_header "x-request-id"
+
+  @doc """
+  Scrubs a `%Plug.Conn{}` using this plug's per-field scrubbers.
+
+  Composes the resolved `:body_scrubber`, `:header_scrubber`, and
+  `:cookie_scrubber` from `opts` (falling back to this module's defaults) and
+  applies them to the corresponding fields of `conn`, returning a scrubbed
+  `%Plug.Conn{}`.
+
+  Registered as the active `Sentry.Scrubber` conn scrubber during `call/2` so
+  that downstream conn scrubbing (e.g. `Sentry.PlugCapture` redacting a conn
+  embedded in `Phoenix.ActionClauseError.args`) honors the same configuration
+  the user passed to `plug Sentry.PlugContext`.
+  """
+  @doc since: "13.1.1"
+  @spec scrub_conn(Plug.Conn.t(), keyword()) :: Plug.Conn.t()
+  def scrub_conn(conn, opts) when is_struct(conn, Plug.Conn) do
+    body_scrubber = Keyword.get(opts, :body_scrubber, {__MODULE__, :default_body_scrubber})
+    header_scrubber = Keyword.get(opts, :header_scrubber, {__MODULE__, :default_header_scrubber})
+    cookie_scrubber = Keyword.get(opts, :cookie_scrubber, {__MODULE__, :default_cookie_scrubber})
+
+    %{
+      conn
+      | cookies: apply_fun_with_conn(conn, cookie_scrubber, %{}),
+        req_headers: headers_to_list(apply_fun_with_conn(conn, header_scrubber, %{})),
+        params: apply_fun_with_conn(conn, body_scrubber, %{})
+    }
+  end
+
+  defp headers_to_list(headers) when is_map(headers), do: Map.to_list(headers)
+  defp headers_to_list(headers) when is_list(headers), do: headers
 
   @doc false
   @spec build_request_interface_data(Plug.Conn.t(), keyword()) :: Sentry.Context.request_context()
@@ -251,6 +283,12 @@ defmodule Sentry.PlugContext do
 
   #{Enum.map_join(@default_scrubbed_header_keys, "\n", &"*  `#{&1}`")}
   """
+  # FIXME: returns a map, but `Plug.Conn.req_headers` is typed as a list of
+  # `{name, value}` tuples. Callers that assign the result back into a conn
+  # (rather than into the request-context map) produce a shape-invalid struct.
+  # Consider returning a list of tuples instead. See `scrub_conn/2` and
+  # `Sentry.Scrubber.scrub_conn/1` for the list-shape-preserving paths used in
+  # the meantime.
   @spec default_header_scrubber(Plug.Conn.t()) :: map()
   def default_header_scrubber(conn) do
     conn.req_headers

--- a/lib/sentry/plug_context.ex
+++ b/lib/sentry/plug_context.ex
@@ -28,7 +28,7 @@ defmodule Sentry.PlugContext do
 
       defmodule MySentryScrubber do
         def scrub_params(conn) do
-          # Makes use of the default body_scrubber to avoid sending password
+          # Makes use of the default body scrubbing to avoid sending password
           # and credit card information in plain text. To also prevent sending
           # our sensitive "my_secret_field" and "other_sensitive_data" fields,
           # we simply drop those keys.
@@ -147,9 +147,7 @@ defmodule Sentry.PlugContext do
 
     @impl Plug
     def call(conn, opts) do
-      Sentry.Scrubber.put_conn_scrubber(
-        Keyword.take(opts, [:body_scrubber, :header_scrubber, :cookie_scrubber, :url_scrubber])
-      )
+      Sentry.Scrubber.put_conn_scrubber(Keyword.take(opts, Sentry.Scrubber.scrubber_names()))
 
       request = build_request_interface_data(conn, opts)
       Sentry.Context.set_request_context(request)
@@ -173,7 +171,7 @@ defmodule Sentry.PlugContext do
       Plug.Conn.fetch_cookies(conn)
       |> Plug.Conn.fetch_query_params()
 
-    scrubbed = Sentry.Scrubber.scrub_conn(conn)
+    scrubbed = Sentry.Scrubber.scrub(conn)
 
     %{
       url: Sentry.Scrubber.scrub_request_url(conn),

--- a/lib/sentry/plug_context.ex
+++ b/lib/sentry/plug_context.ex
@@ -174,7 +174,7 @@ defmodule Sentry.PlugContext do
     scrubbed = Sentry.Scrubber.scrub(conn)
 
     %{
-      url: Sentry.Scrubber.scrub_request_url(conn),
+      url: Sentry.Scrubber.get(:url_scrubber).(conn),
       method: conn.method,
       data: scrubbed.params,
       query_string: conn.query_string,
@@ -228,19 +228,19 @@ defmodule Sentry.PlugContext do
   defp apply_fun_with_conn(conn, fun, _default) when is_function(fun, 1), do: fun.(conn)
 
   @doc """
-  Scrubs **all** cookies off of the request.
-  """
-  @spec default_cookie_scrubber(Plug.Conn.t()) :: map()
-  def default_cookie_scrubber(_conn) do
-    %{}
-  end
-
-  @doc """
   Returns the request URL without modifying it.
   """
   @spec default_url_scrubber(Plug.Conn.t()) :: String.t()
   def default_url_scrubber(conn) do
     Plug.Conn.request_url(conn)
+  end
+
+  @doc """
+  Scrubs **all** cookies off of the request.
+  """
+  @spec default_cookie_scrubber(Plug.Conn.t()) :: map()
+  def default_cookie_scrubber(conn) do
+    Sentry.Scrubber.scrub(conn, :cookies)
   end
 
   @doc """
@@ -252,9 +252,7 @@ defmodule Sentry.PlugContext do
   """
   @spec default_header_scrubber(Plug.Conn.t()) :: map()
   def default_header_scrubber(conn) do
-    conn.req_headers
-    |> Map.new()
-    |> Sentry.Scrubber.drop_keys()
+    Sentry.Scrubber.scrub(conn, :headers)
   end
 
   @doc """
@@ -266,6 +264,6 @@ defmodule Sentry.PlugContext do
   """
   @spec default_body_scrubber(Plug.Conn.t()) :: map()
   def default_body_scrubber(conn) do
-    Sentry.Scrubber.scrub(conn.params)
+    Sentry.Scrubber.scrub(conn, :body)
   end
 end

--- a/lib/sentry/plug_context.ex
+++ b/lib/sentry/plug_context.ex
@@ -60,9 +60,10 @@ defmodule Sentry.PlugContext do
       defmodule MySentryScrubber do
         def scrub_headers(conn) do
           # In this example, we do not want to include Content-Type or User-Agent
-          # in reported headers, so we drop them.
-          conn.req_headers
-          |> Map.new()
+          # in reported headers, so we drop them. `default_header_scrubber/1`
+          # takes the conn and returns a map of the retained headers, which we
+          # then trim further.
+          conn
           |> Sentry.PlugContext.default_header_scrubber()
           |> Map.drop(["content-type", "user-agent"])
         end
@@ -252,7 +253,9 @@ defmodule Sentry.PlugContext do
   """
   @spec default_header_scrubber(Plug.Conn.t()) :: map()
   def default_header_scrubber(conn) do
-    Sentry.Scrubber.scrub(conn, :headers)
+    conn
+    |> Sentry.Scrubber.scrub(:headers)
+    |> Map.new()
   end
 
   @doc """

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -70,7 +70,8 @@ defmodule Sentry.Scrubber do
   @type conn_scrubber_opts :: [
           body_scrubber: field_scrubber(),
           header_scrubber: field_scrubber(),
-          cookie_scrubber: field_scrubber()
+          cookie_scrubber: field_scrubber(),
+          url_scrubber: field_scrubber()
         ]
 
   @doc """
@@ -198,10 +199,10 @@ defmodule Sentry.Scrubber do
   @doc """
   Registers the current process's per-field scrubbers for `%Plug.Conn{}`.
 
-  Accepts the same `:body_scrubber`, `:header_scrubber`, and `:cookie_scrubber`
-  keys that `Sentry.PlugContext` takes as plug options, resolves each missing
-  key to its corresponding `default_*_scrubber/1`, and stores the resolved
-  scrubbers in the process dictionary.
+  Accepts the same `:body_scrubber`, `:header_scrubber`, `:cookie_scrubber`,
+  and `:url_scrubber` keys that `Sentry.PlugContext` takes as plug options,
+  resolves each missing key to its corresponding `default_*_scrubber/1`, and
+  stores the resolved scrubbers in the process dictionary.
 
   The registration lives for the lifetime of the calling process — typically
   the request process when registered from `Sentry.PlugContext.call/2`. Used
@@ -222,7 +223,8 @@ defmodule Sentry.Scrubber do
     %{
       body_scrubber: Keyword.get(opts, :body_scrubber, {__MODULE__, :default_body_scrubber}),
       header_scrubber: Keyword.get(opts, :header_scrubber, {__MODULE__, :default_header_scrubber}),
-      cookie_scrubber: Keyword.get(opts, :cookie_scrubber, {__MODULE__, :default_cookie_scrubber})
+      cookie_scrubber: Keyword.get(opts, :cookie_scrubber, {__MODULE__, :default_cookie_scrubber}),
+      url_scrubber: Keyword.get(opts, :url_scrubber, {__MODULE__, :default_url_scrubber})
     }
   end
 
@@ -311,6 +313,42 @@ defmodule Sentry.Scrubber do
   def default_cookie_scrubber(_conn) do
     %{}
   end
+
+  @doc """
+  Default `:url_scrubber` used by `put_conn_scrubber/1` when no override is
+  provided.
+
+  Returns `Plug.Conn.request_url/1` of the given conn, unchanged.
+  """
+  @doc since: "13.1.1"
+  @spec default_url_scrubber(Plug.Conn.t()) :: String.t()
+  def default_url_scrubber(conn) when is_struct(conn, Plug.Conn) do
+    Plug.Conn.request_url(conn)
+  end
+
+  @doc """
+  Returns the request URL for `conn`, scrubbed by the current process's
+  registered `:url_scrubber`.
+
+  When `put_conn_scrubber/1` has been called for this process, applies the
+  resolved url scrubber. Otherwise falls back to `default_url_scrubber/1`,
+  which returns the URL unchanged.
+  """
+  @doc since: "13.1.1"
+  @spec scrub_request_url(Plug.Conn.t()) :: String.t()
+  def scrub_request_url(conn) when is_struct(conn, Plug.Conn) do
+    url_scrubber =
+      case Process.get(@conn_scrubber_pdict_key) do
+        %{url_scrubber: scrubber} -> scrubber
+        nil -> {__MODULE__, :default_url_scrubber}
+      end
+
+    apply_url_scrubber(conn, url_scrubber)
+  end
+
+  defp apply_url_scrubber(conn, nil), do: Plug.Conn.request_url(conn)
+  defp apply_url_scrubber(conn, {mod, fun}), do: apply(mod, fun, [conn])
+  defp apply_url_scrubber(conn, fun) when is_function(fun, 1), do: fun.(conn)
 
   defp apply_field_scrubber(_conn, nil), do: %{}
   defp apply_field_scrubber(conn, {mod, fun}), do: apply(mod, fun, [conn])

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -47,6 +47,23 @@ defmodule Sentry.Scrubber do
   @scrubber_pdict_key {__MODULE__, :scrubber}
   @scrubber_names [:body_scrubber, :header_scrubber, :cookie_scrubber, :url_scrubber]
 
+  @typedoc """
+  A resolved set of per-field scrubbers for a `%Plug.Conn{}`.
+
+  Each field holds a 1-arity function that takes the conn and returns the
+  scrubbed value for the corresponding field. Built by `put_conn_scrubber/1`
+  from `t:conn_scrubber_opts/0` and stored in the process dictionary.
+  """
+  @type t :: %__MODULE__{
+          body_scrubber: (Plug.Conn.t() -> term()),
+          header_scrubber: (Plug.Conn.t() -> term()),
+          cookie_scrubber: (Plug.Conn.t() -> term()),
+          url_scrubber: (Plug.Conn.t() -> String.t())
+        }
+
+  @enforce_keys @scrubber_names
+  defstruct @scrubber_names
+
   @doc false
   @spec scrubber_names() :: [atom()]
   def scrubber_names, do: @scrubber_names
@@ -225,7 +242,7 @@ defmodule Sentry.Scrubber do
   end
 
   defp resolve_scrubbers(opts) do
-    %{
+    %__MODULE__{
       body_scrubber: resolve_scrubber(opts, :body_scrubber, :body, & &1.params),
       header_scrubber: resolve_scrubber(opts, :header_scrubber, :headers, & &1.req_headers),
       cookie_scrubber: resolve_scrubber(opts, :cookie_scrubber, :cookies, & &1.cookies),
@@ -256,6 +273,7 @@ defmodule Sentry.Scrubber do
     end
   end
 
+  @spec scrubbers() :: t()
   defp scrubbers do
     case Process.get(@scrubber_pdict_key) do
       nil ->
@@ -263,8 +281,8 @@ defmodule Sentry.Scrubber do
         Process.put(@scrubber_pdict_key, defaults)
         defaults
 
-      map ->
-        map
+      %__MODULE__{} = scrubbers ->
+        scrubbers
     end
   end
 

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -273,8 +273,8 @@ defmodule Sentry.Scrubber do
     end
   end
 
-  @spec scrubbers() :: t()
-  defp scrubbers do
+  @spec scrubber() :: t()
+  defp scrubber do
     case Process.get(@scrubber_pdict_key) do
       nil ->
         defaults = resolve_scrubbers([])
@@ -334,9 +334,9 @@ defmodule Sentry.Scrubber do
   def scrub(conn) when is_struct(conn, Plug.Conn) do
     %{
       conn
-      | cookies: scrubbers().cookie_scrubber.(conn),
-        req_headers: headers_to_list(scrubbers().header_scrubber.(conn)),
-        params: scrubbers().body_scrubber.(conn)
+      | cookies: scrubber().cookie_scrubber.(conn),
+        req_headers: headers_to_list(scrubber().header_scrubber.(conn)),
+        params: scrubber().body_scrubber.(conn)
     }
   end
 
@@ -347,7 +347,7 @@ defmodule Sentry.Scrubber do
   @doc since: "13.1.1"
   @spec scrub_request_url(Plug.Conn.t()) :: String.t()
   def scrub_request_url(conn) when is_struct(conn, Plug.Conn) do
-    scrubbers().url_scrubber.(conn)
+    scrubber().url_scrubber.(conn)
   end
 
   defp headers_to_list(headers) when is_map(headers), do: Map.to_list(headers)

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -57,6 +57,15 @@ defmodule Sentry.Scrubber do
   @scrubber_pdict_key {__MODULE__, :scrubber}
   @scrubber_names [:body_scrubber, :header_scrubber, :cookie_scrubber, :url_scrubber]
 
+  # `%Plug.Conn{}` fields scrubbed by `scrub/1`, each mapped to the struct key
+  # of the scrubber that redacts it. Add an entry to make a new field scrubbed
+  # by default.
+  @scrubbable_conn_fields [
+    cookies: :cookie_scrubber,
+    req_headers: :header_scrubber,
+    params: :body_scrubber
+  ]
+
   @typedoc """
   A resolved set of per-field scrubbers for a `%Plug.Conn{}`.
 
@@ -308,12 +317,9 @@ defmodule Sentry.Scrubber do
   @spec scrub(map()) :: map()
 
   def scrub(conn) when is_struct(conn, Plug.Conn) do
-    %{
-      conn
-      | cookies: scrubber().cookie_scrubber.(conn),
-        req_headers: to_header_list(scrubber().header_scrubber.(conn)),
-        params: scrubber().body_scrubber.(conn)
-    }
+    Enum.reduce(@scrubbable_conn_fields, conn, fn {field, scrubber_key}, acc ->
+      Map.replace!(acc, field, normalize(field, get(scrubber_key).(conn)))
+    end)
   end
 
   def scrub(map) when is_map(map) and not is_struct(map), do: scrub(map, [])
@@ -409,10 +415,14 @@ defmodule Sentry.Scrubber do
   def scrub(conn, :url) when is_struct(conn, Plug.Conn),
     do: scrub_url(Plug.Conn.request_url(conn))
 
-  # A header scrubber may return a map (the documented convention — see
-  # `Sentry.PlugContext`'s `default_header_scrubber/1`), but
-  # `%Plug.Conn{}.req_headers` must be a list of `{name, value}` tuples. Coerce
-  # so `scrub/1` always returns a structurally valid conn.
+  # Coerces a per-field scrubber result into the shape its `%Plug.Conn{}` field
+  # requires. A header scrubber may return a map (the documented convention —
+  # see `Sentry.PlugContext`'s `default_header_scrubber/1`), but `req_headers`
+  # must be a list of `{name, value}` tuples, so `scrub/1` stays structurally
+  # valid. Other fields pass through unchanged.
+  defp normalize(:req_headers, headers), do: to_header_list(headers)
+  defp normalize(_field, value), do: value
+
   defp to_header_list(headers) when is_list(headers), do: headers
   defp to_header_list(headers) when is_map(headers), do: Map.to_list(headers)
 

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -276,7 +276,7 @@ defmodule Sentry.Scrubber do
         mfa_to_fun({__MODULE__, :scrub, [field]})
 
       {:ok, nil} ->
-        nil_scrubber(field)
+        pass_through(field)
 
       {:ok, {m, f, args}} when is_atom(m) and is_atom(f) and is_list(args) ->
         mfa_to_fun({m, f, args})
@@ -289,8 +289,8 @@ defmodule Sentry.Scrubber do
     end
   end
 
-  defp nil_scrubber(:url), do: fn conn -> Plug.Conn.request_url(conn) end
-  defp nil_scrubber(_field), do: fn _conn -> %{} end
+  defp pass_through(:url), do: fn conn -> Plug.Conn.request_url(conn) end
+  defp pass_through(_field), do: fn _conn -> %{} end
 
   defp mfa_to_fun({m, f, args}), do: fn conn -> apply(m, f, [conn | args]) end
 

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -45,6 +45,11 @@ defmodule Sentry.Scrubber do
   @default_scrubbed_header_keys ["authorization", "authentication", "cookie"]
   @scrubbed_value "*********"
   @conn_scrubber_pdict_key {__MODULE__, :conn_scrubber}
+  @scrubber_names [:body_scrubber, :header_scrubber, :cookie_scrubber, :url_scrubber]
+
+  @doc false
+  @spec scrubber_names() :: [atom()]
+  def scrubber_names, do: @scrubber_names
 
   @typedoc """
   Options accepted by the scrubbing functions in this module.
@@ -215,149 +220,122 @@ defmodule Sentry.Scrubber do
   @doc since: "13.1.1"
   @spec put_conn_scrubber(conn_scrubber_opts()) :: :ok
   def put_conn_scrubber(opts) when is_list(opts) do
-    Process.put(@conn_scrubber_pdict_key, resolve_conn_scrubber_opts(opts))
+    Process.put(@conn_scrubber_pdict_key, resolve_scrubbers(opts))
     :ok
   end
 
-  defp resolve_conn_scrubber_opts(opts) do
+  defp resolve_scrubbers(opts) do
     %{
-      body_scrubber: Keyword.get(opts, :body_scrubber, {__MODULE__, :default_body_scrubber}),
-      header_scrubber: Keyword.get(opts, :header_scrubber, {__MODULE__, :default_header_scrubber}),
-      cookie_scrubber: Keyword.get(opts, :cookie_scrubber, {__MODULE__, :default_cookie_scrubber}),
-      url_scrubber: Keyword.get(opts, :url_scrubber, {__MODULE__, :default_url_scrubber})
+      body_scrubber: resolve_scrubber(opts, :body_scrubber, :body, & &1.params),
+      header_scrubber: resolve_scrubber(opts, :header_scrubber, :headers, & &1.req_headers),
+      cookie_scrubber: resolve_scrubber(opts, :cookie_scrubber, :cookies, & &1.cookies),
+      url_scrubber:
+        resolve_scrubber(opts, :url_scrubber, :url, fn conn -> Plug.Conn.request_url(conn) end)
     }
   end
+
+  defp resolve_scrubber(opts, opt_name, field, extract) do
+    case Keyword.fetch(opts, opt_name) do
+      :error ->
+        fn conn -> scrub(field, extract.(conn)) end
+
+      {:ok, nil} when field == :url ->
+        fn conn -> Plug.Conn.request_url(conn) end
+
+      {:ok, nil} ->
+        fn _conn -> %{} end
+
+      {:ok, {m, f, args}} when is_atom(m) and is_atom(f) and is_list(args) ->
+        fn conn -> apply(m, f, [conn | args]) end
+
+      {:ok, {m, f}} when is_atom(m) and is_atom(f) ->
+        fn conn -> apply(m, f, [conn]) end
+
+      {:ok, fun} when is_function(fun, 1) ->
+        fun
+    end
+  end
+
+  defp scrubbers do
+    case Process.get(@conn_scrubber_pdict_key) do
+      nil ->
+        defaults = resolve_scrubbers([])
+        Process.put(@conn_scrubber_pdict_key, defaults)
+        defaults
+
+      map ->
+        map
+    end
+  end
+
+  @doc """
+  Default scrubbing for a single `%Plug.Conn{}` field.
+
+    * `:body` — scrubs a `params`-shaped map via `scrub_map/2`; non-maps pass
+      through unchanged (so `%Plug.Conn.Unfetched{}` is preserved).
+    * `:headers` — drops sensitive `req_headers` case-insensitively. Accepts
+      both the list-of-tuples shape (preserved on output) and a map (drops
+      sensitive keys via `drop_keys/2`).
+    * `:cookies` — drops *all* cookies, returning `%{}`.
+    * `:url` — returns the URL unchanged.
+
+  Used by `scrub/1` and `scrub_request_url/1` for fields the user has not
+  overridden via `put_conn_scrubber/1`, and available for custom scrubbers
+  that want to compose the default behavior:
+
+      defmodule MyScrubber do
+        def scrub_params(conn) do
+          Sentry.Scrubber.scrub(:body, conn.params)
+          |> Map.drop(["my_secret_field"])
+        end
+      end
+  """
+  @doc since: "13.1.1"
+  @spec scrub(:body | :headers | :cookies | :url, term()) :: term()
+  def scrub(:body, params) when is_map(params) and not is_struct(params),
+    do: do_scrub_map(params, @default_scrubbed_param_keys)
+
+  def scrub(:body, other), do: other
+
+  def scrub(:headers, headers) when is_list(headers), do: drop_sensitive_req_headers(headers)
+  def scrub(:headers, headers) when is_map(headers), do: drop_keys(headers)
+
+  def scrub(:cookies, _cookies), do: %{}
+
+  def scrub(:url, url) when is_binary(url), do: url
 
   @doc """
   Scrubs a `%Plug.Conn{}` using the current process's registered scrubbers.
 
   When `put_conn_scrubber/1` has been called for this process, applies the
   resolved body, header, and cookie scrubbers to the corresponding conn
-  fields. Otherwise falls back to `default_conn_scrubber/1`.
+  fields. Otherwise falls back to `scrub/2` for each field.
   """
   @doc since: "13.1.1"
-  @spec scrub_conn(Plug.Conn.t()) :: Plug.Conn.t()
-  def scrub_conn(conn) when is_struct(conn, Plug.Conn) do
-    case Process.get(@conn_scrubber_pdict_key) do
-      nil ->
-        default_conn_scrubber(conn)
-
-      %{body_scrubber: body, header_scrubber: header, cookie_scrubber: cookie} ->
-        %{
-          conn
-          | cookies: apply_field_scrubber(conn, cookie),
-            req_headers: headers_to_list(apply_field_scrubber(conn, header)),
-            params: apply_field_scrubber(conn, body)
-        }
-    end
-  end
-
-  @doc """
-  Default scrubber for `%Plug.Conn{}` used by `scrub_conn/1` when no
-  per-process scrubber is registered.
-
-  Clears `cookies`, drops sensitive `req_headers` case-insensitively
-  (preserving the list shape required by `Plug.Conn`), and scrubs `params`
-  via `scrub_map/2`.
-  """
-  @doc since: "13.1.1"
-  @spec default_conn_scrubber(Plug.Conn.t()) :: Plug.Conn.t()
-  def default_conn_scrubber(conn) when is_struct(conn, Plug.Conn) do
+  @spec scrub(Plug.Conn.t()) :: Plug.Conn.t()
+  def scrub(conn) when is_struct(conn, Plug.Conn) do
     %{
       conn
-      | cookies: %{},
-        req_headers: drop_sensitive_req_headers(conn.req_headers),
-        params: scrub_params(conn.params)
+      | cookies: scrubbers().cookie_scrubber.(conn),
+        req_headers: headers_to_list(scrubbers().header_scrubber.(conn)),
+        params: scrubbers().body_scrubber.(conn)
     }
   end
 
   @doc """
-  Default `:body_scrubber` used by `put_conn_scrubber/1` when no override is
-  provided.
-
-  Scrubs `conn.params` via `scrub_map/2`. The default scrubbed keys are:
-
-  #{Enum.map_join(@default_scrubbed_param_keys, "\n", &"  * `\"#{&1}\"`")}
-  """
-  @doc since: "13.1.1"
-  @spec default_body_scrubber(Plug.Conn.t()) :: map()
-  def default_body_scrubber(conn) when is_struct(conn, Plug.Conn) do
-    scrub_map(conn.params)
-  end
-
-  @doc """
-  Default `:header_scrubber` used by `put_conn_scrubber/1` when no override is
-  provided.
-
-  Drops sensitive entries from `conn.req_headers` via `drop_keys/2` after
-  converting to a map. The default scrubbed keys are:
-
-  #{Enum.map_join(@default_scrubbed_header_keys, "\n", &"  * `\"#{&1}\"`")}
-  """
-  @doc since: "13.1.1"
-  @spec default_header_scrubber(Plug.Conn.t()) :: map()
-  def default_header_scrubber(conn) when is_struct(conn, Plug.Conn) do
-    conn.req_headers
-    |> Map.new()
-    |> drop_keys()
-  end
-
-  @doc """
-  Default `:cookie_scrubber` used by `put_conn_scrubber/1` when no override is
-  provided.
-
-  Drops *all* cookies — returns an empty map regardless of input.
-  """
-  @doc since: "13.1.1"
-  @spec default_cookie_scrubber(Plug.Conn.t()) :: map()
-  def default_cookie_scrubber(_conn) do
-    %{}
-  end
-
-  @doc """
-  Default `:url_scrubber` used by `put_conn_scrubber/1` when no override is
-  provided.
-
-  Returns `Plug.Conn.request_url/1` of the given conn, unchanged.
-  """
-  @doc since: "13.1.1"
-  @spec default_url_scrubber(Plug.Conn.t()) :: String.t()
-  def default_url_scrubber(conn) when is_struct(conn, Plug.Conn) do
-    Plug.Conn.request_url(conn)
-  end
-
-  @doc """
   Returns the request URL for `conn`, scrubbed by the current process's
-  registered `:url_scrubber`.
-
-  When `put_conn_scrubber/1` has been called for this process, applies the
-  resolved url scrubber. Otherwise falls back to `default_url_scrubber/1`,
-  which returns the URL unchanged.
+  registered `:url_scrubber`. Falls back to `scrub(:url, url)`.
   """
   @doc since: "13.1.1"
   @spec scrub_request_url(Plug.Conn.t()) :: String.t()
   def scrub_request_url(conn) when is_struct(conn, Plug.Conn) do
-    url_scrubber =
-      case Process.get(@conn_scrubber_pdict_key) do
-        %{url_scrubber: scrubber} -> scrubber
-        nil -> {__MODULE__, :default_url_scrubber}
-      end
-
-    apply_url_scrubber(conn, url_scrubber)
+    scrubbers().url_scrubber.(conn)
   end
-
-  defp apply_url_scrubber(conn, nil), do: Plug.Conn.request_url(conn)
-  defp apply_url_scrubber(conn, {mod, fun}), do: apply(mod, fun, [conn])
-  defp apply_url_scrubber(conn, fun) when is_function(fun, 1), do: fun.(conn)
-
-  defp apply_field_scrubber(_conn, nil), do: %{}
-  defp apply_field_scrubber(conn, {mod, fun}), do: apply(mod, fun, [conn])
-  defp apply_field_scrubber(conn, fun) when is_function(fun, 1), do: fun.(conn)
 
   defp headers_to_list(headers) when is_map(headers), do: Map.to_list(headers)
   defp headers_to_list(headers) when is_list(headers), do: headers
 
-  defp drop_sensitive_req_headers(headers) when is_list(headers) do
+  defp drop_sensitive_req_headers(headers) do
     Enum.reject(headers, fn
       {name, _value} when is_binary(name) ->
         String.downcase(name) in @default_scrubbed_header_keys
@@ -366,13 +344,6 @@ defmodule Sentry.Scrubber do
         false
     end)
   end
-
-  defp drop_sensitive_req_headers(other), do: other
-
-  defp scrub_params(params) when is_map(params) and not is_struct(params),
-    do: do_scrub_map(params, @default_scrubbed_param_keys)
-
-  defp scrub_params(other), do: other
 
   ## Internal recursion
 

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -44,7 +44,7 @@ defmodule Sentry.Scrubber do
   @default_scrubbed_param_keys ["password", "passwd", "secret"]
   @default_scrubbed_header_keys ["authorization", "authentication", "cookie"]
   @scrubbed_value "*********"
-  @conn_scrubber_pdict_key {__MODULE__, :conn_scrubber}
+  @scrubber_pdict_key {__MODULE__, :scrubber}
   @scrubber_names [:body_scrubber, :header_scrubber, :cookie_scrubber, :url_scrubber]
 
   @doc false
@@ -220,7 +220,7 @@ defmodule Sentry.Scrubber do
   @doc since: "13.1.1"
   @spec put_conn_scrubber(conn_scrubber_opts()) :: :ok
   def put_conn_scrubber(opts) when is_list(opts) do
-    Process.put(@conn_scrubber_pdict_key, resolve_scrubbers(opts))
+    Process.put(@scrubber_pdict_key, resolve_scrubbers(opts))
     :ok
   end
 
@@ -257,10 +257,10 @@ defmodule Sentry.Scrubber do
   end
 
   defp scrubbers do
-    case Process.get(@conn_scrubber_pdict_key) do
+    case Process.get(@scrubber_pdict_key) do
       nil ->
         defaults = resolve_scrubbers([])
-        Process.put(@conn_scrubber_pdict_key, defaults)
+        Process.put(@scrubber_pdict_key, defaults)
         defaults
 
       map ->

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -289,7 +289,7 @@ defmodule Sentry.Scrubber do
     end
   end
 
-  defp nil_scrubber(:url), do: mfa_to_fun({__MODULE__, :scrub, [:url]})
+  defp nil_scrubber(:url), do: fn conn -> Plug.Conn.request_url(conn) end
   defp nil_scrubber(_field), do: fn _conn -> %{} end
 
   defp mfa_to_fun({m, f, args}), do: fn conn -> apply(m, f, [conn | args]) end
@@ -371,9 +371,9 @@ defmodule Sentry.Scrubber do
     * `:headers` — drops sensitive `conn.req_headers` case-insensitively,
       preserving the list-of-tuples shape.
     * `:cookies` — drops *all* cookies, returning `%{}`.
-    * `:url` — returns the request URL unchanged. Scrub sensitive data out of
-      URLs by configuring a custom `:url_scrubber` (see `Sentry.PlugContext`),
-      for example one built on `scrub_url/1`.
+    * `:url` — scrubs sensitive query parameters from the request URL via
+      `scrub_url/1`. To disable URL scrubbing, register a `:url_scrubber` of
+      `nil` (or a custom one); see `Sentry.PlugContext`.
 
   Because these clauses are the defaults (not the registered scrubbers), a
   custom `:body_scrubber` can safely compose on the default behavior without
@@ -451,7 +451,7 @@ defmodule Sentry.Scrubber do
   def scrub(conn, :cookies) when is_struct(conn, Plug.Conn), do: %{}
 
   def scrub(conn, :url) when is_struct(conn, Plug.Conn),
-    do: Plug.Conn.request_url(conn)
+    do: scrub_url(Plug.Conn.request_url(conn))
 
   # Resolves a single conn field's strategy (from `@scrubbable_conn_fields` or a
   # `scrub(conn, overrides)` override) to its scrubbed value:

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -52,10 +52,26 @@ defmodule Sentry.Scrubber do
   @type option :: {:keys, [String.t()]}
 
   @typedoc """
-  An MFA tuple identifying a function that takes a `%Plug.Conn{}` (as its first
-  argument) and returns a scrubbed `%Plug.Conn{}`.
+  A per-field scrubber identifying how to redact a particular `%Plug.Conn{}`
+  field.
+
+    * a 1-arity function — invoked as `fun.(conn)`
+    * `{module, function}` — invoked as `apply(module, function, [conn])`
+    * `nil` — disables the scrubber; the field is replaced with `%{}`
   """
-  @type conn_scrubber :: {module(), atom(), [term()]}
+  @type field_scrubber ::
+          (Plug.Conn.t() -> term()) | {module(), atom()} | nil
+
+  @typedoc """
+  Options accepted by `put_conn_scrubber/1`.
+
+  Each key, when omitted, falls back to the corresponding `default_*_scrubber/1`.
+  """
+  @type conn_scrubber_opts :: [
+          body_scrubber: field_scrubber(),
+          header_scrubber: field_scrubber(),
+          cookie_scrubber: field_scrubber()
+        ]
 
   @doc """
   The placeholder string used to replace scrubbed values.
@@ -180,47 +196,57 @@ defmodule Sentry.Scrubber do
   end
 
   @doc """
-  Registers the current process's scrubber for `%Plug.Conn{}` structs.
+  Registers the current process's per-field scrubbers for `%Plug.Conn{}`.
 
-  The scrubber is a `{module, function, args}` tuple; it is invoked as
-  `apply(module, function, [conn | args])` and must return a `%Plug.Conn{}`.
-  The registration is stored in the process dictionary, so it lives only for
-  the lifetime of the calling process — typically the request process when
-  registered from `Sentry.PlugContext.call/2`.
+  Accepts the same `:body_scrubber`, `:header_scrubber`, and `:cookie_scrubber`
+  keys that `Sentry.PlugContext` takes as plug options, resolves each missing
+  key to its corresponding `default_*_scrubber/1`, and stores the resolved
+  scrubbers in the process dictionary.
 
-  `Sentry.PlugContext` uses this to expose its user-configured `body_scrubber`,
-  `header_scrubber`, and `cookie_scrubber` to other parts of the SDK (notably
-  `Sentry.PlugCapture`) so all conn scrubbing honors the same configuration.
+  The registration lives for the lifetime of the calling process — typically
+  the request process when registered from `Sentry.PlugContext.call/2`. Used
+  by other parts of the SDK (notably `Sentry.PlugCapture`) so all conn
+  scrubbing honors the same configuration the user passed to
+  `plug Sentry.PlugContext`.
 
   Returns `:ok`.
   """
   @doc since: "13.1.1"
-  @spec put_conn_scrubber(conn_scrubber()) :: :ok
-  def put_conn_scrubber({mod, fun, args})
-      when is_atom(mod) and is_atom(fun) and is_list(args) do
-    Process.put(@conn_scrubber_pdict_key, {mod, fun, args})
+  @spec put_conn_scrubber(conn_scrubber_opts()) :: :ok
+  def put_conn_scrubber(opts) when is_list(opts) do
+    Process.put(@conn_scrubber_pdict_key, resolve_conn_scrubber_opts(opts))
     :ok
   end
 
-  @doc """
-  Scrubs a `%Plug.Conn{}` using the current process's registered scrubber.
+  defp resolve_conn_scrubber_opts(opts) do
+    %{
+      body_scrubber: Keyword.get(opts, :body_scrubber, {__MODULE__, :default_body_scrubber}),
+      header_scrubber: Keyword.get(opts, :header_scrubber, {__MODULE__, :default_header_scrubber}),
+      cookie_scrubber: Keyword.get(opts, :cookie_scrubber, {__MODULE__, :default_cookie_scrubber})
+    }
+  end
 
-  If no scrubber has been registered via `put_conn_scrubber/1`, falls back to a
-  built-in default that clears cookies, drops sensitive request headers, and
-  scrubs `params` via `scrub_map/2`.
+  @doc """
+  Scrubs a `%Plug.Conn{}` using the current process's registered scrubbers.
+
+  When `put_conn_scrubber/1` has been called for this process, applies the
+  resolved body, header, and cookie scrubbers to the corresponding conn
+  fields. Otherwise falls back to `default_conn_scrubber/1`.
   """
   @doc since: "13.1.1"
   @spec scrub_conn(Plug.Conn.t()) :: Plug.Conn.t()
   def scrub_conn(conn) when is_struct(conn, Plug.Conn) do
-    {mod, fun, args} =
-      Process.get(@conn_scrubber_pdict_key, {__MODULE__, :default_conn_scrubber, []})
+    case Process.get(@conn_scrubber_pdict_key) do
+      nil ->
+        default_conn_scrubber(conn)
 
-    case apply(mod, fun, [conn | args]) do
-      %_{} = scrubbed when is_struct(scrubbed, Plug.Conn) ->
-        scrubbed
-
-      other ->
-        raise "expected #{inspect(mod)}.#{fun}/#{length(args) + 1} to return a Plug.Conn, got: #{inspect(other)}"
+      %{body_scrubber: body, header_scrubber: header, cookie_scrubber: cookie} ->
+        %{
+          conn
+          | cookies: apply_field_scrubber(conn, cookie),
+            req_headers: headers_to_list(apply_field_scrubber(conn, header)),
+            params: apply_field_scrubber(conn, body)
+        }
     end
   end
 
@@ -228,8 +254,9 @@ defmodule Sentry.Scrubber do
   Default scrubber for `%Plug.Conn{}` used by `scrub_conn/1` when no
   per-process scrubber is registered.
 
-  Clears `cookies`, drops sensitive `req_headers` (preserving the list shape
-  required by `Plug.Conn`), and scrubs `params` via `scrub_map/2`.
+  Clears `cookies`, drops sensitive `req_headers` case-insensitively
+  (preserving the list shape required by `Plug.Conn`), and scrubs `params`
+  via `scrub_map/2`.
   """
   @doc since: "13.1.1"
   @spec default_conn_scrubber(Plug.Conn.t()) :: Plug.Conn.t()
@@ -242,7 +269,55 @@ defmodule Sentry.Scrubber do
     }
   end
 
-  ## Internal recursion
+  @doc """
+  Default `:body_scrubber` used by `put_conn_scrubber/1` when no override is
+  provided.
+
+  Scrubs `conn.params` via `scrub_map/2`. The default scrubbed keys are:
+
+  #{Enum.map_join(@default_scrubbed_param_keys, "\n", &"  * `\"#{&1}\"`")}
+  """
+  @doc since: "13.1.1"
+  @spec default_body_scrubber(Plug.Conn.t()) :: map()
+  def default_body_scrubber(conn) when is_struct(conn, Plug.Conn) do
+    scrub_map(conn.params)
+  end
+
+  @doc """
+  Default `:header_scrubber` used by `put_conn_scrubber/1` when no override is
+  provided.
+
+  Drops sensitive entries from `conn.req_headers` via `drop_keys/2` after
+  converting to a map. The default scrubbed keys are:
+
+  #{Enum.map_join(@default_scrubbed_header_keys, "\n", &"  * `\"#{&1}\"`")}
+  """
+  @doc since: "13.1.1"
+  @spec default_header_scrubber(Plug.Conn.t()) :: map()
+  def default_header_scrubber(conn) when is_struct(conn, Plug.Conn) do
+    conn.req_headers
+    |> Map.new()
+    |> drop_keys()
+  end
+
+  @doc """
+  Default `:cookie_scrubber` used by `put_conn_scrubber/1` when no override is
+  provided.
+
+  Drops *all* cookies — returns an empty map regardless of input.
+  """
+  @doc since: "13.1.1"
+  @spec default_cookie_scrubber(Plug.Conn.t()) :: map()
+  def default_cookie_scrubber(_conn) do
+    %{}
+  end
+
+  defp apply_field_scrubber(_conn, nil), do: %{}
+  defp apply_field_scrubber(conn, {mod, fun}), do: apply(mod, fun, [conn])
+  defp apply_field_scrubber(conn, fun) when is_function(fun, 1), do: fun.(conn)
+
+  defp headers_to_list(headers) when is_map(headers), do: Map.to_list(headers)
+  defp headers_to_list(headers) when is_list(headers), do: headers
 
   defp drop_sensitive_req_headers(headers) when is_list(headers) do
     Enum.reject(headers, fn
@@ -260,6 +335,8 @@ defmodule Sentry.Scrubber do
     do: do_scrub_map(params, @default_scrubbed_param_keys)
 
   defp scrub_params(other), do: other
+
+  ## Internal recursion
 
   defp do_scrub_map(map, keys) do
     Map.new(map, fn {key, value} -> {key, scrub_value(key, value, keys)} end)

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -298,7 +298,7 @@ defmodule Sentry.Scrubber do
     %{
       conn
       | cookies: scrubber().cookie_scrubber.(conn),
-        req_headers: headers_to_list(scrubber().header_scrubber.(conn)),
+        req_headers: to_header_list(scrubber().header_scrubber.(conn)),
         params: scrubber().body_scrubber.(conn)
     }
   end
@@ -381,19 +381,8 @@ defmodule Sentry.Scrubber do
     end
   end
 
-  def scrub(conn, :headers) when is_struct(conn, Plug.Conn),
-    do: drop_sensitive_req_headers(conn.req_headers)
-
-  def scrub(conn, :cookies) when is_struct(conn, Plug.Conn), do: %{}
-
-  def scrub(conn, :url) when is_struct(conn, Plug.Conn),
-    do: scrub_url(Plug.Conn.request_url(conn))
-
-  defp headers_to_list(headers) when is_map(headers), do: Map.to_list(headers)
-  defp headers_to_list(headers) when is_list(headers), do: headers
-
-  defp drop_sensitive_req_headers(headers) do
-    Enum.reject(headers, fn
+  def scrub(conn, :headers) when is_struct(conn, Plug.Conn) do
+    Enum.reject(conn.req_headers, fn
       {name, _value} when is_binary(name) ->
         String.downcase(name) in @default_scrubbed_header_keys
 
@@ -401,6 +390,18 @@ defmodule Sentry.Scrubber do
         false
     end)
   end
+
+  def scrub(conn, :cookies) when is_struct(conn, Plug.Conn), do: %{}
+
+  def scrub(conn, :url) when is_struct(conn, Plug.Conn),
+    do: scrub_url(Plug.Conn.request_url(conn))
+
+  # A header scrubber may return a map (the documented convention — see
+  # `Sentry.PlugContext`'s `default_header_scrubber/1`), but
+  # `%Plug.Conn{}.req_headers` must be a list of `{name, value}` tuples. Coerce
+  # so `scrub/1` always returns a structurally valid conn.
+  defp to_header_list(headers) when is_list(headers), do: headers
+  defp to_header_list(headers) when is_map(headers), do: Map.to_list(headers)
 
   defp scrub_value(key, value, keys) do
     cond do

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -215,11 +215,24 @@ defmodule Sentry.Scrubber do
   @doc since: "13.1.1"
   @spec put_conn_scrubber(conn_scrubber_opts()) :: :ok
   def put_conn_scrubber(opts) when is_list(opts) do
-    Process.put(@scrubber_pdict_key, resolve_scrubbers(opts))
+    Process.put(@scrubber_pdict_key, new(opts))
     :ok
   end
 
-  defp resolve_scrubbers(opts) do
+  @doc """
+  Builds a resolved `t:t/0` set of per-field scrubbers from the given options.
+
+  Accepts the same `:body_scrubber`, `:header_scrubber`, `:cookie_scrubber`,
+  and `:url_scrubber` keys as `put_conn_scrubber/1`. Each missing key falls
+  back to the field's default scrubber (the matching `scrub(conn, field)`
+  clause). Called with no arguments, `new/0` returns the all-defaults scrubber.
+
+  Unlike `put_conn_scrubber/1`, this only constructs the struct — it does not
+  register it for the current process.
+  """
+  @doc since: "13.1.1"
+  @spec new(conn_scrubber_opts()) :: t()
+  def new(opts \\ []) when is_list(opts) do
     %__MODULE__{
       body_scrubber: resolve_scrubber(opts, :body_scrubber, :body),
       header_scrubber: resolve_scrubber(opts, :header_scrubber, :headers),
@@ -257,7 +270,7 @@ defmodule Sentry.Scrubber do
   defp scrubber do
     case Process.get(@scrubber_pdict_key) do
       nil ->
-        defaults = resolve_scrubbers([])
+        defaults = new()
         Process.put(@scrubber_pdict_key, defaults)
         defaults
 

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -98,7 +98,8 @@ defmodule Sentry.Scrubber do
 
     * a 1-arity function — invoked as `fun.(conn)`
     * `{module, function}` — invoked as `apply(module, function, [conn])`
-    * `nil` — disables the scrubber; the field is replaced with `%{}`
+    * `nil` — disables the scrubber; map-shaped fields are replaced with `%{}`,
+      and `:url` falls back to the request URL unchanged
   """
   @type field_scrubber ::
           (Plug.Conn.t() -> term()) | {module(), atom()} | nil
@@ -253,14 +254,15 @@ defmodule Sentry.Scrubber do
   # Resolves a per-field scrubber option into a `(conn -> term)` function. A
   # missing option falls back to the field's default scrubber, expressed as an
   # `{module, function, args}` MFA that captures the matching `scrub(conn, field)`
-  # clause. `nil` disables scrubbing for the field (it becomes `%{}`).
+  # clause. `nil` disables scrubbing for the field: the map-shaped fields become
+  # `%{}`, while `:url` (a string field) falls back to the request URL unchanged.
   defp resolve_scrubber(opts, opt_name, field) do
     case Keyword.fetch(opts, opt_name) do
       :error ->
         mfa_to_fun({__MODULE__, :scrub, [field]})
 
       {:ok, nil} ->
-        fn _conn -> %{} end
+        nil_scrubber(field)
 
       {:ok, {m, f, args}} when is_atom(m) and is_atom(f) and is_list(args) ->
         mfa_to_fun({m, f, args})
@@ -272,6 +274,9 @@ defmodule Sentry.Scrubber do
         fun
     end
   end
+
+  defp nil_scrubber(:url), do: mfa_to_fun({__MODULE__, :scrub, [:url]})
+  defp nil_scrubber(_field), do: fn _conn -> %{} end
 
   defp mfa_to_fun({m, f, args}), do: fn conn -> apply(m, f, [conn | args]) end
 
@@ -355,8 +360,9 @@ defmodule Sentry.Scrubber do
     * `:headers` — drops sensitive `conn.req_headers` case-insensitively,
       preserving the list-of-tuples shape.
     * `:cookies` — drops *all* cookies, returning `%{}`.
-    * `:url` — scrubs sensitive query parameters from the request URL via
-      `scrub_url/1`.
+    * `:url` — returns the request URL unchanged. Scrub sensitive data out of
+      URLs by configuring a custom `:url_scrubber` (see `Sentry.PlugContext`),
+      for example one built on `scrub_url/1`.
 
   Because these clauses are the defaults (not the registered scrubbers), a
   custom `:body_scrubber` can safely compose on the default behavior without
@@ -419,7 +425,7 @@ defmodule Sentry.Scrubber do
   def scrub(conn, :cookies) when is_struct(conn, Plug.Conn), do: %{}
 
   def scrub(conn, :url) when is_struct(conn, Plug.Conn),
-    do: scrub_url(Plug.Conn.request_url(conn))
+    do: Plug.Conn.request_url(conn)
 
   # Coerces a per-field scrubber result into the shape its `%Plug.Conn{}` field
   # requires. A header scrubber may return a map (the documented convention —

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -315,6 +315,7 @@ defmodule Sentry.Scrubber do
   @doc since: "13.1.1"
   @spec scrub(Plug.Conn.t()) :: Plug.Conn.t()
   @spec scrub(map()) :: map()
+  @spec scrub(term()) :: term()
 
   def scrub(conn) when is_struct(conn, Plug.Conn) do
     Enum.reduce(@scrubbable_conn_fields, conn, fn {field, scrubber_key}, acc ->
@@ -324,16 +325,18 @@ defmodule Sentry.Scrubber do
 
   def scrub(map) when is_map(map) and not is_struct(map), do: scrub(map, [])
 
+  def scrub(other), do: other
+
   @doc """
-  Scrubs a value, dispatching on the first argument.
+  Scrubs a value with the given options, dispatching on the value's type.
 
-  ## Scrubbing a map or list — `scrub(map, opts)` / `scrub(list, opts)`
+  ## Scrubbing a map, list, or leaf value — `scrub(value, opts)`
 
-  Recursively scrubs a map. Any value whose key is in the configured sensitive
-  key list is replaced with the placeholder. Values matching the credit-card
-  pattern are also replaced. Nested maps, structs, and lists are scrubbed
-  recursively. A list given as the top-level value is scrubbed element-wise
-  using the same rules.
+  Recursively scrubs a map: any value whose key is in the configured sensitive
+  key list is replaced with the placeholder, and the remaining values are
+  scrubbed in turn. Lists are scrubbed element-wise, structs are scrubbed as
+  maps, and credit-card-shaped binaries are replaced with the placeholder. Any
+  other leaf value is returned unchanged.
 
   Accepts the same `:keys` option as the other scrubbing functions:
 
@@ -370,23 +373,26 @@ defmodule Sentry.Scrubber do
   @doc since: "13.1.0"
   @spec scrub(map(), [option()]) :: map()
   @spec scrub(list(), [option()]) :: list()
+  @spec scrub(term(), [option()]) :: term()
   @spec scrub(Plug.Conn.t(), :body | :headers | :cookies | :url) :: term()
-  def scrub(value, opts \\ [])
 
   def scrub(map, opts) when is_map(map) and not is_struct(map) and is_list(opts) do
     keys = Keyword.get(opts, :keys, @default_scrubbed_param_keys)
-    Map.new(map, fn {key, value} -> {key, scrub_value(key, value, keys)} end)
-  end
 
-  def scrub(list, opts) when is_list(list) do
-    Enum.map(list, fn value ->
-      cond do
-        is_struct(value) -> value |> Map.from_struct() |> scrub(opts)
-        is_map(value) or is_list(value) -> scrub(value, opts)
-        true -> value
-      end
+    Map.new(map, fn {key, value} ->
+      {key, if(key in keys, do: @scrubbed_value, else: scrub(value, opts))}
     end)
   end
+
+  def scrub(struct, opts) when is_struct(struct) and is_list(opts),
+    do: struct |> Map.from_struct() |> scrub(opts)
+
+  def scrub(list, opts) when is_list(list), do: Enum.map(list, &scrub(&1, opts))
+
+  def scrub(value, opts) when is_binary(value) and is_list(opts),
+    do: if(value =~ credit_card_regex(), do: @scrubbed_value, else: value)
+
+  def scrub(value, opts) when is_list(opts), do: value
 
   # These are the SDK's default per-field scrubbers, captured as
   # `{__MODULE__, :scrub, [field]}` MFAs in `resolve_scrubber/3`. `scrub/1`
@@ -420,21 +426,11 @@ defmodule Sentry.Scrubber do
   # see `Sentry.PlugContext`'s `default_header_scrubber/1`), but `req_headers`
   # must be a list of `{name, value}` tuples, so `scrub/1` stays structurally
   # valid. Other fields pass through unchanged.
-  defp normalize(:req_headers, headers), do: to_header_list(headers)
-  defp normalize(_field, value), do: value
-
-  defp to_header_list(headers) when is_list(headers), do: headers
-  defp to_header_list(headers) when is_map(headers), do: Map.to_list(headers)
-
-  defp scrub_value(key, value, keys) do
-    cond do
-      key in keys -> @scrubbed_value
-      is_binary(value) and value =~ credit_card_regex() -> @scrubbed_value
-      is_struct(value) -> scrub(Map.from_struct(value), keys: keys)
-      is_map(value) or is_list(value) -> scrub(value, keys: keys)
-      true -> value
-    end
+  defp normalize(:req_headers, headers) do
+    if is_list(headers), do: headers, else: Map.to_list(headers)
   end
+
+  defp normalize(_field, value), do: value
 
   defp credit_card_regex, do: ~r/^(?:\d[ -]*?){13,16}$/
 end

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -407,7 +407,7 @@ defmodule Sentry.Scrubber do
     cond do
       key in keys -> @scrubbed_value
       is_binary(value) and value =~ credit_card_regex() -> @scrubbed_value
-      is_struct(value) -> value |> Map.from_struct() |> scrub(keys: keys)
+      is_struct(value) -> scrub(Map.from_struct(value), keys: keys)
       is_map(value) or is_list(value) -> scrub(value, keys: keys)
       true -> value
     end

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -44,11 +44,18 @@ defmodule Sentry.Scrubber do
   @default_scrubbed_param_keys ["password", "passwd", "secret"]
   @default_scrubbed_header_keys ["authorization", "authentication", "cookie"]
   @scrubbed_value "*********"
+  @conn_scrubber_pdict_key {__MODULE__, :conn_scrubber}
 
   @typedoc """
   Options accepted by the scrubbing functions in this module.
   """
   @type option :: {:keys, [String.t()]}
+
+  @typedoc """
+  An MFA tuple identifying a function that takes a `%Plug.Conn{}` (as its first
+  argument) and returns a scrubbed `%Plug.Conn{}`.
+  """
+  @type conn_scrubber :: {module(), atom(), [term()]}
 
   @doc """
   The placeholder string used to replace scrubbed values.
@@ -172,7 +179,87 @@ defmodule Sentry.Scrubber do
     |> URI.encode_query()
   end
 
+  @doc """
+  Registers the current process's scrubber for `%Plug.Conn{}` structs.
+
+  The scrubber is a `{module, function, args}` tuple; it is invoked as
+  `apply(module, function, [conn | args])` and must return a `%Plug.Conn{}`.
+  The registration is stored in the process dictionary, so it lives only for
+  the lifetime of the calling process — typically the request process when
+  registered from `Sentry.PlugContext.call/2`.
+
+  `Sentry.PlugContext` uses this to expose its user-configured `body_scrubber`,
+  `header_scrubber`, and `cookie_scrubber` to other parts of the SDK (notably
+  `Sentry.PlugCapture`) so all conn scrubbing honors the same configuration.
+
+  Returns `:ok`.
+  """
+  @doc since: "13.1.1"
+  @spec put_conn_scrubber(conn_scrubber()) :: :ok
+  def put_conn_scrubber({mod, fun, args})
+      when is_atom(mod) and is_atom(fun) and is_list(args) do
+    Process.put(@conn_scrubber_pdict_key, {mod, fun, args})
+    :ok
+  end
+
+  @doc """
+  Scrubs a `%Plug.Conn{}` using the current process's registered scrubber.
+
+  If no scrubber has been registered via `put_conn_scrubber/1`, falls back to a
+  built-in default that clears cookies, drops sensitive request headers, and
+  scrubs `params` via `scrub_map/2`.
+  """
+  @doc since: "13.1.1"
+  @spec scrub_conn(Plug.Conn.t()) :: Plug.Conn.t()
+  def scrub_conn(conn) when is_struct(conn, Plug.Conn) do
+    {mod, fun, args} =
+      Process.get(@conn_scrubber_pdict_key, {__MODULE__, :default_conn_scrubber, []})
+
+    case apply(mod, fun, [conn | args]) do
+      %_{} = scrubbed when is_struct(scrubbed, Plug.Conn) ->
+        scrubbed
+
+      other ->
+        raise "expected #{inspect(mod)}.#{fun}/#{length(args) + 1} to return a Plug.Conn, got: #{inspect(other)}"
+    end
+  end
+
+  @doc """
+  Default scrubber for `%Plug.Conn{}` used by `scrub_conn/1` when no
+  per-process scrubber is registered.
+
+  Clears `cookies`, drops sensitive `req_headers` (preserving the list shape
+  required by `Plug.Conn`), and scrubs `params` via `scrub_map/2`.
+  """
+  @doc since: "13.1.1"
+  @spec default_conn_scrubber(Plug.Conn.t()) :: Plug.Conn.t()
+  def default_conn_scrubber(conn) when is_struct(conn, Plug.Conn) do
+    %{
+      conn
+      | cookies: %{},
+        req_headers: drop_sensitive_req_headers(conn.req_headers),
+        params: scrub_params(conn.params)
+    }
+  end
+
   ## Internal recursion
+
+  defp drop_sensitive_req_headers(headers) when is_list(headers) do
+    Enum.reject(headers, fn
+      {name, _value} when is_binary(name) ->
+        String.downcase(name) in @default_scrubbed_header_keys
+
+      _ ->
+        false
+    end)
+  end
+
+  defp drop_sensitive_req_headers(other), do: other
+
+  defp scrub_params(params) when is_map(params) and not is_struct(params),
+    do: do_scrub_map(params, @default_scrubbed_param_keys)
+
+  defp scrub_params(other), do: other
 
   defp do_scrub_map(map, keys) do
     Map.new(map, fn {key, value} -> {key, scrub_value(key, value, keys)} end)

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -219,21 +219,20 @@ defmodule Sentry.Scrubber do
 
   defp resolve_scrubbers(opts) do
     %__MODULE__{
-      body_scrubber: resolve_scrubber(opts, :body_scrubber, :body, & &1.params),
-      header_scrubber: resolve_scrubber(opts, :header_scrubber, :headers, & &1.req_headers),
-      cookie_scrubber: resolve_scrubber(opts, :cookie_scrubber, :cookies, & &1.cookies),
-      url_scrubber:
-        resolve_scrubber(opts, :url_scrubber, :url, fn conn -> Plug.Conn.request_url(conn) end)
+      body_scrubber: resolve_scrubber(opts, :body_scrubber, :body),
+      header_scrubber: resolve_scrubber(opts, :header_scrubber, :headers),
+      cookie_scrubber: resolve_scrubber(opts, :cookie_scrubber, :cookies),
+      url_scrubber: resolve_scrubber(opts, :url_scrubber, :url)
     }
   end
 
-  defp resolve_scrubber(opts, opt_name, field, extract) do
+  defp resolve_scrubber(opts, opt_name, field) do
     case Keyword.fetch(opts, opt_name) do
       :error ->
-        fn conn -> scrub(field, extract.(conn)) end
+        fn conn -> scrub(field, conn) end
 
       {:ok, nil} when field == :url ->
-        fn conn -> Plug.Conn.request_url(conn) end
+        fn conn -> scrub(:url, conn) end
 
       {:ok, nil} ->
         fn _conn -> %{} end
@@ -304,15 +303,17 @@ defmodule Sentry.Scrubber do
     * `:keys` - the list of sensitive keys to redact. Defaults to
       `default_param_keys/0`.
 
-  ## Default scrubbing for a `%Plug.Conn{}` field — `scrub(field, value)`
+  ## Default scrubbing for a `%Plug.Conn{}` field — `scrub(field, conn)`
 
-    * `:body` — scrubs a `params`-shaped map via `scrub/2`; non-maps pass
-      through unchanged (so `%Plug.Conn.Unfetched{}` is preserved).
-    * `:headers` — drops sensitive `req_headers` case-insensitively. Accepts
-      both the list-of-tuples shape (preserved on output) and a map (drops
-      sensitive keys via `drop_keys/2`).
+  Extracts the relevant field from the `conn` itself and applies the SDK's
+  default redaction for it:
+
+    * `:body` — scrubs `conn.params` via `scrub/2`; non-map params (such as
+      `%Plug.Conn.Unfetched{}`) pass through unchanged.
+    * `:headers` — drops sensitive `conn.req_headers` case-insensitively,
+      preserving the list-of-tuples shape.
     * `:cookies` — drops *all* cookies, returning `%{}`.
-    * `:url` — returns the URL unchanged.
+    * `:url` — returns the conn's request URL unchanged.
 
   Used by `scrub/1` and `scrub_request_url/1` for fields the user has not
   overridden via `put_conn_scrubber/1`, and available for custom scrubbers
@@ -320,7 +321,7 @@ defmodule Sentry.Scrubber do
 
       defmodule MyScrubber do
         def scrub_params(conn) do
-          Sentry.Scrubber.scrub(:body, conn.params)
+          Sentry.Scrubber.scrub(:body, conn)
           |> Map.drop(["my_secret_field"])
         end
       end
@@ -328,7 +329,7 @@ defmodule Sentry.Scrubber do
   @doc since: "13.1.0"
   @spec scrub(map(), [option()]) :: map()
   @spec scrub(list(), [option()]) :: list()
-  @spec scrub(:body | :headers | :cookies | :url, term()) :: term()
+  @spec scrub(:body | :headers | :cookies | :url, Plug.Conn.t()) :: term()
   def scrub(value, opts \\ [])
 
   def scrub(map, opts) when is_map(map) and not is_struct(map) and is_list(opts) do
@@ -346,12 +347,19 @@ defmodule Sentry.Scrubber do
     end)
   end
 
-  def scrub(:body, params) when is_map(params) and not is_struct(params), do: scrub(params)
-  def scrub(:body, other), do: other
-  def scrub(:headers, headers) when is_list(headers), do: drop_sensitive_req_headers(headers)
-  def scrub(:headers, headers) when is_map(headers), do: drop_keys(headers)
-  def scrub(:cookies, _cookies), do: %{}
-  def scrub(:url, url) when is_binary(url), do: url
+  def scrub(:body, conn) when is_struct(conn, Plug.Conn) do
+    if is_map(conn.params) and not is_struct(conn.params) do
+      scrub(conn.params)
+    else
+      conn.params
+    end
+  end
+
+  def scrub(:headers, conn) when is_struct(conn, Plug.Conn),
+    do: drop_sensitive_req_headers(conn.req_headers)
+
+  def scrub(:cookies, conn) when is_struct(conn, Plug.Conn), do: %{}
+  def scrub(:url, conn) when is_struct(conn, Plug.Conn), do: Plug.Conn.request_url(conn)
 
   @spec scrub_request_url(Plug.Conn.t()) :: String.t()
   def scrub_request_url(conn) when is_struct(conn, Plug.Conn), do: scrubber().url_scrubber.(conn)

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -43,10 +43,10 @@ defmodule Sentry.Scrubber do
   Conn scrubbing is configured per process rather than per call. Register the
   per-field scrubbers once with `put_conn_scrubber/1` (typically from
   `Sentry.PlugContext.call/2`), then `scrub/1` redacts a conn's params,
-  headers, and cookies using that registration, and `scrub_request_url/1`
-  returns the conn's request URL through the registered `:url_scrubber`. Any
-  field left unregistered falls back to the default behavior described on
-  `scrub/2`'s `scrub(field, value)` clause.
+  headers, and cookies using that registration. The request URL is not a conn
+  field, so callers fetch the registered `:url_scrubber` with `get/1` and
+  apply it to the conn. Any field left unregistered falls back to the default
+  behavior implemented by `scrub/2`'s `scrub(conn, field)` clauses.
   """
 
   @moduledoc since: "13.1.0"
@@ -97,7 +97,8 @@ defmodule Sentry.Scrubber do
   @typedoc """
   Options accepted by `put_conn_scrubber/1`.
 
-  Each key, when omitted, falls back to the corresponding `default_*_scrubber/1`.
+  Each key, when omitted, falls back to the field's default scrubber — the
+  matching `scrub(conn, field)` clause of `scrub/2`.
   """
   @type conn_scrubber_opts :: [
           body_scrubber: field_scrubber(),
@@ -199,8 +200,9 @@ defmodule Sentry.Scrubber do
 
   Accepts the same `:body_scrubber`, `:header_scrubber`, `:cookie_scrubber`,
   and `:url_scrubber` keys that `Sentry.PlugContext` takes as plug options,
-  resolves each missing key to its corresponding `default_*_scrubber/1`, and
-  stores the resolved scrubbers in the process dictionary.
+  resolves each missing key to the field's default scrubber (the
+  `{__MODULE__, :scrub, [field]}` MFA, i.e. the matching `scrub(conn, field)`
+  clause), and stores the resolved scrubbers in the process dictionary.
 
   The registration lives for the lifetime of the calling process — typically
   the request process when registered from `Sentry.PlugContext.call/2`. Used
@@ -226,27 +228,30 @@ defmodule Sentry.Scrubber do
     }
   end
 
+  # Resolves a per-field scrubber option into a `(conn -> term)` function. A
+  # missing option falls back to the field's default scrubber, expressed as an
+  # `{module, function, args}` MFA that captures the matching `scrub(conn, field)`
+  # clause. `nil` disables scrubbing for the field (it becomes `%{}`).
   defp resolve_scrubber(opts, opt_name, field) do
     case Keyword.fetch(opts, opt_name) do
       :error ->
-        fn conn -> scrub(field, conn) end
-
-      {:ok, nil} when field == :url ->
-        fn conn -> scrub(:url, conn) end
+        mfa_to_fun({__MODULE__, :scrub, [field]})
 
       {:ok, nil} ->
         fn _conn -> %{} end
 
       {:ok, {m, f, args}} when is_atom(m) and is_atom(f) and is_list(args) ->
-        fn conn -> apply(m, f, [conn | args]) end
+        mfa_to_fun({m, f, args})
 
       {:ok, {m, f}} when is_atom(m) and is_atom(f) ->
-        fn conn -> apply(m, f, [conn]) end
+        mfa_to_fun({m, f, []})
 
       {:ok, fun} when is_function(fun, 1) ->
         fun
     end
   end
+
+  defp mfa_to_fun({m, f, args}), do: fn conn -> apply(m, f, [conn | args]) end
 
   @spec scrubber() :: t()
   defp scrubber do
@@ -262,12 +267,25 @@ defmodule Sentry.Scrubber do
   end
 
   @doc """
+  Returns the current process's resolved scrubber function for the given field.
+
+  `key` is one of `#{inspect(@scrubber_names)}`. Returns the scrubber registered
+  via `put_conn_scrubber/1`, or the field's default if none was registered. The
+  returned function takes a `%Plug.Conn{}` and returns the scrubbed value, so
+  callers apply it as `Sentry.Scrubber.get(:url_scrubber).(conn)`.
+  """
+  @doc since: "13.1.1"
+  @spec get(atom()) :: (Plug.Conn.t() -> term())
+  def get(key) when key in @scrubber_names, do: Map.get(scrubber(), key)
+
+  @doc """
   Scrubs a `%Plug.Conn{}` or a plain map.
 
-  Given a `%Plug.Conn{}`, scrubs it using the current process's registered
-  scrubbers. When `put_conn_scrubber/1` has been called for this process,
-  applies the resolved body, header, and cookie scrubbers to the corresponding
-  conn fields. Otherwise falls back to `scrub/2` for each field.
+  Given a `%Plug.Conn{}`, scrubs its cookies, headers, and params using the
+  current process's registered scrubbers (see `put_conn_scrubber/1`), falling
+  back to the SDK defaults for any field without a registered scrubber. The
+  request URL is not a conn field; callers scrub it separately by applying the
+  `:url_scrubber` from `get/1` (whose default is `scrub(conn, :url)`).
 
   Given a plain map, recursively scrubs it with the default sensitive keys —
   equivalent to `scrub(map, [])`. See `scrub/2`.
@@ -303,25 +321,29 @@ defmodule Sentry.Scrubber do
     * `:keys` - the list of sensitive keys to redact. Defaults to
       `default_param_keys/0`.
 
-  ## Default scrubbing for a `%Plug.Conn{}` field — `scrub(field, conn)`
+  ## Scrubbing a single `%Plug.Conn{}` field — `scrub(conn, field)`
 
-  Extracts the relevant field from the `conn` itself and applies the SDK's
-  default redaction for it:
+  Extracts the given field from the `conn` and applies the SDK's *default*
+  redaction for it. Each clause is what the field's default scrubber captures
+  as a `{__MODULE__, :scrub, [field]}` MFA, and what `scrub/1` (conn fields)
+  and `get/1` (URL) fall back to when no custom scrubber is registered:
 
     * `:body` — scrubs `conn.params` via `scrub/2`; non-map params (such as
       `%Plug.Conn.Unfetched{}`) pass through unchanged.
     * `:headers` — drops sensitive `conn.req_headers` case-insensitively,
       preserving the list-of-tuples shape.
     * `:cookies` — drops *all* cookies, returning `%{}`.
-    * `:url` — returns the conn's request URL unchanged.
+    * `:url` — scrubs sensitive query parameters from the request URL via
+      `scrub_url/1`.
 
-  Used by `scrub/1` and `scrub_request_url/1` for fields the user has not
-  overridden via `put_conn_scrubber/1`, and available for custom scrubbers
-  that want to compose the default behavior:
+  Because these clauses are the defaults (not the registered scrubbers), a
+  custom `:body_scrubber` can safely compose on the default behavior without
+  recursing:
 
       defmodule MyScrubber do
         def scrub_params(conn) do
-          Sentry.Scrubber.scrub(:body, conn)
+          conn
+          |> Sentry.Scrubber.scrub(:body)
           |> Map.drop(["my_secret_field"])
         end
       end
@@ -329,7 +351,7 @@ defmodule Sentry.Scrubber do
   @doc since: "13.1.0"
   @spec scrub(map(), [option()]) :: map()
   @spec scrub(list(), [option()]) :: list()
-  @spec scrub(:body | :headers | :cookies | :url, Plug.Conn.t()) :: term()
+  @spec scrub(Plug.Conn.t(), :body | :headers | :cookies | :url) :: term()
   def scrub(value, opts \\ [])
 
   def scrub(map, opts) when is_map(map) and not is_struct(map) and is_list(opts) do
@@ -347,7 +369,11 @@ defmodule Sentry.Scrubber do
     end)
   end
 
-  def scrub(:body, conn) when is_struct(conn, Plug.Conn) do
+  # These are the SDK's default per-field scrubbers, captured as
+  # `{__MODULE__, :scrub, [field]}` MFAs in `resolve_scrubber/3`. `scrub/1`
+  # (conn fields) and `get/1` (URL) apply the *registered* scrubbers; these
+  # clauses are the defaults those registrations fall back to.
+  def scrub(conn, :body) when is_struct(conn, Plug.Conn) do
     if is_map(conn.params) and not is_struct(conn.params) do
       scrub(conn.params)
     else
@@ -355,14 +381,13 @@ defmodule Sentry.Scrubber do
     end
   end
 
-  def scrub(:headers, conn) when is_struct(conn, Plug.Conn),
+  def scrub(conn, :headers) when is_struct(conn, Plug.Conn),
     do: drop_sensitive_req_headers(conn.req_headers)
 
-  def scrub(:cookies, conn) when is_struct(conn, Plug.Conn), do: %{}
-  def scrub(:url, conn) when is_struct(conn, Plug.Conn), do: Plug.Conn.request_url(conn)
+  def scrub(conn, :cookies) when is_struct(conn, Plug.Conn), do: %{}
 
-  @spec scrub_request_url(Plug.Conn.t()) :: String.t()
-  def scrub_request_url(conn) when is_struct(conn, Plug.Conn), do: scrubber().url_scrubber.(conn)
+  def scrub(conn, :url) when is_struct(conn, Plug.Conn),
+    do: scrub_url(Plug.Conn.request_url(conn))
 
   defp headers_to_list(headers) when is_map(headers), do: Map.to_list(headers)
   defp headers_to_list(headers) when is_list(headers), do: headers

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -330,7 +330,10 @@ defmodule Sentry.Scrubber do
   `scrub(conn, :url)`).
 
   Given a plain map, recursively scrubs it with the default sensitive keys —
-  equivalent to `scrub(map, [])`. See `scrub/2`.
+  equivalent to `scrub(map, [])`. Any other struct is converted to a map and
+  scrubbed the same way, so a sensitive field can't slip through unredacted —
+  for example when the struct is inspected into stacktrace frame vars. See
+  `scrub/2`.
   """
   @doc since: "13.1.1"
   @spec scrub(Plug.Conn.t()) :: Plug.Conn.t()
@@ -339,7 +342,9 @@ defmodule Sentry.Scrubber do
 
   def scrub(conn) when is_struct(conn, Plug.Conn), do: scrub(conn, [])
 
-  def scrub(map) when is_map(map) and not is_struct(map), do: scrub(map, [])
+  def scrub(struct) when is_struct(struct), do: scrub(struct, [])
+
+  def scrub(map) when is_map(map), do: scrub(map, [])
 
   def scrub(other), do: other
 

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -28,15 +28,25 @@ defmodule Sentry.Scrubber do
 
   ## Custom scrubbing
 
-  All public functions accept an optional `:keys` option that overrides the
-  default list of sensitive keys. This makes it possible to compose custom
-  scrubbers on top of the defaults:
+  The map/query/header functions accept an optional `:keys` option that
+  overrides the default list of sensitive keys. This makes it possible to
+  compose custom scrubbers on top of the defaults:
 
       def scrub(map) do
         map
-        |> Sentry.Scrubber.scrub_map(keys: ["password", "api_key"])
+        |> Sentry.Scrubber.scrub(keys: ["password", "api_key"])
         |> Map.drop(["internal_notes"])
       end
+
+  ## Scrubbing a `%Plug.Conn{}`
+
+  Conn scrubbing is configured per process rather than per call. Register the
+  per-field scrubbers once with `put_conn_scrubber/1` (typically from
+  `Sentry.PlugContext.call/2`), then `scrub/1` redacts a conn's params,
+  headers, and cookies using that registration, and `scrub_request_url/1`
+  returns the conn's request URL through the registered `:url_scrubber`. Any
+  field left unregistered falls back to the default behavior described on
+  `scrub/2`'s `scrub(field, value)` clause.
   """
 
   @moduledoc since: "13.1.0"
@@ -118,40 +128,6 @@ defmodule Sentry.Scrubber do
   def default_header_keys, do: @default_scrubbed_header_keys
 
   @doc """
-  Recursively scrubs a map.
-
-  Any value whose key is in the configured sensitive key list is replaced with
-  the placeholder. Values matching the credit-card pattern are also replaced.
-  Nested maps, structs, and lists are scrubbed recursively.
-
-  ## Options
-
-    * `:keys` - the list of sensitive keys to redact. Defaults to
-      `default_param_keys/0`.
-  """
-  @doc since: "13.1.0"
-  @spec scrub_map(map(), [option()]) :: map()
-  def scrub_map(map, opts \\ []) when is_map(map) do
-    keys = Keyword.get(opts, :keys, @default_scrubbed_param_keys)
-    do_scrub_map(map, keys)
-  end
-
-  @doc """
-  Recursively scrubs a list, applying the same rules as `scrub_map/2` to any
-  maps it contains.
-
-  ## Options
-
-  See `scrub_map/2`.
-  """
-  @doc since: "13.1.0"
-  @spec scrub_list(list(), [option()]) :: list()
-  def scrub_list(list, opts \\ []) when is_list(list) do
-    keys = Keyword.get(opts, :keys, @default_scrubbed_param_keys)
-    do_scrub_list(list, keys)
-  end
-
-  @doc """
   Drops sensitive keys from a flat map.
 
   This is the strategy used for HTTP headers, where the sensitive value should
@@ -176,7 +152,7 @@ defmodule Sentry.Scrubber do
 
   ## Options
 
-  See `scrub_map/2`.
+  See `scrub/2`.
   """
   @doc since: "13.1.0"
   @spec scrub_url(String.t(), [option()]) :: String.t()
@@ -199,7 +175,7 @@ defmodule Sentry.Scrubber do
 
   ## Options
 
-  See `scrub_map/2`.
+  See `scrub/2`.
   """
   @doc since: "13.1.0"
   @spec scrub_query_string(String.t(), [option()]) :: String.t()
@@ -287,9 +263,50 @@ defmodule Sentry.Scrubber do
   end
 
   @doc """
-  Default scrubbing for a single `%Plug.Conn{}` field.
+  Scrubs a `%Plug.Conn{}` or a plain map.
 
-    * `:body` — scrubs a `params`-shaped map via `scrub_map/2`; non-maps pass
+  Given a `%Plug.Conn{}`, scrubs it using the current process's registered
+  scrubbers. When `put_conn_scrubber/1` has been called for this process,
+  applies the resolved body, header, and cookie scrubbers to the corresponding
+  conn fields. Otherwise falls back to `scrub/2` for each field.
+
+  Given a plain map, recursively scrubs it with the default sensitive keys —
+  equivalent to `scrub(map, [])`. See `scrub/2`.
+  """
+  @doc since: "13.1.1"
+  @spec scrub(Plug.Conn.t()) :: Plug.Conn.t()
+  @spec scrub(map()) :: map()
+
+  def scrub(conn) when is_struct(conn, Plug.Conn) do
+    %{
+      conn
+      | cookies: scrubber().cookie_scrubber.(conn),
+        req_headers: headers_to_list(scrubber().header_scrubber.(conn)),
+        params: scrubber().body_scrubber.(conn)
+    }
+  end
+
+  def scrub(map) when is_map(map) and not is_struct(map), do: scrub(map, [])
+
+  @doc """
+  Scrubs a value, dispatching on the first argument.
+
+  ## Scrubbing a map or list — `scrub(map, opts)` / `scrub(list, opts)`
+
+  Recursively scrubs a map. Any value whose key is in the configured sensitive
+  key list is replaced with the placeholder. Values matching the credit-card
+  pattern are also replaced. Nested maps, structs, and lists are scrubbed
+  recursively. A list given as the top-level value is scrubbed element-wise
+  using the same rules.
+
+  Accepts the same `:keys` option as the other scrubbing functions:
+
+    * `:keys` - the list of sensitive keys to redact. Defaults to
+      `default_param_keys/0`.
+
+  ## Default scrubbing for a `%Plug.Conn{}` field — `scrub(field, value)`
+
+    * `:body` — scrubs a `params`-shaped map via `scrub/2`; non-maps pass
       through unchanged (so `%Plug.Conn.Unfetched{}` is preserved).
     * `:headers` — drops sensitive `req_headers` case-insensitively. Accepts
       both the list-of-tuples shape (preserved on output) and a map (drops
@@ -308,47 +325,36 @@ defmodule Sentry.Scrubber do
         end
       end
   """
-  @doc since: "13.1.1"
+  @doc since: "13.1.0"
+  @spec scrub(map(), [option()]) :: map()
+  @spec scrub(list(), [option()]) :: list()
   @spec scrub(:body | :headers | :cookies | :url, term()) :: term()
-  def scrub(:body, params) when is_map(params) and not is_struct(params),
-    do: do_scrub_map(params, @default_scrubbed_param_keys)
+  def scrub(value, opts \\ [])
 
+  def scrub(map, opts) when is_map(map) and not is_struct(map) and is_list(opts) do
+    keys = Keyword.get(opts, :keys, @default_scrubbed_param_keys)
+    Map.new(map, fn {key, value} -> {key, scrub_value(key, value, keys)} end)
+  end
+
+  def scrub(list, opts) when is_list(list) do
+    Enum.map(list, fn value ->
+      cond do
+        is_struct(value) -> value |> Map.from_struct() |> scrub(opts)
+        is_map(value) or is_list(value) -> scrub(value, opts)
+        true -> value
+      end
+    end)
+  end
+
+  def scrub(:body, params) when is_map(params) and not is_struct(params), do: scrub(params)
   def scrub(:body, other), do: other
-
   def scrub(:headers, headers) when is_list(headers), do: drop_sensitive_req_headers(headers)
   def scrub(:headers, headers) when is_map(headers), do: drop_keys(headers)
-
   def scrub(:cookies, _cookies), do: %{}
-
   def scrub(:url, url) when is_binary(url), do: url
 
-  @doc """
-  Scrubs a `%Plug.Conn{}` using the current process's registered scrubbers.
-
-  When `put_conn_scrubber/1` has been called for this process, applies the
-  resolved body, header, and cookie scrubbers to the corresponding conn
-  fields. Otherwise falls back to `scrub/2` for each field.
-  """
-  @doc since: "13.1.1"
-  @spec scrub(Plug.Conn.t()) :: Plug.Conn.t()
-  def scrub(conn) when is_struct(conn, Plug.Conn) do
-    %{
-      conn
-      | cookies: scrubber().cookie_scrubber.(conn),
-        req_headers: headers_to_list(scrubber().header_scrubber.(conn)),
-        params: scrubber().body_scrubber.(conn)
-    }
-  end
-
-  @doc """
-  Returns the request URL for `conn`, scrubbed by the current process's
-  registered `:url_scrubber`. Falls back to `scrub(:url, url)`.
-  """
-  @doc since: "13.1.1"
   @spec scrub_request_url(Plug.Conn.t()) :: String.t()
-  def scrub_request_url(conn) when is_struct(conn, Plug.Conn) do
-    scrubber().url_scrubber.(conn)
-  end
+  def scrub_request_url(conn) when is_struct(conn, Plug.Conn), do: scrubber().url_scrubber.(conn)
 
   defp headers_to_list(headers) when is_map(headers), do: Map.to_list(headers)
   defp headers_to_list(headers) when is_list(headers), do: headers
@@ -363,30 +369,12 @@ defmodule Sentry.Scrubber do
     end)
   end
 
-  ## Internal recursion
-
-  defp do_scrub_map(map, keys) do
-    Map.new(map, fn {key, value} -> {key, scrub_value(key, value, keys)} end)
-  end
-
-  defp do_scrub_list(list, keys) do
-    Enum.map(list, fn value ->
-      cond do
-        is_struct(value) -> value |> Map.from_struct() |> do_scrub_map(keys)
-        is_map(value) -> do_scrub_map(value, keys)
-        is_list(value) -> do_scrub_list(value, keys)
-        true -> value
-      end
-    end)
-  end
-
   defp scrub_value(key, value, keys) do
     cond do
       key in keys -> @scrubbed_value
       is_binary(value) and value =~ credit_card_regex() -> @scrubbed_value
-      is_struct(value) -> value |> Map.from_struct() |> do_scrub_map(keys)
-      is_map(value) -> do_scrub_map(value, keys)
-      is_list(value) -> do_scrub_list(value, keys)
+      is_struct(value) -> value |> Map.from_struct() |> scrub(keys: keys)
+      is_map(value) or is_list(value) -> scrub(value, keys: keys)
       true -> value
     end
   end

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -40,13 +40,23 @@ defmodule Sentry.Scrubber do
 
   ## Scrubbing a `%Plug.Conn{}`
 
-  Conn scrubbing is configured per process rather than per call. Register the
-  per-field scrubbers once with `put_conn_scrubber/1` (typically from
-  `Sentry.PlugContext.call/2`), then `scrub/1` redacts a conn's params,
-  headers, and cookies using that registration. The request URL is not a conn
-  field, so callers fetch the registered `:url_scrubber` with `get/1` and
-  apply it to the conn. Any field left unregistered falls back to the default
-  behavior implemented by `scrub/2`'s `scrub(conn, field)` clauses.
+  `scrub/1` redacts a conn by applying, to each field listed in the
+  `@scrubbable_conn_fields` attribute, that field's *strategy*. A strategy is
+  either:
+
+    * a configurable scrubber (`:cookie_scrubber`, `:header_scrubber`,
+      `:body_scrubber`) — resolved per process via `put_conn_scrubber/1`
+      (typically from `Sentry.PlugContext.call/2`), falling back to the SDK
+      default `scrub(conn, field)` clause when none is registered, or
+    * a fixed tag — `:clear` replaces the field with `%{}`, `:params` scrubs the
+      field as a params-shaped map, and `:query_string` redacts sensitive params
+      from a raw query string.
+
+  The defaults can be overridden per call with `scrub(conn, overrides)`, where
+  `overrides` is a `field: strategy` keyword list merged over the attribute —
+  for example `scrub(conn, assigns: :clear)`. The request URL is not a conn
+  field, so callers fetch the registered `:url_scrubber` with `get/1` and apply
+  it to the conn.
   """
 
   @moduledoc since: "13.1.0"
@@ -57,20 +67,24 @@ defmodule Sentry.Scrubber do
   @scrubber_pdict_key {__MODULE__, :scrubber}
   @scrubber_names [:body_scrubber, :header_scrubber, :cookie_scrubber, :url_scrubber]
 
-  # `%Plug.Conn{}` fields scrubbed by `scrub/1`, each mapped to the struct key
-  # of the scrubber that redacts it. Add an entry to make a new field scrubbed
-  # by default.
+  # Default `field -> strategy` mapping applied by `scrub/1` (overridable per
+  # call via `scrub(conn, overrides)`). A strategy is either a configurable
+  # scrubber struct-key (resolved per process via `get/1`) or a fixed tag:
+  # `:clear` -> `%{}`, `:params` -> params-shaped scrub (Unfetched-safe),
+  # `:query_string` -> redact sensitive params from the raw query string.
+  # Add an entry to make a new conn field scrubbed by default.
   @scrubbable_conn_fields [
     cookies: :cookie_scrubber,
     req_headers: :header_scrubber,
-    params: :body_scrubber
+    params: :body_scrubber,
+    query_string: :query_string
   ]
 
   @typedoc """
   A resolved set of per-field scrubbers for a `%Plug.Conn{}`.
 
-  Each field holds a 1-arity function that takes the conn and returns the
-  scrubbed value for the corresponding field. Built by `put_conn_scrubber/1`
+  Each scrubber field holds a 1-arity function that takes the conn and returns
+  the scrubbed value for the corresponding field. Built by `put_conn_scrubber/1`
   from `t:conn_scrubber_opts/0` and stored in the process dictionary.
   """
   @type t :: %__MODULE__{
@@ -107,8 +121,8 @@ defmodule Sentry.Scrubber do
   @typedoc """
   Options accepted by `put_conn_scrubber/1`.
 
-  Each key, when omitted, falls back to the field's default scrubber — the
-  matching `scrub(conn, field)` clause of `scrub/2`.
+  Each `*_scrubber` key, when omitted, falls back to the field's default
+  scrubber — the matching `scrub(conn, field)` clause of `scrub/2`.
   """
   @type conn_scrubber_opts :: [
           body_scrubber: field_scrubber(),
@@ -308,11 +322,12 @@ defmodule Sentry.Scrubber do
   @doc """
   Scrubs a `%Plug.Conn{}` or a plain map.
 
-  Given a `%Plug.Conn{}`, scrubs its cookies, headers, and params using the
-  current process's registered scrubbers (see `put_conn_scrubber/1`), falling
-  back to the SDK defaults for any field without a registered scrubber. The
-  request URL is not a conn field; callers scrub it separately by applying the
-  `:url_scrubber` from `get/1` (whose default is `scrub(conn, :url)`).
+  Given a `%Plug.Conn{}`, scrubs each field listed in `@scrubbable_conn_fields`
+  according to its strategy — see the "Scrubbing a `%Plug.Conn{}`" section in
+  the module docs and `scrub/2` for the per-field defaults and how to override
+  them per call. The request URL is not a conn field; callers scrub it
+  separately by applying the `:url_scrubber` from `get/1` (whose default is
+  `scrub(conn, :url)`).
 
   Given a plain map, recursively scrubs it with the default sensitive keys —
   equivalent to `scrub(map, [])`. See `scrub/2`.
@@ -322,11 +337,7 @@ defmodule Sentry.Scrubber do
   @spec scrub(map()) :: map()
   @spec scrub(term()) :: term()
 
-  def scrub(conn) when is_struct(conn, Plug.Conn) do
-    Enum.reduce(@scrubbable_conn_fields, conn, fn {field, scrubber_key}, acc ->
-      Map.replace!(acc, field, normalize(field, get(scrubber_key).(conn)))
-    end)
-  end
+  def scrub(conn) when is_struct(conn, Plug.Conn), do: scrub(conn, [])
 
   def scrub(map) when is_map(map) and not is_struct(map), do: scrub(map, [])
 
@@ -375,11 +386,22 @@ defmodule Sentry.Scrubber do
           |> Map.drop(["my_secret_field"])
         end
       end
+
+  ## Scrubbing a whole `%Plug.Conn{}` with overrides — `scrub(conn, overrides)`
+
+  Behaves like `scrub/1` but merges the `field: strategy` keyword `overrides`
+  over the `@scrubbable_conn_fields` defaults, so a caller can scrub additional
+  fields or change a field's strategy for that call. Strategies are a
+  configurable scrubber struct-key, `:clear` (replace with `%{}`), or `:params`
+  (params-shaped scrub of that field):
+
+      Sentry.Scrubber.scrub(conn, assigns: :clear, query_params: :params)
   """
   @doc since: "13.1.0"
   @spec scrub(map(), [option()]) :: map()
   @spec scrub(list(), [option()]) :: list()
   @spec scrub(term(), [option()]) :: term()
+  @spec scrub(Plug.Conn.t(), keyword()) :: Plug.Conn.t()
   @spec scrub(Plug.Conn.t(), :body | :headers | :cookies | :url) :: term()
 
   def scrub(map, opts) when is_map(map) and not is_struct(map) and is_list(opts) do
@@ -390,8 +412,17 @@ defmodule Sentry.Scrubber do
     end)
   end
 
-  def scrub(struct, opts) when is_struct(struct) and is_list(opts),
-    do: struct |> Map.from_struct() |> scrub(opts)
+  def scrub(conn, overrides) when is_struct(conn, Plug.Conn) and is_list(overrides) do
+    @scrubbable_conn_fields
+    |> Keyword.merge(overrides)
+    |> Enum.reduce(conn, fn {field, strategy}, acc ->
+      Map.replace(acc, field, normalize(field, scrub_conn_field(conn, field, strategy)))
+    end)
+  end
+
+  def scrub(struct, opts)
+      when is_struct(struct) and not is_struct(struct, Plug.Conn) and is_list(opts),
+      do: struct |> Map.from_struct() |> scrub(opts)
 
   def scrub(list, opts) when is_list(list), do: Enum.map(list, &scrub(&1, opts))
 
@@ -404,13 +435,8 @@ defmodule Sentry.Scrubber do
   # `{__MODULE__, :scrub, [field]}` MFAs in `resolve_scrubber/3`. `scrub/1`
   # (conn fields) and `get/1` (URL) apply the *registered* scrubbers; these
   # clauses are the defaults those registrations fall back to.
-  def scrub(conn, :body) when is_struct(conn, Plug.Conn) do
-    if is_map(conn.params) and not is_struct(conn.params) do
-      scrub(conn.params)
-    else
-      conn.params
-    end
-  end
+  def scrub(conn, :body) when is_struct(conn, Plug.Conn),
+    do: scrub_params_value(conn.params)
 
   def scrub(conn, :headers) when is_struct(conn, Plug.Conn) do
     Enum.reject(conn.req_headers, fn
@@ -426,6 +452,33 @@ defmodule Sentry.Scrubber do
 
   def scrub(conn, :url) when is_struct(conn, Plug.Conn),
     do: Plug.Conn.request_url(conn)
+
+  # Resolves a single conn field's strategy (from `@scrubbable_conn_fields` or a
+  # `scrub(conn, overrides)` override) to its scrubbed value:
+  #
+  #   * a configurable scrubber struct-key — resolved per-process via `get/1`,
+  #     honoring any `put_conn_scrubber/1` registration
+  #   * `:clear` — replaces the field with `%{}`
+  #   * `:params` — scrubs THIS field (read via `Map.fetch!/2`) as a
+  #     params-shaped map, leaving `%Plug.Conn.Unfetched{}` untouched
+  #   * `:query_string` — redacts sensitive params from THIS field (a raw query
+  #     string) via `scrub_query_string/1`
+  defp scrub_conn_field(conn, _field, scrubber_key) when scrubber_key in @scrubber_names,
+    do: get(scrubber_key).(conn)
+
+  defp scrub_conn_field(_conn, _field, :clear), do: %{}
+
+  defp scrub_conn_field(conn, field, :params),
+    do: scrub_params_value(Map.fetch!(conn, field))
+
+  defp scrub_conn_field(conn, field, :query_string),
+    do: scrub_query_string(Map.fetch!(conn, field))
+
+  # Scrubs a params-shaped value with the default sensitive keys, leaving
+  # `%Plug.Conn.Unfetched{}` (and any non-plain-map) untouched. Shared by the
+  # `:body` default clause and the `:params` strategy.
+  defp scrub_params_value(value) when is_map(value) and not is_struct(value), do: scrub(value)
+  defp scrub_params_value(value), do: value
 
   # Coerces a per-field scrubber result into the shape its `%Plug.Conn{}` field
   # requires. A header scrubber may return a map (the documented convention —

--- a/test/plug_capture_test.exs
+++ b/test/plug_capture_test.exs
@@ -198,6 +198,12 @@ defmodule Sentry.PlugCaptureTest do
       assert [exception] = event.exception
       assert exception.type == "Phoenix.ActionClauseError"
       assert exception.value =~ ~s(params: %{"password" => "*********"})
+
+      # conn.query_string must be scrubbed too. The "query_string:" prefix isolates
+      # this from the conn's query_params map, which is not broadened into the
+      # scrubbed fields on this branch.
+      refute exception.value =~ ~s(query_string: "password=secret"),
+             "query_string leaked into exception value: #{exception.value}"
     end
 
     test "scrubs Phoenix.ActionClauseError using PlugContext-configured body_scrubber" do

--- a/test/plug_capture_test.exs
+++ b/test/plug_capture_test.exs
@@ -56,6 +56,22 @@ defmodule Sentry.PlugCaptureTest do
     plug PhoenixRouter
   end
 
+  defmodule CustomBodyScrubber do
+    def scrub(_conn), do: %{"scrubbed_by" => "custom_body_scrubber"}
+  end
+
+  defmodule PhoenixEndpointWithCustomPlugContext do
+    use Sentry.PlugCapture
+    use Phoenix.Endpoint, otp_app: :sentry
+    use Plug.Debugger, otp_app: :sentry
+
+    json_mod = if Code.ensure_loaded?(JSON), do: JSON, else: Jason
+
+    plug Plug.Parsers, parsers: [:json], pass: ["*/*"], json_decoder: json_mod
+    plug Sentry.PlugContext, body_scrubber: {CustomBodyScrubber, :scrub}
+    plug PhoenixRouter
+  end
+
   setup do
     SentryTest.setup_sentry()
   end
@@ -182,6 +198,36 @@ defmodule Sentry.PlugCaptureTest do
       assert [exception] = event.exception
       assert exception.type == "Phoenix.ActionClauseError"
       assert exception.value =~ ~s(params: %{"password" => "*********"})
+    end
+
+    test "scrubs Phoenix.ActionClauseError using PlugContext-configured body_scrubber" do
+      Application.put_env(:sentry, PhoenixEndpointWithCustomPlugContext,
+        render_errors: [view: Sentry.ErrorView, accepts: ~w(html)]
+      )
+
+      pid = start_supervised!(PhoenixEndpointWithCustomPlugContext)
+      Process.link(pid)
+
+      assert_raise Phoenix.ActionClauseError, fn ->
+        conn(:get, "/action_clause_error?password=secret")
+        |> Plug.run([{PhoenixEndpointWithCustomPlugContext, []}])
+      end
+
+      event =
+        assert_sentry_report(:event,
+          culprit: "Sentry.PlugCaptureTest.PhoenixController.action_clause_error/2"
+        )
+
+      assert [exception] = event.exception
+      assert exception.type == "Phoenix.ActionClauseError"
+
+      assert exception.value =~ ~s("scrubbed_by" => "custom_body_scrubber"),
+             """
+             expected the embedded conn's params to be scrubbed by the user-configured \
+             body_scrubber from Sentry.PlugContext, but got:
+
+             #{exception.value}
+             """
     end
 
     test "can render feedback form in Phoenix ErrorView" do

--- a/test/sentry/live_view_hook_test.exs
+++ b/test/sentry/live_view_hook_test.exs
@@ -24,7 +24,7 @@ defmodule SentryTest.Live do
 end
 
 defmodule SentryTest.CustomScrubber do
-  def scrub(data), do: Sentry.Scrubber.scrub_map(data, keys: ["api_key"])
+  def scrub(data), do: Sentry.Scrubber.scrub(data, keys: ["api_key"])
 end
 
 defmodule SentryTest.CustomScrubberLive do

--- a/test/sentry/plug_context_test.exs
+++ b/test/sentry/plug_context_test.exs
@@ -110,11 +110,27 @@ defmodule Sentry.PlugContextTest do
     assert %{"not-secret" => "not-secret"} == Sentry.Context.get_all().request.cookies
   end
 
+  test "does not scrub the URL by default" do
+    conn = conn(:get, "/test?password=hunter2")
+    call(conn, [])
+
+    assert "http://www.example.com/test?password=hunter2" ==
+             Sentry.Context.get_all().request.url
+  end
+
   test "allows configuring URL scrubber" do
     conn = conn(:get, "/secret-token/secret")
     call(conn, url_scrubber: {__MODULE__, :url_scrubber})
 
     assert "http://www.example.com/secret-token/****" == Sentry.Context.get_all().request.url
+  end
+
+  test "url_scrubber: nil falls back to the request URL unchanged" do
+    conn = conn(:get, "/test?password=hunter2")
+    call(conn, url_scrubber: nil)
+
+    assert "http://www.example.com/test?password=hunter2" ==
+             Sentry.Context.get_all().request.url
   end
 
   test "allows configuring request id header", %{conn: conn} do

--- a/test/sentry/plug_context_test.exs
+++ b/test/sentry/plug_context_test.exs
@@ -183,11 +183,11 @@ defmodule Sentry.PlugContextTest do
   end
 
   describe "scrubber registration" do
-    test "registers a conn scrubber accessible via Sentry.Scrubber.scrub_conn/1", %{conn: conn} do
+    test "registers a conn scrubber accessible via Sentry.Scrubber.scrub/1", %{conn: conn} do
       call(conn, [])
 
       scrubbed =
-        Sentry.Scrubber.scrub_conn(%Plug.Conn{
+        Sentry.Scrubber.scrub(%Plug.Conn{
           cookies: %{"session" => "secret"},
           req_headers: [{"authorization", "Bearer x"}, {"x-keep", "yes"}],
           params: %{"password" => "hunter2", "ok" => "fine"}
@@ -198,12 +198,12 @@ defmodule Sentry.PlugContextTest do
       assert scrubbed.params == %{"password" => "*********", "ok" => "fine"}
     end
 
-    test "honors a custom body_scrubber when scrub_conn/1 is called downstream",
+    test "honors a custom body_scrubber when scrub/1 is called downstream",
          %{conn: conn} do
       call(conn, body_scrubber: {__MODULE__, :body_scrubber})
 
       scrubbed =
-        Sentry.Scrubber.scrub_conn(%Plug.Conn{
+        Sentry.Scrubber.scrub(%Plug.Conn{
           params: %{"foo" => "kept", "bar" => "dropped"}
         })
 

--- a/test/sentry/plug_context_test.exs
+++ b/test/sentry/plug_context_test.exs
@@ -182,6 +182,35 @@ defmodule Sentry.PlugContextTest do
            }
   end
 
+  describe "scrubber registration" do
+    test "registers a conn scrubber accessible via Sentry.Scrubber.scrub_conn/1", %{conn: conn} do
+      call(conn, [])
+
+      scrubbed =
+        Sentry.Scrubber.scrub_conn(%Plug.Conn{
+          cookies: %{"session" => "secret"},
+          req_headers: [{"authorization", "Bearer x"}, {"x-keep", "yes"}],
+          params: %{"password" => "hunter2", "ok" => "fine"}
+        })
+
+      assert scrubbed.cookies == %{}
+      assert scrubbed.req_headers == [{"x-keep", "yes"}]
+      assert scrubbed.params == %{"password" => "*********", "ok" => "fine"}
+    end
+
+    test "honors a custom body_scrubber when scrub_conn/1 is called downstream",
+         %{conn: conn} do
+      call(conn, body_scrubber: {__MODULE__, :body_scrubber})
+
+      scrubbed =
+        Sentry.Scrubber.scrub_conn(%Plug.Conn{
+          params: %{"foo" => "kept", "bar" => "dropped"}
+        })
+
+      assert scrubbed.params == %{"foo" => "kept"}
+    end
+  end
+
   defp call(conn, opts) do
     Plug.run(conn, [{Sentry.PlugContext, opts}])
   end

--- a/test/sentry/scrubber_test.exs
+++ b/test/sentry/scrubber_test.exs
@@ -3,42 +3,42 @@ defmodule Sentry.ScrubberTest do
 
   alias Sentry.Scrubber
 
-  describe "scrub_map/2" do
+  describe "scrub/2" do
     test "redacts sensitive top-level keys" do
-      assert Scrubber.scrub_map(%{"password" => "x", "ok" => 1}) ==
+      assert Scrubber.scrub(%{"password" => "x", "ok" => 1}) ==
                %{"password" => "*********", "ok" => 1}
     end
 
     test "recurses into nested maps" do
-      assert Scrubber.scrub_map(%{"outer" => %{"secret" => "shh"}}) ==
+      assert Scrubber.scrub(%{"outer" => %{"secret" => "shh"}}) ==
                %{"outer" => %{"secret" => "*********"}}
     end
 
     test "recurses into lists of maps" do
-      assert Scrubber.scrub_map(%{"items" => [%{"passwd" => "1"}, %{"ok" => 2}]}) ==
+      assert Scrubber.scrub(%{"items" => [%{"passwd" => "1"}, %{"ok" => 2}]}) ==
                %{"items" => [%{"passwd" => "*********"}, %{"ok" => 2}]}
     end
 
     test "redacts credit-card-shaped values" do
-      assert Scrubber.scrub_map(%{"cc" => "4111111111111111"}) ==
+      assert Scrubber.scrub(%{"cc" => "4111111111111111"}) ==
                %{"cc" => "*********"}
     end
 
     test "scrubs structs by converting them to maps" do
       uri = URI.parse("http://example.com")
-      assert %{"u" => scrubbed} = Scrubber.scrub_map(%{"u" => uri})
+      assert %{"u" => scrubbed} = Scrubber.scrub(%{"u" => uri})
       assert is_map(scrubbed)
       refute Map.has_key?(scrubbed, :__struct__)
     end
 
     test "respects custom :keys option" do
-      assert Scrubber.scrub_map(%{"api_key" => "x", "password" => "y"}, keys: ["api_key"]) ==
+      assert Scrubber.scrub(%{"api_key" => "x", "password" => "y"}, keys: ["api_key"]) ==
                %{"api_key" => "*********", "password" => "y"}
     end
 
     test "leaves non-sensitive values untouched" do
       data = %{"name" => "alice", "age" => 30}
-      assert Scrubber.scrub_map(data) == data
+      assert Scrubber.scrub(data) == data
     end
   end
 

--- a/test/sentry/scrubber_test.exs
+++ b/test/sentry/scrubber_test.exs
@@ -166,6 +166,79 @@ defmodule Sentry.ScrubberTest do
 
       assert changed == [:cookies, :params, :req_headers]
     end
+
+    test "scrubs sensitive params from query_string" do
+      conn = %Plug.Conn{
+        query_string: "password=secret&token=abc&card=4242424242424242&keep=ok"
+      }
+
+      scrubbed = Scrubber.scrub(conn).query_string
+
+      refute scrubbed =~ "secret"
+      refute scrubbed =~ "4242424242424242"
+      assert scrubbed =~ "token=abc"
+      assert scrubbed =~ "keep=ok"
+    end
+  end
+
+  describe "scrub/2 with conn field overrides" do
+    test ":clear override replaces additional fields with %{}" do
+      conn = %Plug.Conn{
+        params: %{"password" => "hunter2"},
+        assigns: %{current_user: %{password_hash: "secret"}},
+        private: %{guardian_token: "jwt"}
+      }
+
+      scrubbed = Scrubber.scrub(conn, assigns: :clear, private: :clear)
+
+      # default fields still scrubbed
+      assert scrubbed.params == %{"password" => "*********"}
+      # overridden fields cleared wholesale
+      assert scrubbed.assigns == %{}
+      assert scrubbed.private == %{}
+    end
+
+    test ":params override scrubs the named field by default sensitive keys" do
+      conn = %Plug.Conn{
+        body_params: %{"user" => %{"password" => "hunter2", "email" => "a@b.c"}},
+        query_params: %{"secret" => "leak", "page" => "1"}
+      }
+
+      scrubbed = Scrubber.scrub(conn, body_params: :params, query_params: :params)
+
+      assert scrubbed.body_params == %{
+               "user" => %{"password" => "*********", "email" => "a@b.c"}
+             }
+
+      assert scrubbed.query_params == %{"secret" => "*********", "page" => "1"}
+    end
+
+    test ":params override leaves %Plug.Conn.Unfetched{} untouched" do
+      unfetched = %Plug.Conn.Unfetched{aspect: :body_params}
+      conn = %Plug.Conn{body_params: unfetched}
+
+      scrubbed = Scrubber.scrub(conn, body_params: :params)
+
+      assert scrubbed.body_params == unfetched
+    end
+
+    test "an override can change a default field's strategy" do
+      conn = %Plug.Conn{params: %{"password" => "hunter2", "name" => "Alice"}}
+
+      # default for :params is :body_scrubber (key-based); override to :clear
+      scrubbed = Scrubber.scrub(conn, params: :clear)
+
+      assert scrubbed.params == %{}
+    end
+
+    test "no overrides behaves like scrub/1" do
+      conn = %Plug.Conn{
+        cookies: %{"session" => "secret"},
+        params: %{"password" => "hunter2"}
+      }
+
+      assert Scrubber.scrub(conn, []) == Scrubber.scrub(conn)
+    end
   end
 
   describe "put_conn_scrubber/1 + scrub/1" do

--- a/test/sentry/scrubber_test.exs
+++ b/test/sentry/scrubber_test.exs
@@ -100,6 +100,21 @@ defmodule Sentry.ScrubberTest do
     end
   end
 
+  describe "scrub/2 with a Plug.Conn field" do
+    test ":url returns the request URL unchanged, including sensitive query params" do
+      conn = %Plug.Conn{
+        scheme: :http,
+        host: "example.com",
+        port: 80,
+        request_path: "/foo",
+        query_string: "password=secret&visible=ok"
+      }
+
+      assert Scrubber.scrub(conn, :url) == Plug.Conn.request_url(conn)
+      assert Scrubber.scrub(conn, :url) =~ "password=secret"
+    end
+  end
+
   describe "scrub_query_string/2" do
     test "redacts sensitive params" do
       scrubbed = Scrubber.scrub_query_string("password=hunter2&visible=ok")

--- a/test/sentry/scrubber_test.exs
+++ b/test/sentry/scrubber_test.exs
@@ -140,6 +140,17 @@ defmodule Sentry.ScrubberTest do
     test "returns a %Plug.Conn{} struct", %{scrubbed: scrubbed} do
       assert is_struct(scrubbed, Plug.Conn)
     end
+
+    test "rewrites only cookies, req_headers, and params", %{conn: conn, scrubbed: scrubbed} do
+      changed =
+        conn
+        |> Map.from_struct()
+        |> Enum.filter(fn {key, value} -> Map.fetch!(scrubbed, key) != value end)
+        |> Enum.map(fn {key, _value} -> key end)
+        |> Enum.sort()
+
+      assert changed == [:cookies, :params, :req_headers]
+    end
   end
 
   describe "put_conn_scrubber/1 + scrub/1" do

--- a/test/sentry/scrubber_test.exs
+++ b/test/sentry/scrubber_test.exs
@@ -101,7 +101,7 @@ defmodule Sentry.ScrubberTest do
   end
 
   describe "scrub/2 with a Plug.Conn field" do
-    test ":url returns the request URL unchanged, including sensitive query params" do
+    test ":url scrubs sensitive query parameters" do
       conn = %Plug.Conn{
         scheme: :http,
         host: "example.com",
@@ -110,8 +110,28 @@ defmodule Sentry.ScrubberTest do
         query_string: "password=secret&visible=ok"
       }
 
-      assert Scrubber.scrub(conn, :url) == Plug.Conn.request_url(conn)
-      assert Scrubber.scrub(conn, :url) =~ "password=secret"
+      scrubbed = Scrubber.scrub(conn, :url)
+
+      refute scrubbed =~ "secret"
+      assert scrubbed =~ "visible=ok"
+      assert scrubbed =~ "http://example.com/foo?"
+      # equivalent to scrubbing the URL directly
+      assert scrubbed == Scrubber.scrub_url(Plug.Conn.request_url(conn))
+    end
+
+    test "a nil :url_scrubber leaves the URL unchanged" do
+      conn = %Plug.Conn{
+        scheme: :http,
+        host: "example.com",
+        port: 80,
+        request_path: "/foo",
+        query_string: "password=secret&visible=ok"
+      }
+
+      :ok = Scrubber.put_conn_scrubber(url_scrubber: nil)
+
+      assert Scrubber.get(:url_scrubber).(conn) == Plug.Conn.request_url(conn)
+      assert Scrubber.get(:url_scrubber).(conn) =~ "password=secret"
     end
   end
 

--- a/test/sentry/scrubber_test.exs
+++ b/test/sentry/scrubber_test.exs
@@ -116,19 +116,56 @@ defmodule Sentry.ScrubberTest do
   end
 
   describe "put_conn_scrubber/1 + scrub_conn/1" do
-    defmodule MarkerScrubber do
-      def stamp(conn, marker) do
-        %{conn | params: %{"marker" => marker}}
-      end
-    end
-
-    test "registered MFA scrubber wins over the default" do
+    test "registered :body_scrubber wins over the default" do
       conn = %Plug.Conn{params: %{"password" => "hunter2"}}
 
-      :ok = Scrubber.put_conn_scrubber({MarkerScrubber, :stamp, ["registered"]})
+      :ok = Scrubber.put_conn_scrubber(body_scrubber: fn _ -> %{"marker" => "registered"} end)
 
       scrubbed = Scrubber.scrub_conn(conn)
       assert scrubbed.params == %{"marker" => "registered"}
+    end
+
+    test "registered {module, function} tuple is invoked with the conn" do
+      defmodule TupleScrubber do
+        def stamp(_conn), do: %{"marker" => "from-mf"}
+      end
+
+      conn = %Plug.Conn{params: %{"password" => "hunter2"}}
+      :ok = Scrubber.put_conn_scrubber(body_scrubber: {TupleScrubber, :stamp})
+
+      assert Scrubber.scrub_conn(conn).params == %{"marker" => "from-mf"}
+    end
+
+    test "a nil scrubber for a field clears that field to %{}" do
+      conn = %Plug.Conn{
+        cookies: %{"session" => "secret"},
+        req_headers: [{"authorization", "Bearer x"}],
+        params: %{"password" => "hunter2"}
+      }
+
+      :ok = Scrubber.put_conn_scrubber(body_scrubber: nil, cookie_scrubber: nil)
+
+      scrubbed = Scrubber.scrub_conn(conn)
+      assert scrubbed.params == %{}
+      assert scrubbed.cookies == %{}
+    end
+
+    test "missing keys fall back to Sentry.PlugContext defaults" do
+      conn = %Plug.Conn{
+        cookies: %{"session" => "secret"},
+        req_headers: [{"authorization", "Bearer x"}, {"x-keep", "yes"}],
+        params: %{"password" => "hunter2", "name" => "Alice"}
+      }
+
+      :ok = Scrubber.put_conn_scrubber([])
+
+      scrubbed = Scrubber.scrub_conn(conn)
+      assert scrubbed.cookies == %{}
+      assert scrubbed.params == %{"password" => "*********", "name" => "Alice"}
+      # default_header_scrubber returns a map; headers_to_list preserves the conn shape
+      assert is_list(scrubbed.req_headers)
+      assert {"x-keep", "yes"} in scrubbed.req_headers
+      refute Enum.any?(scrubbed.req_headers, fn {k, _v} -> k == "authorization" end)
     end
 
     test "registration is process-local" do
@@ -136,32 +173,19 @@ defmodule Sentry.ScrubberTest do
 
       task =
         Task.async(fn ->
-          :ok = Scrubber.put_conn_scrubber({MarkerScrubber, :stamp, ["task-only"]})
+          :ok = Scrubber.put_conn_scrubber(body_scrubber: fn _ -> %{"marker" => "task-only"} end)
           Scrubber.scrub_conn(conn)
         end)
 
       task_result = Task.await(task)
       assert task_result.params == %{"marker" => "task-only"}
 
-      # The current process never registered a scrubber, so it falls back to the default.
+      # The current process never registered a scrubber, so it falls back to default_conn_scrubber.
       scrubbed = Scrubber.scrub_conn(conn)
       assert scrubbed.params == %{"password" => "*********"}
     end
 
-    test "raises when the registered scrubber returns a non-Plug.Conn" do
-      defmodule BrokenScrubber do
-        def scrub(_conn), do: :not_a_conn
-      end
-
-      conn = %Plug.Conn{}
-      :ok = Scrubber.put_conn_scrubber({BrokenScrubber, :scrub, []})
-
-      assert_raise RuntimeError, ~r/expected.*to return a Plug.Conn/, fn ->
-        Scrubber.scrub_conn(conn)
-      end
-    end
-
-    test "validates the MFA shape on put" do
+    test "validates the opts shape on put" do
       assert_raise FunctionClauseError, fn ->
         Scrubber.put_conn_scrubber({"not", "an", "mfa"})
       end

--- a/test/sentry/scrubber_test.exs
+++ b/test/sentry/scrubber_test.exs
@@ -242,4 +242,50 @@ defmodule Sentry.ScrubberTest do
       end
     end
   end
+
+  describe "scrub/1 dispatch" do
+    test "delegates Plug.Conn input to the conn scrubbers" do
+      conn = %Plug.Conn{
+        cookies: %{"session" => "secret"},
+        req_headers: [{"authorization", "Bearer x"}, {"x-keep", "yes"}],
+        params: %{"password" => "hunter2"}
+      }
+
+      scrubbed = Scrubber.scrub(conn)
+
+      assert is_struct(scrubbed, Plug.Conn)
+      assert scrubbed.cookies == %{}
+      assert scrubbed.req_headers == [{"x-keep", "yes"}]
+      assert scrubbed.params == %{"password" => "*********"}
+    end
+
+    test "honors a registered conn scrubber for the Plug.Conn dispatch path" do
+      defmodule ScrubValueMarkerScrubber do
+        def stamp(_conn), do: %{"marker" => "from-registered"}
+      end
+
+      :ok = Scrubber.put_conn_scrubber(body_scrubber: {ScrubValueMarkerScrubber, :stamp})
+
+      scrubbed = Scrubber.scrub(%Plug.Conn{params: %{"password" => "hunter2"}})
+
+      assert scrubbed.params == %{"marker" => "from-registered"}
+    end
+
+    test "scrubs a plain map with default sensitive keys" do
+      assert Scrubber.scrub(%{"password" => "x", "ok" => 1}) ==
+               %{"password" => "*********", "ok" => 1}
+    end
+
+    test "returns integers, atoms, binaries, and lists unchanged" do
+      assert Scrubber.scrub(42) == 42
+      assert Scrubber.scrub(:foo) == :foo
+      assert Scrubber.scrub("hello") == "hello"
+      assert Scrubber.scrub([1, 2, 3]) == [1, 2, 3]
+    end
+
+    test "returns unrelated structs unchanged" do
+      uri = URI.parse("http://example.com")
+      assert Scrubber.scrub(uri) == uri
+    end
+  end
 end

--- a/test/sentry/scrubber_test.exs
+++ b/test/sentry/scrubber_test.exs
@@ -1,7 +1,13 @@
+defmodule Sentry.ScrubberTest.LeakyStruct do
+  @moduledoc false
+  defstruct [:card_number, :name]
+end
+
 defmodule Sentry.ScrubberTest do
   use ExUnit.Case, async: true
 
   alias Sentry.Scrubber
+  alias Sentry.ScrubberTest.LeakyStruct
 
   describe "new/1" do
     test "new/0 builds an all-defaults scrubber" do
@@ -391,9 +397,25 @@ defmodule Sentry.ScrubberTest do
       assert Scrubber.scrub([1, 2, 3]) == [1, 2, 3]
     end
 
-    test "returns unrelated structs unchanged" do
-      uri = URI.parse("http://example.com")
-      assert Scrubber.scrub(uri) == uri
+    test "scrubs non-Plug.Conn structs by converting them to a map" do
+      uri = URI.parse("http://example.com/path")
+
+      scrubbed = Scrubber.scrub(uri)
+
+      # The struct is converted to a plain map and scrubbed, never returned as-is.
+      refute is_struct(scrubbed)
+      assert is_map(scrubbed)
+      assert scrubbed.host == "example.com"
+    end
+
+    test "redacts value-detectable secrets in a non-Plug.Conn struct" do
+      scrubbed = Scrubber.scrub(%LeakyStruct{card_number: "4242424242424242", name: "Alice"})
+
+      refute is_struct(scrubbed)
+      # Once the struct is a map, value-based heuristics reach its fields: the
+      # credit-card-shaped value is redacted, non-sensitive data is preserved.
+      assert scrubbed.card_number == "*********"
+      assert scrubbed.name == "Alice"
     end
   end
 end

--- a/test/sentry/scrubber_test.exs
+++ b/test/sentry/scrubber_test.exs
@@ -125,6 +125,19 @@ defmodule Sentry.ScrubberTest do
       assert scrubbed.params == %{"marker" => "registered"}
     end
 
+    test "a map-returning :header_scrubber still yields list-shaped req_headers" do
+      conn = %Plug.Conn{req_headers: [{"authorization", "Bearer x"}, {"x-keep", "yes"}]}
+
+      :ok =
+        Scrubber.put_conn_scrubber(
+          header_scrubber: fn conn -> conn.req_headers |> Map.new() |> Map.take(["x-keep"]) end
+        )
+
+      scrubbed = Scrubber.scrub(conn)
+      assert is_list(scrubbed.req_headers)
+      assert scrubbed.req_headers == [{"x-keep", "yes"}]
+    end
+
     test "registered {module, function} tuple is invoked with the conn" do
       defmodule TupleScrubber do
         def stamp(_conn), do: %{"marker" => "from-mf"}

--- a/test/sentry/scrubber_test.exs
+++ b/test/sentry/scrubber_test.exs
@@ -3,6 +3,33 @@ defmodule Sentry.ScrubberTest do
 
   alias Sentry.Scrubber
 
+  describe "new/1" do
+    test "new/0 builds an all-defaults scrubber" do
+      scrubber = Scrubber.new()
+
+      assert %Scrubber{} = scrubber
+
+      for field <- Scrubber.scrubber_names() do
+        assert is_function(Map.fetch!(scrubber, field), 1)
+      end
+    end
+
+    test "uses the given per-field scrubber and defaults the rest" do
+      marker = fn _conn -> %{"marker" => "custom"} end
+      scrubber = Scrubber.new(body_scrubber: marker)
+
+      assert scrubber.body_scrubber == marker
+      assert is_function(scrubber.header_scrubber, 1)
+    end
+
+    test "does not register the scrubber for the process" do
+      _ = Scrubber.new(body_scrubber: fn _conn -> %{"marker" => "unregistered"} end)
+
+      conn = %Plug.Conn{params: %{"password" => "hunter2"}}
+      assert Scrubber.scrub(conn).params == %{"password" => "*********"}
+    end
+  end
+
   describe "scrub/2" do
     test "redacts sensitive top-level keys" do
       assert Scrubber.scrub(%{"password" => "x", "ok" => 1}) ==

--- a/test/sentry/scrubber_test.exs
+++ b/test/sentry/scrubber_test.exs
@@ -80,4 +80,91 @@ defmodule Sentry.ScrubberTest do
       assert scrubbed =~ "visible=ok"
     end
   end
+
+  describe "scrub_conn/1 with no registered scrubber" do
+    setup do
+      conn = %Plug.Conn{
+        cookies: %{"session" => "secret-session"},
+        req_headers: [
+          {"Authorization", "Bearer secret-token"},
+          {"cookie", "session=secret-session"},
+          {"x-request-id", "abc-123"}
+        ],
+        params: %{"password" => "hunter2", "name" => "Alice"}
+      }
+
+      %{conn: conn, scrubbed: Scrubber.scrub_conn(conn)}
+    end
+
+    test "clears cookies", %{scrubbed: scrubbed} do
+      assert scrubbed.cookies == %{}
+    end
+
+    test "drops sensitive req_headers case-insensitively and keeps list shape",
+         %{scrubbed: scrubbed} do
+      assert scrubbed.req_headers == [{"x-request-id", "abc-123"}]
+      assert is_list(scrubbed.req_headers)
+    end
+
+    test "scrubs params", %{scrubbed: scrubbed} do
+      assert scrubbed.params == %{"password" => "*********", "name" => "Alice"}
+    end
+
+    test "returns a %Plug.Conn{} struct", %{scrubbed: scrubbed} do
+      assert is_struct(scrubbed, Plug.Conn)
+    end
+  end
+
+  describe "put_conn_scrubber/1 + scrub_conn/1" do
+    defmodule MarkerScrubber do
+      def stamp(conn, marker) do
+        %{conn | params: %{"marker" => marker}}
+      end
+    end
+
+    test "registered MFA scrubber wins over the default" do
+      conn = %Plug.Conn{params: %{"password" => "hunter2"}}
+
+      :ok = Scrubber.put_conn_scrubber({MarkerScrubber, :stamp, ["registered"]})
+
+      scrubbed = Scrubber.scrub_conn(conn)
+      assert scrubbed.params == %{"marker" => "registered"}
+    end
+
+    test "registration is process-local" do
+      conn = %Plug.Conn{params: %{"password" => "hunter2"}}
+
+      task =
+        Task.async(fn ->
+          :ok = Scrubber.put_conn_scrubber({MarkerScrubber, :stamp, ["task-only"]})
+          Scrubber.scrub_conn(conn)
+        end)
+
+      task_result = Task.await(task)
+      assert task_result.params == %{"marker" => "task-only"}
+
+      # The current process never registered a scrubber, so it falls back to the default.
+      scrubbed = Scrubber.scrub_conn(conn)
+      assert scrubbed.params == %{"password" => "*********"}
+    end
+
+    test "raises when the registered scrubber returns a non-Plug.Conn" do
+      defmodule BrokenScrubber do
+        def scrub(_conn), do: :not_a_conn
+      end
+
+      conn = %Plug.Conn{}
+      :ok = Scrubber.put_conn_scrubber({BrokenScrubber, :scrub, []})
+
+      assert_raise RuntimeError, ~r/expected.*to return a Plug.Conn/, fn ->
+        Scrubber.scrub_conn(conn)
+      end
+    end
+
+    test "validates the MFA shape on put" do
+      assert_raise FunctionClauseError, fn ->
+        Scrubber.put_conn_scrubber({"not", "an", "mfa"})
+      end
+    end
+  end
 end

--- a/test/sentry/scrubber_test.exs
+++ b/test/sentry/scrubber_test.exs
@@ -81,7 +81,7 @@ defmodule Sentry.ScrubberTest do
     end
   end
 
-  describe "scrub_conn/1 with no registered scrubber" do
+  describe "scrub/1 with no registered scrubber" do
     setup do
       conn = %Plug.Conn{
         cookies: %{"session" => "secret-session"},
@@ -93,7 +93,7 @@ defmodule Sentry.ScrubberTest do
         params: %{"password" => "hunter2", "name" => "Alice"}
       }
 
-      %{conn: conn, scrubbed: Scrubber.scrub_conn(conn)}
+      %{conn: conn, scrubbed: Scrubber.scrub(conn)}
     end
 
     test "clears cookies", %{scrubbed: scrubbed} do
@@ -115,13 +115,13 @@ defmodule Sentry.ScrubberTest do
     end
   end
 
-  describe "put_conn_scrubber/1 + scrub_conn/1" do
+  describe "put_conn_scrubber/1 + scrub/1" do
     test "registered :body_scrubber wins over the default" do
       conn = %Plug.Conn{params: %{"password" => "hunter2"}}
 
       :ok = Scrubber.put_conn_scrubber(body_scrubber: fn _ -> %{"marker" => "registered"} end)
 
-      scrubbed = Scrubber.scrub_conn(conn)
+      scrubbed = Scrubber.scrub(conn)
       assert scrubbed.params == %{"marker" => "registered"}
     end
 
@@ -133,7 +133,7 @@ defmodule Sentry.ScrubberTest do
       conn = %Plug.Conn{params: %{"password" => "hunter2"}}
       :ok = Scrubber.put_conn_scrubber(body_scrubber: {TupleScrubber, :stamp})
 
-      assert Scrubber.scrub_conn(conn).params == %{"marker" => "from-mf"}
+      assert Scrubber.scrub(conn).params == %{"marker" => "from-mf"}
     end
 
     test "a nil scrubber for a field clears that field to %{}" do
@@ -145,7 +145,7 @@ defmodule Sentry.ScrubberTest do
 
       :ok = Scrubber.put_conn_scrubber(body_scrubber: nil, cookie_scrubber: nil)
 
-      scrubbed = Scrubber.scrub_conn(conn)
+      scrubbed = Scrubber.scrub(conn)
       assert scrubbed.params == %{}
       assert scrubbed.cookies == %{}
     end
@@ -159,10 +159,9 @@ defmodule Sentry.ScrubberTest do
 
       :ok = Scrubber.put_conn_scrubber([])
 
-      scrubbed = Scrubber.scrub_conn(conn)
+      scrubbed = Scrubber.scrub(conn)
       assert scrubbed.cookies == %{}
       assert scrubbed.params == %{"password" => "*********", "name" => "Alice"}
-      # default_header_scrubber returns a map; headers_to_list preserves the conn shape
       assert is_list(scrubbed.req_headers)
       assert {"x-keep", "yes"} in scrubbed.req_headers
       refute Enum.any?(scrubbed.req_headers, fn {k, _v} -> k == "authorization" end)
@@ -174,14 +173,15 @@ defmodule Sentry.ScrubberTest do
       task =
         Task.async(fn ->
           :ok = Scrubber.put_conn_scrubber(body_scrubber: fn _ -> %{"marker" => "task-only"} end)
-          Scrubber.scrub_conn(conn)
+          Scrubber.scrub(conn)
         end)
 
       task_result = Task.await(task)
       assert task_result.params == %{"marker" => "task-only"}
 
-      # The current process never registered a scrubber, so it falls back to default_conn_scrubber.
-      scrubbed = Scrubber.scrub_conn(conn)
+      # The current process never registered a scrubber, so scrub/1 lazily
+      # initializes defaults instead of inheriting the task's marker scrubber.
+      scrubbed = Scrubber.scrub(conn)
       assert scrubbed.params == %{"password" => "*********"}
     end
 


### PR DESCRIPTION
This encapsulates scrub-related logic fully in the `Sentry.Scrubber` and expands its interface to make it easily usable standalone and introduces a "current scrubber" concept, so that customized scrubbers *are actually respected and used* across processes.

This will also make it simpler to implement the new spec that replaces "default PII" concept later this year.

The public API remains the same, which means that plug options accept the same keys which result in the same behavior and the original default scrubbing functions are still there (`PlugContext.default_*_scrubber` ones). To be honest, I'd deprecate them and shift entire scrubbing stuff to the `Scrubber` eventually. Something to consider.

These improvements make fixes here #1068 and here #1070 trivial, which is the actual biggest reason why I've done this.

### Basic examples

```elixir
Sentry.Scrubber.scrub(%{password: "super-secret", custom_secret: "HIDE PLZZZ"}, keys: [:password, :custom_secret])
#=> %{password: "*********", custom_secret: "*********"}

# Falls back to the default keys (["password", "passwd", "secret"]) when none given
Sentry.Scrubber.scrub(%{"password" => "hunter2", "name" => "Jane"})
#=> %{"password" => "*********", "name" => "Jane"}

# Recurses into nested maps/lists; credit-card-shaped values are caught too
Sentry.Scrubber.scrub(%{user: %{name: "Jane", password: "hunter2"}, tokens: ["4111 1111 1111 1111"]}, keys: [:password])
#=> %{user: %{name: "Jane", password: "*********"}, tokens: ["*********"]}
```

### Web-related scrubbing helpers

```elixir
Sentry.Scrubber.scrub_query_string("user=jane&password=hunter2")
#=> "user=jane&password=%2A%2A%2A%2A%2A%2A%2A%2A%2A"

Sentry.Scrubber.scrub_url("https://example.com/login?token=abc&secret=xyz", keys: ["secret"])
#=> "https://example.com/login?token=abc&secret=%2A%2A%2A%2A%2A%2A%2A%2A%2A"

Sentry.Scrubber.drop_keys(%{"authorization" => "Bearer x", "accept" => "json"})
#=> %{"accept" => "json"}
```

### Stored scrubber instance

This stuff is used internally by the `PlugContext`:

```elixir
# Register per-field scrubbers for the request
Sentry.Scrubber.put_conn_scrubber(
  body_scrubber: &MyScrubber.scrub_params/1,
  header_scrubber: {MyScrubber, :scrub_headers},
  cookie_scrubber: nil
)
#=> :ok

# Scrub a conn's params, headers, and cookies using the registered scrubbers
Sentry.Scrubber.scrub(conn)
#=> %Plug.Conn{params: %{"password" => "*********", ...}, ...}

# The URL is not a conn field — fetch its scrubber and apply it separately
Sentry.Scrubber.get(:url_scrubber).(conn)
#=> "https://example.com/login?secret=*********"
```