### PR TITLE
fix(oban): handle non-list stacktraces in Oban error reporter

### DIFF
--- a/lib/sentry/integrations/oban/error_reporter.ex
+++ b/lib/sentry/integrations/oban/error_reporter.ex
@@ -78,6 +78,13 @@ defmodule Sentry.Integrations.Oban.ErrorReporter do
   end
 
   defp report(job, kind, reason, stacktrace, config) do
+    # Oban can hand us a non-list "stacktrace" when a job dies from a gen-call
+    # exit (such as a GenServer.call or NimblePool checkout timeout): the value
+    # is the `{module, function, args}` from the exit reason rather than a
+    # stacktrace. Sentry's :stacktrace option only accepts a list, so anything
+    # else would crash this handler (and get it detached). Coerce it away.
+    stacktrace = if is_list(stacktrace), do: stacktrace, else: []
+
     stacktrace =
       case {apply(Oban.Worker, :from_string, [job.worker]), stacktrace} do
         {{:ok, atom_worker}, []} -> [{atom_worker, :process, 1, []}]

--- a/test/sentry/integrations/oban/error_reporter_test.exs
+++ b/test/sentry/integrations/oban/error_reporter_test.exs
@@ -116,6 +116,34 @@ defmodule Sentry.Integrations.Oban.ErrorReporterTest do
       )
     end
 
+    test "reports exits with a non-list stacktrace without crashing" do
+      # When a job dies from a gen-call exit (e.g. a GenServer.call or a
+      # NimblePool/Finch checkout timeout), Oban surfaces the {module, function,
+      # args} from the exit reason in the :stacktrace metadata, which is not a
+      # list. The reporter must not pass that straight to Sentry's :stacktrace
+      # option, since it would crash and get the telemetry handler detached.
+      emit_telemetry_for_failed_job(
+        :exit,
+        {:shutdown, :idle_timeout},
+        {NimblePool, :checkout, [self()]}
+      )
+
+      assert_sentry_report(:event,
+        message: %{
+          message: "Oban job #{@worker_as_string} exited: %s",
+          params: ["{:shutdown, :idle_timeout}"],
+          formatted: "Oban job #{@worker_as_string} exited: {:shutdown, :idle_timeout}"
+        },
+        exception: [],
+        tags: %{
+          "oban_queue" => "default",
+          "oban_state" => "available",
+          "oban_worker" => @worker_as_string
+        },
+        fingerprint: [@worker_as_string, "{{ default }}"]
+      )
+    end
+
     test "reports throws to Sentry" do
       emit_telemetry_for_failed_job(:throw, :this_was_not_caught, [])
 


### PR DESCRIPTION
### Problem

When an Oban job dies from a **gen-call exit**, Oban surfaces the `{module, function, args}` from the exit reason in the `:stacktrace` field of the `[:oban, :job, :exception]` telemetry metadata, and **not** a stacktrace list.

`Sentry.Integrations.Oban.ErrorReporter.report/5` passes that value straight into Sentry's `:stacktrace` option, which is typed as a list. This results in an error (that we saw in production):

```
** (NimbleOptions.ValidationError) invalid value for :stacktrace option: expected list, got: {NimblePool, :checkout, [#PID<0.493.0>]}
    (sentry) lib/sentry/event.ex:186: Sentry.Event.create_event/1
    (sentry) lib/sentry.ex: Sentry.capture_message/2
    (sentry) lib/sentry/integrations/oban/error_reporter.ex:114: Sentry.Integrations.Oban.ErrorReporter.report/5
```

The handler raises, and `:telemetry` then **permanently detaches it**. The affected node stops reporting *all* Oban job errors to Sentry until it restarts, so the first such exit silently creates an observability blind spot.

The existing normalization at the top of `report/5` only handled the empty-list (`[]`) case; any other non-list value fell straight through.