### PR TITLE
Bump inspect limit for stacktrace args

### DIFF
--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -324,6 +324,16 @@ defmodule Sentry.Config do
       The maximum number of breadcrumbs to keep. See `Sentry.Context.add_breadcrumb/1`.
       """
     ],
+    max_stacktrace_arg_length: [
+      type: :non_neg_integer,
+      default: 10_000,
+      doc: """
+      The maximum length (in Unicode graphemes) of each inspected function argument reported in
+      the `vars` of a stacktrace frame. Arguments are inspected and then truncated to this
+      length. This guards against very large terms (such as big structs) blowing up the
+      size of an event. *Available since v13.2.0*.
+      """
+    ],
     report_deps: [
       type: :boolean,
       default: true,
@@ -949,6 +959,9 @@ defmodule Sentry.Config do
 
   @spec max_breadcrumbs() :: non_neg_integer()
   def max_breadcrumbs, do: fetch!(:max_breadcrumbs)
+
+  @spec max_stacktrace_arg_length() :: non_neg_integer()
+  def max_stacktrace_arg_length, do: fetch!(:max_stacktrace_arg_length)
 
   @spec dedup_events?() :: boolean()
   def dedup_events?, do: fetch!(:dedup_events)

--- a/lib/sentry/event.ex
+++ b/lib/sentry/event.ex
@@ -461,8 +461,15 @@ defmodule Sentry.Event do
   defp args_from_stacktrace([_other | _rest]), do: %{}
 
   defp stacktrace_args_to_vars(args) do
+    max_length = Config.max_stacktrace_arg_length()
+
+    # An inspected element costs at least ~3 chars (with comma and spaces), so capping the
+    # collection limit at max_length/3 never truncates earlier than the final
+    # String.slice/3 would, while keeping inspect from materializing huge terms.
+    inspect_opts = [printable_limit: max_length, limit: max(div(max_length, 3), 1)]
+
     for {arg, index} <- Enum.with_index(args), into: %{} do
-      {"arg#{index}", String.slice(inspect(arg), 0, 513)}
+      {"arg#{index}", String.slice(inspect(arg, inspect_opts), 0, max_length)}
     end
   end
 

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -6,6 +6,10 @@ defmodule Sentry.EventTest do
   alias Sentry.Event
   alias Sentry.Interfaces
 
+  defmodule SampleStruct do
+    defstruct [:name, :payload]
+  end
+
   doctest Event, import: true
 
   def event_generated_by_exception(extra \\ %{}) do
@@ -14,6 +18,22 @@ defmodule Sentry.EventTest do
     rescue
       e -> Event.transform_exception(e, stacktrace: __STACKTRACE__, extra: extra)
     end
+  end
+
+  defp event_with_stacktrace_args(args) do
+    try do
+      apply(Event, :not_a_function, args)
+    rescue
+      e -> Event.transform_exception(e, stacktrace: __STACKTRACE__)
+    end
+  end
+
+  defp vars_for_failing_frame(event) do
+    Enum.find_value(event.exception, fn %Interfaces.Exception{} = exception ->
+      Enum.find_value(exception.stacktrace.frames, fn frame ->
+        if frame.function == "Sentry.Event.not_a_function/1", do: frame.vars
+      end)
+    end)
   end
 
   test "parses error exception" do
@@ -69,6 +89,38 @@ defmodule Sentry.EventTest do
     assert is_binary(event.contexts.os.version)
     assert is_binary(event.contexts.runtime.name)
     assert is_binary(event.contexts.runtime.version)
+  end
+
+  describe "stacktrace args (vars)" do
+    test "truncates each inspected arg to :max_stacktrace_arg_length characters" do
+      put_test_config(enable_source_code_context: false, max_stacktrace_arg_length: 20)
+
+      long_string = String.duplicate("a", 1_000)
+      event = event_with_stacktrace_args([long_string])
+
+      assert %{"arg0" => arg0} = vars_for_failing_frame(event)
+      assert String.length(arg0) == 20
+    end
+
+    test "renders structs with their type rather than garbling them when truncated" do
+      put_test_config(enable_source_code_context: false, max_stacktrace_arg_length: 5_000)
+
+      struct = %SampleStruct{name: "test", payload: String.duplicate("x", 100)}
+      event = event_with_stacktrace_args([struct])
+
+      assert %{"arg0" => arg0} = vars_for_failing_frame(event)
+      assert String.starts_with?(arg0, "%Sentry.EventTest.SampleStruct{")
+    end
+
+    test "respects a higher :max_stacktrace_arg_length than the old 513 default" do
+      put_test_config(enable_source_code_context: false, max_stacktrace_arg_length: 5_000)
+
+      long_string = String.duplicate("a", 1_000)
+      event = event_with_stacktrace_args([long_string])
+
+      assert %{"arg0" => arg0} = vars_for_failing_frame(event)
+      assert String.length(arg0) > 513
+    end
   end
 
   test "respects extra information passed in" do


### PR DESCRIPTION
### Description

Closes #913.

Also makes the limit configurable.