### PR TITLE
fix(oban): scrub sensitive info from errors

### DIFF
--- a/lib/sentry/integrations/oban/error_reporter.ex
+++ b/lib/sentry/integrations/oban/error_reporter.ex
@@ -95,13 +95,17 @@ defmodule Sentry.Integrations.Oban.ErrorReporter do
 
     tags = merge_oban_tags(base_tags, config[:oban_tags_to_sentry_tags], job)
 
+    extra =
+      job
+      |> Map.take([:args, :attempt, :id, :max_attempts, :meta, :queue, :tags, :worker])
+      |> Map.update!(:args, &Sentry.Scrubber.scrub/1)
+
     opts =
       [
         stacktrace: stacktrace,
         tags: tags,
         fingerprint: [job.worker, "{{ default }}"],
-        extra:
-          Map.take(job, [:args, :attempt, :id, :max_attempts, :meta, :queue, :tags, :worker]),
+        extra: extra,
         integration_meta: %{oban: %{job: job}}
       ]
 

--- a/test/sentry/integrations/oban/error_reporter_test.exs
+++ b/test/sentry/integrations/oban/error_reporter_test.exs
@@ -317,13 +317,35 @@ defmodule Sentry.Integrations.Oban.ErrorReporterTest do
       assert exception.type == "RuntimeError"
       assert exception.value == "oops"
     end
+
+    test "scrubs sensitive values from the job args in the event extra" do
+      emit_telemetry_for_failed_job(
+        :error,
+        %RuntimeError{message: "oops"},
+        [],
+        [],
+        %{"id" => "123", "password" => "hunter2", "entity" => "user"}
+      )
+
+      event = assert_sentry_report(:event, fingerprint: [@worker_as_string, "{{ default }}"])
+
+      assert event.extra[:args]["password"] == "*********"
+      assert event.extra[:args]["id"] == "123"
+      assert event.extra[:args]["entity"] == "user"
+    end
   end
 
   ## Helpers
 
-  defp emit_telemetry_for_failed_job(kind, reason, stacktrace, config \\ []) do
+  defp emit_telemetry_for_failed_job(
+         kind,
+         reason,
+         stacktrace,
+         config \\ [],
+         args \\ %{"id" => "123", "entity" => "user", "type" => "delete"}
+       ) do
     job =
-      %{"id" => "123", "entity" => "user", "type" => "delete"}
+      args
       |> MyWorker.new()
       |> Ecto.Changeset.apply_action!(:validate)
 


### PR DESCRIPTION
Worker args may potentially include some sensitive info so let's use default scrubbing to clean them up.