### PR TITLE
Exclude :bandit domain by default

### DIFF
--- a/lib/sentry/logger_handler.ex
+++ b/lib/sentry/logger_handler.ex
@@ -26,7 +26,7 @@ defmodule Sentry.LoggerHandler do
     ],
     excluded_domains: [
       type: {:list, :atom},
-      default: [:cowboy],
+      default: [:cowboy, :bandit],
       type_doc: "list of `t:atom/0`",
       doc: """
       Any messages with a domain in the configured list will not be sent. The default is so as


### PR DESCRIPTION
### Description

Like for `:cowboy`, we want to exclude the `:bandit` domain to avoid duplicate errors.

bandit is a drop-in replacement for cowboy and has been the default web server for new phoenix apps for a while now:
https://github.com/mtrudel/bandit