### PR TITLE
fix(lv): limit trace context to only what's needed

### DIFF
--- a/lib/sentry/plug/live_view_context.ex
+++ b/lib/sentry/plug/live_view_context.ex
@@ -11,7 +11,7 @@ if Sentry.OpenTelemetry.VersionChecker.tracing_compatible?() and
     ## Why This Is Needed
 
     When a browser requests a page with a LiveView, the HTTP request comes with distributed
-    tracing headers (e.g., `sentry-trace`, `traceparent`). OpenTelemetry propagators extract
+    tracing headers (`sentry-trace` and `baggage`). OpenTelemetry propagators extract
     these headers and attach the trace context to the request process.
 
     However, Phoenix LiveView creates fresh BEAM processes for each lifecycle callback
@@ -96,6 +96,14 @@ if Sentry.OpenTelemetry.VersionChecker.tracing_compatible?() and
 
     @session_key "__sentry_lv_ctx__"
 
+    # The only request headers the SDK extracts trace context from. Everything
+    # else in the request (authorization, cookie, proxy headers, ...) must never
+    # be persisted in the session by the header fallback below.
+    #
+    # `sentry-trace` and `baggage` are Sentry's own propagation headers:
+    # https://develop.sentry.dev/sdk/foundations/trace-propagation/
+    @trace_header_keys ~w(sentry-trace baggage)
+
     @impl Plug
     def init(opts), do: opts
 
@@ -174,11 +182,13 @@ if Sentry.OpenTelemetry.VersionChecker.tracing_compatible?() and
 
     defp extract_from_headers(conn) do
       # Build a carrier from conn headers
-      headers_carrier = Map.new(conn.req_headers)
+      headers_carrier =
+        conn.req_headers
+        |> Map.new()
+        |> Map.take(@trace_header_keys)
 
       # Check if we have trace headers
-      if Map.has_key?(headers_carrier, "sentry-trace") or
-           Map.has_key?(headers_carrier, "traceparent") do
+      if Map.has_key?(headers_carrier, "sentry-trace") do
         # Return the headers directly as the carrier - this will be extracted
         # in the LiveView process by the Propagator
         headers_carrier

--- a/test/sentry/plug/live_view_context_test.exs
+++ b/test/sentry/plug/live_view_context_test.exs
@@ -1,0 +1,73 @@
+defmodule Sentry.Plug.LiveViewContextTest do
+  use Sentry.Case, async: false
+
+  import Plug.Conn
+  import Plug.Test
+
+  alias Sentry.Plug.LiveViewContext
+
+  @session_key LiveViewContext.session_key()
+
+  @trace "d4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1"
+  @baggage "sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b,sentry-public_key=abc"
+
+  defp call_plug(conn) do
+    conn
+    |> init_test_session(%{})
+    |> LiveViewContext.call(LiveViewContext.init([]))
+  end
+
+  describe "trace context fallback from request headers (no active OTel span)" do
+    test "persists only trace-relevant headers, not sensitive ones" do
+      conn =
+        conn(:get, "/")
+        |> put_req_header("sentry-trace", @trace)
+        |> put_req_header("baggage", @baggage)
+        |> put_req_header("authorization", "Bearer super-secret-token")
+        |> put_req_header("cookie", "_app_session=topsecret")
+        |> put_req_header("x-internal-proxy-secret", "10.0.0.1")
+        |> call_plug()
+
+      stored = get_session(conn, @session_key)
+
+      assert stored["sentry-trace"] == @trace
+      assert stored["baggage"] == @baggage
+
+      refute Map.has_key?(stored, "authorization")
+      refute Map.has_key?(stored, "cookie")
+      refute Map.has_key?(stored, "x-internal-proxy-secret")
+    end
+
+    test "does not persist W3C trace headers, only Sentry's own" do
+      conn =
+        conn(:get, "/")
+        |> put_req_header("sentry-trace", @trace)
+        |> put_req_header(
+          "traceparent",
+          "00-#{String.duplicate("a", 32)}-#{String.duplicate("b", 16)}-01"
+        )
+        |> put_req_header("tracestate", "sentry=foo")
+        |> call_plug()
+
+      stored = get_session(conn, @session_key)
+
+      assert stored["sentry-trace"] == @trace
+      refute Map.has_key?(stored, "traceparent")
+      refute Map.has_key?(stored, "tracestate")
+    end
+
+    test "stores nothing when there is no sentry-trace header" do
+      conn =
+        conn(:get, "/")
+        |> put_req_header(
+          "traceparent",
+          "00-#{String.duplicate("a", 32)}-#{String.duplicate("b", 16)}-01"
+        )
+        |> put_req_header("authorization", "Bearer super-secret-token")
+        |> put_req_header("cookie", "_app_session=topsecret")
+        |> call_plug()
+
+      assert get_session(conn, @session_key) == nil
+    end
+  end
+end


### PR DESCRIPTION
This limits LV storing headers only to trace-related values, as that's the only thing that we need for DT.