### PR TITLE
fix(plug): broader scrubbing

### DIFF
--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -514,6 +514,37 @@ defmodule Sentry.Config do
       `{Sentry.Test.Config, :namespace}` as the resolver to enable per-test
       configuration isolation via `Sentry.Test.Config.put/1`.
       """
+    ],
+    scrubber: [
+      type: :keyword_list,
+      default: [],
+      type_doc: "`t:keyword/0`",
+      doc: """
+      Configuration for how the SDK scrubs sensitive data out of captured events.
+
+      *Available since v13.1.1*.
+      """,
+      keys: [
+        conn_private_allow_list: [
+          type: {:list, :atom},
+          default: Sentry.Scrubber.default_private_allow_list(),
+          type_doc: "list of `t:atom/0`",
+          doc: """
+          A list of keys that are retained in a `%Plug.Conn{}`'s `:private` map when
+          a captured error embeds a connection (for example a `Phoenix.ActionClauseError`
+          reported via `Sentry.PlugCapture`). All other `:private` keys are dropped.
+
+          The `:private` map can hold framework internals and sensitive data (such as
+          the decoded session under `:plug_session`), so it is not safe to report
+          wholesale. By default the SDK keeps only Phoenix's routing and render
+          metadata — see `Sentry.Scrubber.default_private_allow_list/0` — which is
+          high-signal for triaging which controller/action failed. Set this option to
+          extend or replace that list.
+
+          *Available since v13.1.1*.
+          """
+        ]
+      ]
     ]
   ]
 
@@ -913,6 +944,9 @@ defmodule Sentry.Config do
 
   @spec in_app_module_allow_list() :: [atom()]
   def in_app_module_allow_list, do: fetch!(:in_app_module_allow_list)
+
+  @spec scrubber() :: keyword()
+  def scrubber, do: fetch!(:scrubber)
 
   @spec send_result() :: :none | :sync
   def send_result, do: fetch!(:send_result)

--- a/lib/sentry/plug_capture.ex
+++ b/lib/sentry/plug_capture.ex
@@ -82,8 +82,10 @@ defmodule Sentry.PlugCapture do
 
       * scrubs *all* cookies (`cookies` and `req_cookies`)
       * drops sensitive request headers (`authorization`, `authentication`, `cookie`)
-      * scrubs sensitive params (`password`, `passwd`, `secret`) in `params`,
-        `body_params`, and `query_params`
+      * scrubs `params` and `body_params` through the configured `body_scrubber`
+        (defaulting to the sensitive params `password`, `passwd`, `secret`; a
+        `nil` `body_scrubber` empties both), and scrubs the same sensitive params
+        in `query_params`
       * clears `assigns` (where auth libraries store user structs and tokens)
       * reduces `private` to an allow-list of framework metadata, dropping
         everything else (notably the decoded session under `:plug_session`);

--- a/lib/sentry/plug_capture.ex
+++ b/lib/sentry/plug_capture.ex
@@ -80,9 +80,14 @@ defmodule Sentry.PlugCapture do
       request. When no `Sentry.PlugContext` has run, falls back to the
       defaults defined by `Sentry.Scrubber.scrub/2`:
 
-      * scrubs *all* cookies
+      * scrubs *all* cookies (`cookies` and `req_cookies`)
       * drops sensitive request headers (`authorization`, `authentication`, `cookie`)
-      * scrubs sensitive body params (`password`, `passwd`, `secret`)
+      * scrubs sensitive params (`password`, `passwd`, `secret`) in `params`,
+        `body_params`, and `query_params`
+      * clears `assigns` (where auth libraries store user structs and tokens)
+      * reduces `private` to an allow-list of framework metadata, dropping
+        everything else (notably the decoded session under `:plug_session`);
+        configurable via the `scrubber: [conn_private_allow_list: ...]` option
 
   """
   defmacro __using__(opts) do

--- a/lib/sentry/plug_context.ex
+++ b/lib/sentry/plug_context.ex
@@ -155,6 +155,7 @@ defmodule Sentry.PlugContext do
         # when no :url_scrubber is configured, fall back to the no-op
         # default_url_scrubber/1 rather than Sentry.Scrubber's scrubbing default.
         |> Keyword.put_new(:url_scrubber, {__MODULE__, :default_url_scrubber, []})
+        |> Keyword.put(:private_allow_list, Sentry.Config.scrubber()[:conn_private_allow_list])
 
       Sentry.Scrubber.put_conn_scrubber(conn_scrubber_opts)
 

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -49,8 +49,20 @@ defmodule Sentry.Scrubber do
       (typically from `Sentry.PlugContext.call/2`), falling back to the SDK
       default `scrub(conn, field)` clause when none is registered, or
     * a fixed tag — `:clear` replaces the field with `%{}`, `:params` scrubs the
