### PR TITLE
fix: improve Ranch errors in Sentry.LoggerHandler

### DIFF
--- a/lib/sentry/logger_handler/error_backend.ex
+++ b/lib/sentry/logger_handler/error_backend.ex
@@ -322,24 +322,70 @@ defmodule Sentry.LoggerHandler.ErrorBackend do
 
   # This is only causing issues on OTP 25 apparently.
   # TODO: remove special-cased Ranch handling when we depend on OTP 26+.
-  defp capture_from_ranch_error(
-         _args = [
-           _listener,
-           _connection_process,
-           _stream,
-           _request_process,
-           _reason = {{exception, stacktrace}, _}
-         ],
-         sentry_opts,
-         config
-       )
-       when is_exception(exception) do
-    sentry_opts = Keyword.merge(sentry_opts, stacktrace: stacktrace, handled: false)
-    capture(:exception, exception, sentry_opts, config)
+  #
+  # The reason is always the *last* element of the Ranch args list, but the list's
+  # arity varies across ranch/cowboy versions (4-element for :cowboy_clear crashes,
+  # 5-element for others), so we pull it positionally rather than matching a fixed
+  # arity. The reason itself shows up in a few shapes, and we want to preserve the
+  # stacktrace whenever one is present:
+  #
+  #   * {{exception, stacktrace}, _} or {exception, stacktrace} -> structured exception.
+  #   * {reason, stacktrace} where reason is not an exception (like {:badmatch, _},
+  #     {:case_clause, _}, atoms) -> message event that still carries the stacktrace,
+  #     reusing the same path as log_from_crash_reason/4.
+  #   * anything else -> plain message with inspect(args).
+  defp capture_from_ranch_error(args, sentry_opts, config) when is_list(args) do
+    case normalize_ranch_reason(List.last(args)) do
+      {:exception, exception, stacktrace, extra} ->
+        sentry_opts = Keyword.merge(sentry_opts, stacktrace: stacktrace, handled: false)
+
+        sentry_opts =
+          if extra do
+            add_extra_to_sentry_opts(sentry_opts, %{
+              ranch_extra: inspect(extra, printable_limit: 4096, limit: 100)
+            })
+          else
+            sentry_opts
+          end
+
+        capture(:exception, exception, sentry_opts, config)
+
+      {:reason, reason, stacktrace} ->
+        message = "Ranch listener error: #{inspect(args)}"
+        log_from_crash_reason({reason, stacktrace}, message, sentry_opts, config)
+
+      :error ->
+        capture(:message, "Ranch listener error: #{inspect(args)}", sentry_opts, config)
+    end
   end
 
   defp capture_from_ranch_error(args, sentry_opts, config) do
     capture(:message, "Ranch listener error: #{inspect(args)}", sentry_opts, config)
+  end
+
+  # Doubly-nested {{exception, stacktrace}, extra} (the original matched shape). The
+  # trailing "extra" is Cowboy's context about what it was doing (often an MFA or
+  # partial request/stream state), so we preserve it under the event's extra metadata.
+  defp normalize_ranch_reason({{exception, stacktrace}, extra})
+       when is_exception(exception) and is_list(stacktrace) do
+    {:exception, exception, stacktrace, extra}
+  end
+
+  # Bare {exception, stacktrace}, with no trailing Cowboy context.
+  defp normalize_ranch_reason({exception, stacktrace})
+       when is_exception(exception) and is_list(stacktrace) do
+    {:exception, exception, stacktrace, _extra = nil}
+  end
+
+  # Non-exception reason (throw/badmatch/exit term) that still carries a stacktrace.
+  # The whole reason (including any trailing term) is captured as extra by
+  # log_from_crash_reason/4, so there's nothing extra to thread through here.
+  defp normalize_ranch_reason({reason, stacktrace}) when is_list(stacktrace) do
+    {:reason, reason, stacktrace}
+  end
+
+  defp normalize_ranch_reason(_other) do
+    :error
   end
 
   defp add_extra_to_sentry_opts(sentry_opts, new_extra) do

--- a/test/sentry/logger_handler_test.exs
+++ b/test/sentry/logger_handler_test.exs
@@ -527,6 +527,97 @@ defmodule Sentry.LoggerHandlerTest do
     end
   end
 
