### PR TITLE
chore(ci): ensure mix.lock was not changed under 1.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,6 +130,10 @@ jobs:
         SKIP_TRACING_E2E: "true"
       run: mix test.integrations
 
+    - name: Ensure lockfiles are unchanged
+      if: matrix.elixir == '1.13'
+      run: git diff --exit-code -- mix.lock 'test_integrations/*/mix.lock'
+
     - name: Check `mix release` with phoenix_app and sentry configured
       if: matrix.release_test
       run: |


### PR DESCRIPTION
We gotta special case older Elixir due to the lack of `--check-locked` flag.

---

Related to #1072