-      field as a params-shaped map, and `:query_string` redacts sensitive params
-      from a raw query string.
+      field as a params-shaped map, `:query_string` redacts sensitive params from
+      a raw query string, and `:private_allow_list` keeps only the registered
+      allow-listed keys of the field (see `default_private_allow_list/0` and the
+      `:private_allow_list` option of `put_conn_scrubber/1`), dropping everything
+      else.
+
+  By default `scrub/1` redacts `cookies`, `req_headers`, and `params` (the
+  configurable fields), clears `req_cookies` and `assigns` to `%{}`, scrubs
+  `body_params` and `query_params` as params-shaped maps, and reduces `private`
+  to its allow-listed keys (`default_private_allow_list/0`). `assigns` is cleared
+  wholesale because auth libraries (Guardian, Pow, Coherence) routinely store
+  decoded tokens, full user structs, and session data there, where no key-based
+  heuristic redacts safely. `private` keeps only the allow-listed framework
+  metadata and drops everything else (notably `:plug_session`).
 
   The defaults can be overridden per call with `scrub(conn, overrides)`, where
   `overrides` is a `field: strategy` keyword list merged over the attribute —
@@ -67,35 +79,70 @@ defmodule Sentry.Scrubber do
   @scrubber_pdict_key {__MODULE__, :scrubber}
   @scrubber_names [:body_scrubber, :header_scrubber, :cookie_scrubber, :url_scrubber]
 
+  # Keys retained when a `%Plug.Conn{}`'s `:private` map is scrubbed with the
+  # `:private_allow_list` strategy. These are Phoenix's routing/render metadata
+  # — safe, high-signal breadcrumbs for triaging which controller/action failed.
+  # Anything not listed (e.g. `:plug_session`, which holds decoded session data)
+  # is dropped. This is the SDK default; the `scrubber: [conn_private_allow_list: ...]`
+  # config option exposes it as a user-configurable option.
+  @default_private_allow_list [
+    :phoenix_controller,
+    :phoenix_action,
+    :phoenix_endpoint,
+    :phoenix_router,
+    :phoenix_view,
+    :phoenix_layout,
+    :phoenix_format,
+    :phoenix_template,
+    :phoenix_router_url,
+    :phoenix_static_url
+  ]
+
   # Default `field -> strategy` mapping applied by `scrub/1` (overridable per
   # call via `scrub(conn, overrides)`). A strategy is either a configurable
   # scrubber struct-key (resolved per process via `get/1`) or a fixed tag:
   # `:clear` -> `%{}`, `:params` -> params-shaped scrub (Unfetched-safe),
-  # `:query_string` -> redact sensitive params from the raw query string.
+  # `:query_string` -> redact sensitive params from the raw query string,
+  # `:private_allow_list` -> keep only the registered allow-listed keys.
   # Add an entry to make a new conn field scrubbed by default.
+  #
+  # `assigns` is cleared wholesale because auth libraries (Guardian, Pow,
+  # Coherence) routinely store decoded tokens, full user structs, and session
+  # data there — there is no reliable key-based heuristic to redact it safely.
+  # `private` mixes sensitive data (e.g. `:plug_session`) with high-signal
+  # framework metadata (Phoenix routing), so it uses an allow-list instead of
+  # clearing wholesale — see `@default_private_allow_list`.
   @scrubbable_conn_fields [
     cookies: :cookie_scrubber,
+    req_cookies: :clear,
     req_headers: :header_scrubber,
     params: :body_scrubber,
-    query_string: :query_string
+    body_params: :params,
+    query_params: :params,
+    query_string: :query_string,
+    assigns: :clear,
+    private: :private_allow_list
   ]
 
   @typedoc """
   A resolved set of per-field scrubbers for a `%Plug.Conn{}`.
 
   Each scrubber field holds a 1-arity function that takes the conn and returns
-  the scrubbed value for the corresponding field. Built by `put_conn_scrubber/1`
-  from `t:conn_scrubber_opts/0` and stored in the process dictionary.
+  the scrubbed value for the corresponding field. `private_allow_list` holds the
+  keys retained by the `:private_allow_list` strategy. Built by
+  `put_conn_scrubber/1` from `t:conn_scrubber_opts/0` and stored in the process
+  dictionary.
   """
   @type t :: %__MODULE__{
           body_scrubber: (Plug.Conn.t() -> term()),
           header_scrubber: (Plug.Conn.t() -> term()),
           cookie_scrubber: (Plug.Conn.t() -> term()),
-          url_scrubber: (Plug.Conn.t() -> String.t())
+          url_scrubber: (Plug.Conn.t() -> String.t()),
+          private_allow_list: [atom()]
         }
 
   @enforce_keys @scrubber_names
-  defstruct @scrubber_names
+  defstruct @scrubber_names ++ [private_allow_list: @default_private_allow_list]
 
   @doc false
   @spec scrubber_names() :: [atom()]
@@ -123,12 +170,14 @@ defmodule Sentry.Scrubber do
 
   Each `*_scrubber` key, when omitted, falls back to the field's default
   scrubber — the matching `scrub(conn, field)` clause of `scrub/2`.
+  `:private_allow_list` defaults to `default_private_allow_list/0`.
   """
   @type conn_scrubber_opts :: [
           body_scrubber: field_scrubber(),
           header_scrubber: field_scrubber(),
           cookie_scrubber: field_scrubber(),
-          url_scrubber: field_scrubber()
+          url_scrubber: field_scrubber(),
+          private_allow_list: [atom()]
         ]
 
   @doc """