+  describe "with a Ranch listener error" do
+    # The stacktrace mimics a Phoenix socket serializer raising while decoding a
+    # malformed WebSocket frame, which is the real-world shape this handling targets.
+    @ranch_stacktrace [
+      {Phoenix.Socket.V2.JSONSerializer, :decode_text, 1,
+       [file: ~c"lib/phoenix/socket/serializers/v2_json_serializer.ex", line: 113]},
+      {Phoenix.Socket, :__in__, 2, [file: ~c"lib/phoenix/socket.ex", line: 521]},
+      {:cowboy_websocket, :handler_call, 6, [file: ~c"src/cowboy_websocket.erl", line: 0]},
+      {:proc_lib, :wake_up, 3, [file: ~c"proc_lib.erl", line: 0]}
+    ]
+
+    test "with a 4-element args list reports a structured exception (arity robustness)",
+         %{sender_ref: ref} do
+      # Only 4 elements (e.g. a :cowboy_clear crash), so the old fixed 5-arity clause
+      # would have missed this and produced a plain message event.
+      log_ranch_error([
+        MyApp.Endpoint.HTTP,
+        :cowboy_clear,
+        self(),
+        {{%RuntimeError{message: "malformed frame"}, @ranch_stacktrace},
+         {:cowboy_handler, :execute, 2}}
+      ])
+
+      assert_receive {^ref, event}
+      assert [exception] = event.exception
+      assert exception.type == "RuntimeError"
+      assert exception.value == "malformed frame"
+
+      assert Enum.find(
+               exception.stacktrace.frames,
+               &(&1.function == "Phoenix.Socket.V2.JSONSerializer.decode_text/1")
+             )
+
+      # The trailing Cowboy context is preserved as extra metadata.
+      assert event.extra.ranch_extra == inspect({:cowboy_handler, :execute, 2})
+    end
+
+    test "with a bare {exception, stacktrace} reason reports a structured exception",
+         %{sender_ref: ref} do
+      log_ranch_error([
+        MyApp.Endpoint.HTTP,
+        :cowboy_clear,
+        self(),
+        :some_stream,
+        {%RuntimeError{message: "malformed frame"}, @ranch_stacktrace}
+      ])
+
+      assert_receive {^ref, event}
+      assert [exception] = event.exception
+      assert exception.type == "RuntimeError"
+      assert exception.value == "malformed frame"
+
+      assert Enum.find(
+               exception.stacktrace.frames,
+               &(&1.function == "Phoenix.Socket.V2.JSONSerializer.decode_text/1")
+             )
+
+      # No trailing Cowboy context in this shape, so no ranch_extra is added.
+      refute Map.has_key?(event.extra, :ranch_extra)
+    end
+
+    test "with a non-exception {{:badmatch, term}, stacktrace} reason reports a message " <>
+           "event that still carries the stacktrace",
+         %{sender_ref: ref} do
+      reason =
+        {{:badmatch, %{"text" => "irrelevant", "type" => "contextual_update"}}, @ranch_stacktrace}
+
+      log_ranch_error([MyApp.Endpoint.HTTP, :cowboy_clear, self(), reason])
+
+      assert_receive {^ref, event}
+
+      assert event.exception == []
+      assert event.message.formatted =~ "Ranch listener error:"
+
+      assert [%{stacktrace: stacktrace}] = event.threads
+
+      assert Enum.find(
+               stacktrace.frames,
+               &(&1.function == "Phoenix.Socket.V2.JSONSerializer.decode_text/1")
+             )
+    end
+
+    defp log_ranch_error(args) do
+      :logger.error(%{
+        format:
+          ~c"Ranch listener ~p had connection process started with ~p:~p/4 exit with reason: ~p",
+        args: args
+      })
+    end
+  end
+
   describe "rate limiting" do
     @tag handler_config: %{
            rate_limiting: [max_events: 2, interval: 150],


### PR DESCRIPTION
### Description

These changes mean that we get much better errors when the range is stack trace and reason include an exception for example. We've actually seen this happen in production quite a bit, and it's a pretty annoying error to debug and whatnot. 