### PR TITLE
ci(deps): pinning hardening

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Elixir and Erlang
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
@@ -24,12 +24,12 @@ jobs:
           otp-version: "27.2"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
 
       - name: Cache Elixir dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             deps
@@ -41,7 +41,7 @@ jobs:
             ${{ runner.os }}-elixir-1.18-otp-27.2-mix-
 
       - name: Cache Node.js dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             test_integrations/tracing/node_modules
@@ -111,7 +111,7 @@ jobs:
         run: npx playwright test --reporter=list
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: playwright-report
@@ -119,7 +119,7 @@ jobs:
           retention-days: 7
 
       - name: Upload test screenshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: test-screenshots

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
     - name: Check out this repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
     - name: Setup Elixir and Erlang
       uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
@@ -67,7 +67,7 @@ jobs:
         otp-version: ${{ matrix.otp }}
 
     - name: Cache downloaded dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       id: mix-downloaded-deps-cache
       with:
         path: |
@@ -100,7 +100,7 @@ jobs:
     # We need to manually restore and then save, so that we can save the "_build" directory
     # *without* the Elixir compiled code in it.
     - name: Cache compiled Elixir code
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       id: mix-cache
       with:
         path: |
@@ -137,7 +137,7 @@ jobs:
         MIX_ENV=prod mix release
 
     - name: Cache Dialyzer PLT
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       if: matrix.dialyzer
       id: plt-cache
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,12 @@ jobs:
         with:
           app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           token: ${{ steps.token.outputs.token }}
           fetch-depth: 0
       - name: Prepare release
-        uses: getsentry/action-prepare-release@v1
+        uses: getsentry/action-prepare-release@c8e1c2009ab08259029170132c384f03c1064c0e # v1
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         with:

--- a/mix.exs
+++ b/mix.exs
@@ -211,7 +211,12 @@ defmodule Sentry.Mixfile do
   end
 
   defp setup_integration(integration, opts) do
-    run_in_integration(integration, ["deps.get"], opts)
+    deps_get_args =
+      if Version.match?(System.version(), ">= 1.14.0"),
+        do: ["deps.get", "--check-locked"],
+        else: ["deps.get"]
+
+    run_in_integration(integration, deps_get_args, opts)
   end
 
   defp run_in_integration(integration, args, opts) do


### PR DESCRIPTION
1. Pins github action shas
2. Adds `--check-locked` for deps in the integration test suites

---

This is part of the #1072 effort.