@@ -151,6 +200,18 @@ defmodule Sentry.Scrubber do
   @doc since: "13.1.0"
   @spec default_header_keys() :: [String.t()]
   def default_header_keys, do: @default_scrubbed_header_keys
+
+  @doc """
+  Returns the default list of `%Plug.Conn{}` `:private` keys retained by the
+  `:private_allow_list` scrubbing strategy.
+
+  These are Phoenix's routing/render metadata keys, kept because they are
+  high-signal, non-sensitive breadcrumbs for triaging errors. This is the
+  default for the `scrubber: [conn_private_allow_list: ...]` configuration option.
+  """
+  @doc since: "13.1.1"
+  @spec default_private_allow_list() :: [atom()]
+  def default_private_allow_list, do: @default_private_allow_list
 
   @doc """
   Drops sensitive keys from a flat map.
@@ -261,7 +322,8 @@ defmodule Sentry.Scrubber do
       body_scrubber: resolve_scrubber(opts, :body_scrubber, :body),
       header_scrubber: resolve_scrubber(opts, :header_scrubber, :headers),
       cookie_scrubber: resolve_scrubber(opts, :cookie_scrubber, :cookies),
-      url_scrubber: resolve_scrubber(opts, :url_scrubber, :url)
+      url_scrubber: resolve_scrubber(opts, :url_scrubber, :url),
+      private_allow_list: Keyword.get(opts, :private_allow_list, @default_private_allow_list)
     }
   end
 
@@ -468,6 +530,8 @@ defmodule Sentry.Scrubber do
   #     params-shaped map, leaving `%Plug.Conn.Unfetched{}` untouched
   #   * `:query_string` — redacts sensitive params from THIS field (a raw query
   #     string) via `scrub_query_string/1`
+  #   * `:private_allow_list` — keeps only the registered allow-listed keys of
+  #     THIS field (a map), dropping everything else
   defp scrub_conn_field(conn, _field, scrubber_key) when scrubber_key in @scrubber_names,
     do: get(scrubber_key).(conn)
 
@@ -478,6 +542,9 @@ defmodule Sentry.Scrubber do
 
   defp scrub_conn_field(conn, field, :query_string),
     do: scrub_query_string(Map.fetch!(conn, field))
+
+  defp scrub_conn_field(conn, field, :private_allow_list),
+    do: Map.take(Map.fetch!(conn, field), scrubber().private_allow_list)
 
   # Scrubs a params-shaped value with the default sensitive keys, leaving
   # `%Plug.Conn.Unfetched{}` (and any non-plain-map) untouched. Shared by the

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -55,9 +55,11 @@ defmodule Sentry.Scrubber do
       `:private_allow_list` option of `put_conn_scrubber/1`), dropping everything
       else.
 
-  By default `scrub/1` redacts `cookies`, `req_headers`, and `params` (the
-  configurable fields), clears `req_cookies` and `assigns` to `%{}`, scrubs
-  `body_params` and `query_params` as params-shaped maps, and reduces `private`
+  By default `scrub/1` redacts `cookies`, `req_headers`, `params`, and
+  `body_params` (the configurable fields — `body_params` shares the
+  `:body_scrubber` with `params`, so it honors the same registered scrubber and
+  is emptied when `body_scrubber` is `nil`), clears `req_cookies` and `assigns`
+  to `%{}`, scrubs `query_params` as a params-shaped map, and reduces `private`
   to its allow-listed keys (`default_private_allow_list/0`). `assigns` is cleared
   wholesale because auth libraries (Guardian, Pow, Coherence) routinely store
   decoded tokens, full user structs, and session data there, where no key-based
@@ -117,7 +119,7 @@ defmodule Sentry.Scrubber do
     req_cookies: :clear,
     req_headers: :header_scrubber,
     params: :body_scrubber,
-    body_params: :params,
+    body_params: :body_scrubber,
     query_params: :params,
     query_string: :query_string,
     assigns: :clear,

--- a/test/plug_capture_test.exs
+++ b/test/plug_capture_test.exs
@@ -213,6 +213,37 @@ defmodule Sentry.PlugCaptureTest do
       refute arg2 =~ "secret", "non-conn params arg leaked into exception value: #{arg2}"
     end
 
+    test "retains allow-listed conn.private metadata when scrubbing ActionClauseError" do
+      # The embedded conn's :private map is reduced to the allow-list: Phoenix
+      # routing metadata is high-signal for triage and must survive, while
+      # non-allow-listed entries (e.g. the per-router pipeline key) are dropped.
+      assert_raise Phoenix.ActionClauseError, fn ->
+        conn(:get, "/action_clause_error?password=secret")
+        |> call_phoenix_endpoint()
+      end
+
+      event =
+        assert_sentry_report(:event,
+          culprit: "Sentry.PlugCaptureTest.PhoenixController.action_clause_error/2"
+        )
+
+      assert [exception] = event.exception
+
+      # Sensitive data is still scrubbed (proves the scrubber ran)...
+      assert exception.value =~ ~s(params: %{"password" => "*********"})
+
+      # ...routing metadata in the allow-list survives...
+      assert exception.value =~ "phoenix_controller"
+      assert exception.value =~ "Sentry.PlugCaptureTest.PhoenixController"
+      assert exception.value =~ "phoenix_action"
+      assert exception.value =~ ":action_clause_error"
+
+      # ...but non-allow-listed private entries are dropped. Phoenix stores a
+      # per-router pipeline list under the router module key; it is not in the
+      # allow-list, so it must not appear in the reported conn.
+      refute exception.value =~ "Sentry.PlugCaptureTest.PhoenixRouter => []"
+    end
+
     test "scrubs Phoenix.ActionClauseError using PlugContext-configured body_scrubber" do
       Application.put_env(:sentry, PhoenixEndpointWithCustomPlugContext,
         render_errors: [view: Sentry.ErrorView, accepts: ~w(html)]

--- a/test/sentry/config_test.exs
+++ b/test/sentry/config_test.exs
@@ -122,6 +122,20 @@ defmodule Sentry.ConfigTest do
       end
     end
 
+    test ":scrubber :conn_private_allow_list" do
+      assert Config.validate!([])[:scrubber][:conn_private_allow_list] ==
+               Sentry.Scrubber.default_private_allow_list()
+
+      config = [scrubber: [conn_private_allow_list: [:phoenix_action, :my_custom_key]]]
+
+      assert Config.validate!(config)[:scrubber][:conn_private_allow_list] ==
+               [:phoenix_action, :my_custom_key]
+
+      assert_raise ArgumentError, ~r/invalid list in :conn_private_allow_list/, fn ->
+        Config.validate!(scrubber: [conn_private_allow_list: ["not_an_atom"]])
+      end
+    end
+
     # TODO: remove me on v11.0.0. :included_environments has been deprecated in v10.0.0.
     test ":included_environments" do
       output =

--- a/test/sentry/plug_context_test.exs
+++ b/test/sentry/plug_context_test.exs
@@ -225,6 +225,24 @@ defmodule Sentry.PlugContextTest do
 
       assert scrubbed.params == %{"foo" => "kept"}
     end
+
+    test "registers the configured scrubber :conn_private_allow_list", %{conn: conn} do
+      Sentry.Test.Config.put(scrubber: [conn_private_allow_list: [:phoenix_action]])
+
+      call(conn, [])
+
+      # call/2 read the config value and registered it, so the :private_allow_list
+      # strategy now retains only the configured key.
+      scrubbed =
+        Sentry.Scrubber.scrub(
+          %Plug.Conn{
+            private: %{phoenix_action: :show, phoenix_controller: SomeApp.PageController}
+          },
+          private: :private_allow_list
+        )
+
+      assert scrubbed.private == %{phoenix_action: :show}
+    end
   end
 
   defp call(conn, opts) do

--- a/test/sentry/scrubber_test.exs
+++ b/test/sentry/scrubber_test.exs
@@ -228,10 +228,11 @@ defmodule Sentry.ScrubberTest do
              }
     end
 
-    test "scrubs body_params with default sensitive keys", %{scrubbed: scrubbed} do
-      assert scrubbed.body_params == %{
-               "user" => %{"email" => "alice@example.com", "password" => "*********"}
-             }
+    test "mirrors the scrubbed params onto body_params (shares :body_scrubber)",
+         %{scrubbed: scrubbed} do
+      # body_params is wired to the same configurable :body_scrubber as params,
+      # so it reflects the body scrubber's output rather than its own raw value.
+      assert scrubbed.body_params == scrubbed.params
     end
 
     test "scrubs query_params with default sensitive keys", %{scrubbed: scrubbed} do
@@ -269,15 +270,20 @@ defmodule Sentry.ScrubberTest do
       assert is_struct(scrubbed, Plug.Conn)
     end
 
-    test "leaves %Plug.Conn.Unfetched{} body_params/query_params alone" do
+    test "passes %Plug.Conn.Unfetched{} through (body_params mirrors params, query_params untouched)" do
       conn = %Plug.Conn{
+        params: %Plug.Conn.Unfetched{aspect: :params},
         body_params: %Plug.Conn.Unfetched{aspect: :body_params},
         query_params: %Plug.Conn.Unfetched{aspect: :query_params}
       }
 
       scrubbed = Scrubber.scrub(conn)
 
-      assert scrubbed.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
+      # params/body_params share the Unfetched-safe :body_scrubber default, so
+      # body_params reflects the (unfetched) params rather than its own value.
+      assert scrubbed.params == %Plug.Conn.Unfetched{aspect: :params}
+      assert scrubbed.body_params == %Plug.Conn.Unfetched{aspect: :params}
+      # query_params keeps the fixed :params strategy, which leaves Unfetched alone.
       assert scrubbed.query_params == %Plug.Conn.Unfetched{aspect: :query_params}
     end
 
@@ -450,7 +456,8 @@ defmodule Sentry.ScrubberTest do
       conn = %Plug.Conn{
         cookies: %{"session" => "secret"},
         req_headers: [{"authorization", "Bearer x"}],
-        params: %{"password" => "hunter2"}
+        params: %{"password" => "hunter2"},
+        body_params: %{"ssn" => "123-45-6789"}
       }
 
       :ok = Scrubber.put_conn_scrubber(body_scrubber: nil, cookie_scrubber: nil)
@@ -458,6 +465,28 @@ defmodule Sentry.ScrubberTest do
       scrubbed = Scrubber.scrub(conn)
       assert scrubbed.params == %{}
       assert scrubbed.cookies == %{}
+      # body_params shares :body_scrubber, so a nil body_scrubber empties it too —
+      # the non-default "ssn" key no longer rides along in embedded conns.
+      assert scrubbed.body_params == %{}
+    end
+
+    test "a custom body_scrubber governs body_params too" do
+      conn = %Plug.Conn{
+        params: %{"my_secret" => "leak", "name" => "Alice"},
+        body_params: %{"my_secret" => "leak", "name" => "Alice"}
+      }
+
+      :ok =
+        Scrubber.put_conn_scrubber(
+          body_scrubber: fn conn -> Map.drop(conn.params, ["my_secret"]) end
+        )
+
+      scrubbed = Scrubber.scrub(conn)
+
+      # The custom scrubber drops the non-default "my_secret"; body_params honors
+      # it instead of falling back to a fixed default-key scrub that would leak it.
+      assert scrubbed.body_params == %{"name" => "Alice"}
+      assert scrubbed.body_params == scrubbed.params
     end
 
     test "missing keys fall back to Sentry.PlugContext defaults" do

--- a/test/sentry/scrubber_test.exs
+++ b/test/sentry/scrubber_test.exs
@@ -157,45 +157,128 @@ defmodule Sentry.ScrubberTest do
   describe "scrub/1 with no registered scrubber" do
     setup do
       conn = %Plug.Conn{
-        cookies: %{"session" => "secret-session"},
+        # `Plug.Conn.fetch_cookies/2` parses incoming Cookie headers into both
+        # `cookies` and `req_cookies`. Apps using Plug.Session also see the
+        # encoded session cookie here.
+        cookies: %{
+          "_my_app_session" => "SFMyNTY.g3QAAAACbQAAAAtfY3Nyb..."
+        },
+        req_cookies: %{
+          "_my_app_session" => "SFMyNTY.g3QAAAACbQAAAAtfY3Nyb...",
+          "user_remember_me" => "abc123-remember-token"
+        },
         req_headers: [
-          {"Authorization", "Bearer secret-token"},
-          {"cookie", "session=secret-session"},
-          {"x-request-id", "abc-123"}
+          {"authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.signature"},
+          {"cookie", "_my_app_session=...; user_remember_me=abc123"},
+          {"x-request-id", "req-abc-123"}
         ],
-        params: %{"password" => "hunter2", "name" => "Alice"}
+        params: %{
+          "user" => %{"email" => "alice@example.com", "password" => "hunter2"},
+          "_csrf_token" => "csrf-leaky-token"
+        },
+        body_params: %{
+          "user" => %{"email" => "alice@example.com", "password" => "hunter2"}
+        },
+        query_params: %{
+          "redirect_to" => "/dashboard",
+          "secret" => "password-reset-token-xyz"
+        },
+        # Guardian.Plug.LoadResource and custom auth plugs put the loaded user
+        # struct here. Pow uses conn.assigns[:current_user] by default.
+        assigns: %{
+          current_user: %{
+            id: 1,
+            email: "alice@example.com",
+            password_hash: "$2b$12$leaky.bcrypt.hash.value.here"
+          },
+          jwt_claims: %{"sub" => "1", "exp" => 1_700_000_000, "secret" => "claim-secret"}
+        },
+        # Guardian stores the raw JWT and decoded claims here. Plug.Session
+        # puts the session data here. Phoenix populates its own routing /
+        # dispatch metadata here.
+        private: %{
+          guardian_default_token: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.signature",
+          guardian_default_claims: %{"sub" => "1", "exp" => 1_700_000_000},
+          plug_session: %{"user_id" => 1, "_csrf_token" => "csrf-token-xyz"},
+          phoenix_endpoint: SomeApp.Endpoint,
+          phoenix_controller: SomeApp.PageController
+        },
+        request_path: "/users",
+        method: "POST"
       }
 
       %{conn: conn, scrubbed: Scrubber.scrub(conn)}
     end
 
-    test "clears cookies", %{scrubbed: scrubbed} do
+    test "clears cookies and req_cookies", %{scrubbed: scrubbed} do
       assert scrubbed.cookies == %{}
+      assert scrubbed.req_cookies == %{}
     end
 
     test "drops sensitive req_headers case-insensitively and keeps list shape",
          %{scrubbed: scrubbed} do
-      assert scrubbed.req_headers == [{"x-request-id", "abc-123"}]
+      assert scrubbed.req_headers == [{"x-request-id", "req-abc-123"}]
       assert is_list(scrubbed.req_headers)
     end
 
-    test "scrubs params", %{scrubbed: scrubbed} do
-      assert scrubbed.params == %{"password" => "*********", "name" => "Alice"}
+    test "scrubs params with default sensitive keys", %{scrubbed: scrubbed} do
+      assert scrubbed.params == %{
+               "user" => %{"email" => "alice@example.com", "password" => "*********"},
+               "_csrf_token" => "csrf-leaky-token"
+             }
+    end
+
+    test "scrubs body_params with default sensitive keys", %{scrubbed: scrubbed} do
+      assert scrubbed.body_params == %{
+               "user" => %{"email" => "alice@example.com", "password" => "*********"}
+             }
+    end
+
+    test "scrubs query_params with default sensitive keys", %{scrubbed: scrubbed} do
+      assert scrubbed.query_params == %{
+               "redirect_to" => "/dashboard",
+               "secret" => "*********"
+             }
+    end
+
+    test "clears assigns wholesale", %{scrubbed: scrubbed} do
+      # Auth libraries put current_user + password_hash + JWT claims here.
+      # No reliable key-based heuristic — clear the whole map.
+      assert scrubbed.assigns == %{}
+    end
+
+    test "reduces private to the allow-listed framework metadata", %{scrubbed: scrubbed} do
+      # Phoenix routing metadata is retained (high-signal for triage); Guardian
+      # tokens and the decoded Plug.Session payload are dropped.
+      assert scrubbed.private == %{
+               phoenix_endpoint: SomeApp.Endpoint,
+               phoenix_controller: SomeApp.PageController
+             }
+
+      refute Map.has_key?(scrubbed.private, :plug_session)
+      refute Map.has_key?(scrubbed.private, :guardian_default_token)
+      refute Map.has_key?(scrubbed.private, :guardian_default_claims)
+    end
+
+    test "preserves non-sensitive fields", %{scrubbed: scrubbed} do
+      assert scrubbed.request_path == "/users"
+      assert scrubbed.method == "POST"
     end
 
     test "returns a %Plug.Conn{} struct", %{scrubbed: scrubbed} do
       assert is_struct(scrubbed, Plug.Conn)
     end
 
-    test "rewrites only cookies, req_headers, and params", %{conn: conn, scrubbed: scrubbed} do
-      changed =
-        conn
-        |> Map.from_struct()
-        |> Enum.filter(fn {key, value} -> Map.fetch!(scrubbed, key) != value end)
-        |> Enum.map(fn {key, _value} -> key end)
-        |> Enum.sort()
+    test "leaves %Plug.Conn.Unfetched{} body_params/query_params alone" do
+      conn = %Plug.Conn{
+        body_params: %Plug.Conn.Unfetched{aspect: :body_params},
+        query_params: %Plug.Conn.Unfetched{aspect: :query_params}
+      }
 
-      assert changed == [:cookies, :params, :req_headers]
+      scrubbed = Scrubber.scrub(conn)
+
+      assert scrubbed.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
+      assert scrubbed.query_params == %Plug.Conn.Unfetched{aspect: :query_params}
     end
 
     test "scrubs sensitive params from query_string" do
@@ -269,6 +352,63 @@ defmodule Sentry.ScrubberTest do
       }
 
       assert Scrubber.scrub(conn, []) == Scrubber.scrub(conn)
+    end
+  end
+
+  describe ":private_allow_list strategy" do
+    setup do
+      conn = %Plug.Conn{
+        private: %{
+          phoenix_controller: SomeApp.PageController,
+          phoenix_action: :show,
+          phoenix_endpoint: SomeApp.Endpoint,
+          phoenix_router: SomeApp.Router,
+          plug_session: %{"user_id" => 1, "token" => "secret"},
+          guardian_default_token: "eyJhbG.signature"
+        }
+      }
+
+      %{conn: conn}
+    end
+
+    test "keeps default-allow-listed routing keys and drops everything else", %{conn: conn} do
+      scrubbed = Scrubber.scrub(conn, private: :private_allow_list)
+
+      assert scrubbed.private == %{
+               phoenix_controller: SomeApp.PageController,
+               phoenix_action: :show,
+               phoenix_endpoint: SomeApp.Endpoint,
+               phoenix_router: SomeApp.Router
+             }
+
+      refute Map.has_key?(scrubbed.private, :plug_session)
+      refute Map.has_key?(scrubbed.private, :guardian_default_token)
+    end
+
+    test "honors a custom private_allow_list registered via put_conn_scrubber/1", %{conn: conn} do
+      :ok = Scrubber.put_conn_scrubber(private_allow_list: [:phoenix_action])
+
+      scrubbed = Scrubber.scrub(conn, private: :private_allow_list)
+
+      assert scrubbed.private == %{phoenix_action: :show}
+    end
+
+    test "an empty allow_list drops all private keys", %{conn: conn} do
+      :ok = Scrubber.put_conn_scrubber(private_allow_list: [])
+
+      scrubbed = Scrubber.scrub(conn, private: :private_allow_list)
+
+      assert scrubbed.private == %{}
+    end
+  end
+
+  describe "default_private_allow_list/0" do
+    test "returns Phoenix routing/render metadata keys" do
+      allow_list = Scrubber.default_private_allow_list()
+
+      assert :phoenix_controller in allow_list
+      assert :phoenix_action in allow_list
+      refute :plug_session in allow_list
     end
   end
 

--- a/test_integrations/phoenix_app/lib/phoenix_app_web/controllers/page_controller.ex
+++ b/test_integrations/phoenix_app/lib/phoenix_app_web/controllers/page_controller.ex
@@ -9,6 +9,14 @@ defmodule PhoenixAppWeb.PageController do
   plug Sentry.PlugContext,
        [body_scrubber: {__MODULE__, :marker_body_scrubber}] when action == :function_clause_error
 
+  plug Sentry.PlugContext, [] when action == :function_clause_error_default
+
+  plug Sentry.PlugContext, [] when action == :function_clause_error_private
+  plug :put_sensitive_private when action == :function_clause_error_private
+
+  plug Sentry.PlugContext, [] when action == :function_clause_error_cleared
+  plug :put_sensitive_assigns_and_cookies when action == :function_clause_error_cleared
+
   plug Sentry.PlugContext, [] when action == :generic_clause_error
 
   plug Sentry.PlugContext, [] when action == :checkout
@@ -22,6 +30,18 @@ defmodule PhoenixAppWeb.PageController do
   end
 
   def function_clause_error(_conn, %{"required" => _value}) do
+    :ok
+  end
+
+  def function_clause_error_default(_conn, %{"required" => _value}) do
+    :ok
+  end
+
+  def function_clause_error_private(_conn, %{"required" => _value}) do
+    :ok
+  end
+
+  def function_clause_error_cleared(_conn, %{"required" => _value}) do
     :ok
   end
 
@@ -55,6 +75,24 @@ defmodule PhoenixAppWeb.PageController do
 
   @doc false
   def marker_body_scrubber(_conn), do: %{"marker" => "custom-scrub-applied"}
+
+  # Injects a non-allow-listed key into conn.private so the captured
+  # Phoenix.ActionClauseError exercises the :private allow-list scrubbing: the
+  # injected key must be dropped, while Phoenix's routing metadata is retained.
+  defp put_sensitive_private(conn, _opts) do
+    Plug.Conn.put_private(conn, :plug_session, %{
+      "user_id" => 1,
+      "csrf_token" => "secret-csrf-value"
+    })
+  end
+
+  # Injects sensitive data into conn.assigns and req_cookies so the captured
+  # Phoenix.ActionClauseError exercises the :clear strategy: both fields must be
+  # cleared to %{} so none of this data reaches Sentry.
+  defp put_sensitive_assigns_and_cookies(conn, _opts) do
+    conn = Plug.Conn.assign(conn, :current_user, %{id: 1, password_hash: "secret-assigns-hash"})
+    %{conn | req_cookies: %{"sid" => "secret-cookie-session"}}
+  end
 
   def transaction(conn, _params) do
     Tracer.with_span "test_span" do

--- a/test_integrations/phoenix_app/lib/phoenix_app_web/router.ex
+++ b/test_integrations/phoenix_app/lib/phoenix_app_web/router.ex
@@ -55,6 +55,9 @@ defmodule PhoenixAppWeb.Router do
     get "/error", PageController, :api_error
     get "/health", PageController, :health
     post "/function-clause-error", PageController, :function_clause_error
+    post "/function-clause-error-default", PageController, :function_clause_error_default
+    post "/function-clause-error-private", PageController, :function_clause_error_private
+    post "/function-clause-error-cleared", PageController, :function_clause_error_cleared
     post "/generic-clause-error", PageController, :generic_clause_error
     post "/checkout", PageController, :checkout
     get "/api/data", PageController, :api_data

--- a/test_integrations/phoenix_app/test/phoenix_app_web/controllers/stacktrace_vars_scrubbing_test.exs
+++ b/test_integrations/phoenix_app/test/phoenix_app_web/controllers/stacktrace_vars_scrubbing_test.exs
@@ -44,6 +44,80 @@ defmodule Sentry.Integrations.Phoenix.StacktraceVarsScrubbingTest do
            "user-provided body_scrubber marker missing from frame vars: #{frame_vars}"
   end
 
+  test "default scrubbing redacts sensitive params when no custom body_scrubber is configured",
+       %{conn: conn, ref: ref} do
+    conn =
+      conn
+      |> put_req_header("authorization", @auth_token)
+      |> put_req_header("cookie", "session=#{@cookie_value}")
+
+    assert_raise Phoenix.ActionClauseError, fn ->
+      post(
+        conn,
+        "/function-clause-error-default?password=qs-secret&keep_me=visible",
+        %{"password" => "body-secret", "username" => "alice"}
+      )
+    end
+
+    [[{%{"type" => "event"}, event_payload}]] = collect_envelopes(ref, 1, timeout: 2000)
+
+    value = exception_value(event_payload)
+
+    # Default key-based scrubbing redacts sensitive values wherever they appear:
+    # body params, query params, query string, the auth header, and cookies.
+    refute value =~ "body-secret", "body password leaked into exception value: #{value}"
+    refute value =~ "qs-secret", "query password leaked into exception value: #{value}"
+    refute value =~ @auth_token, "auth token leaked into exception value: #{value}"
+    refute value =~ @cookie_value, "session cookie leaked into exception value: #{value}"
+
+    # Non-sensitive data is preserved.
+    assert value =~ "alice"
+    assert value =~ "keep_me=visible"
+
+    # The user-provided marker is NOT applied on this endpoint (default path).
+    refute value =~ "custom-scrub-applied"
+  end
+
+  test "reduces conn.private to the allow-list (drops session data, keeps routing metadata)",
+       %{conn: conn, ref: ref} do
+    assert_raise Phoenix.ActionClauseError, fn ->
+      post(conn, ~p"/function-clause-error-private", %{})
+    end
+
+    [[{%{"type" => "event"}, event_payload}]] = collect_envelopes(ref, 1, timeout: 2000)
+
+    value = exception_value(event_payload)
+
+    # The non-allow-listed :private key injected on the conn (and its session data)
+    # is dropped from the captured exception.
+    refute value =~ "plug_session", "non-allow-listed :private key leaked: #{value}"
+    refute value =~ "secret-csrf-value", "session data leaked from conn.private: #{value}"
+
+    # High-signal Phoenix routing metadata is retained.
+    assert value =~ "phoenix_action", "expected routing metadata to be kept: #{value}"
+    assert value =~ "phoenix_controller", "expected routing metadata to be kept: #{value}"
+  end
+
+  test "clears conn.assigns and req_cookies wholesale",
+       %{conn: conn, ref: ref} do
+    assert_raise Phoenix.ActionClauseError, fn ->
+      post(conn, ~p"/function-clause-error-cleared", %{})
+    end
+
+    [[{%{"type" => "event"}, event_payload}]] = collect_envelopes(ref, 1, timeout: 2000)
+
+    value = exception_value(event_payload)
+
+    # assigns and req_cookies are cleared wholesale, so neither the injected
+    # assign data nor the cookie value reaches Sentry.
+    assert value =~ "assigns: %{}", "expected assigns to be cleared: #{value}"
+    assert value =~ "req_cookies: %{}", "expected req_cookies to be cleared: #{value}"
+
+    refute value =~ "secret-assigns-hash", "assigns data leaked: #{value}"
+    refute value =~ "current_user", "assigns key leaked: #{value}"
+    refute value =~ "secret-cookie-session", "req_cookies data leaked: #{value}"
+  end
+
   test "scrubs args of a generic FunctionClauseError raised inside an action",
        %{conn: conn, ref: ref} do
     # This is a plain Elixir FunctionClauseError (not a Phoenix.ActionClauseError),
@@ -102,5 +176,12 @@ defmodule Sentry.Integrations.Phoenix.StacktraceVarsScrubbingTest do
     |> get_in(["stacktrace", "frames"])
     |> Enum.flat_map(fn frame -> Map.values(frame["vars"] || %{}) end)
     |> Enum.join("\n")
+  end
+
+  defp exception_value(event_payload) do
+    event_payload
+    |> Map.fetch!("exception")
+    |> hd()
+    |> Map.fetch!("value")
   end
 end

--- a/test_integrations/phoenix_app/test/phoenix_app_web/controllers/stacktrace_vars_scrubbing_test.exs
+++ b/test_integrations/phoenix_app/test/phoenix_app_web/controllers/stacktrace_vars_scrubbing_test.exs
@@ -28,6 +28,9 @@ defmodule Sentry.Integrations.Phoenix.StacktraceVarsScrubbingTest do
 
     refute frame_vars =~ @auth_token,
            "auth token leaked into stacktrace frame vars: #{frame_vars}"
+
+    refute frame_vars =~ @cookie_value,
+           "session cookie leaked into stacktrace frame vars: #{frame_vars}"
   end
 
   test "user-provided body_scrubber on PlugContext is applied to conn in stacktrace args",


### PR DESCRIPTION
Broadens the default `%Plug.Conn{}` scrubbing and adds a `:scrubber` config
option to control which `:private` keys survive. *Since v13.1.1.*

- `scrub/1` on a conn now also: clears `req_cookies` and `assigns`, scrubs `body_params`/`query_params`, and reduces `private` to an allow-list (drops everything else, notably `:plug_session`).
- New `:private_allow_list` strategy + `default_private_allow_list/0` (Phoenix routing/render metadata).
- New `:scrubber` config option; `PlugContext` wires it into the per-request scrubber.

## New `scrubber` config

This is a top-level key with nested settings because we will need more features eventually once updated "PII handling" spec settles.

```elixir
config :sentry,
  scrubber: [
    # Defaults to Sentry.Scrubber.default_private_allow_list()
    conn_private_allow_list: [:phoenix_controller, :phoenix_action, :my_custom_key]
  ]
```
