### PR TITLE
Revert "Exclude :bandit domain by default (#1073)"

### DIFF
--- a/lib/sentry/logger_handler.ex
+++ b/lib/sentry/logger_handler.ex
@@ -26,7 +26,7 @@ defmodule Sentry.LoggerHandler do
     ],
     excluded_domains: [
       type: {:list, :atom},
-      default: [:cowboy, :bandit],
+      default: [:cowboy],
       type_doc: "list of `t:atom/0`",
       doc: """
       Any messages with a domain in the configured list will not be sent. The default is so as


### PR DESCRIPTION
This reverts commit 752f218e044ab5e1a60b20ce20cb3601731e1d25.

See this comment for context: https://github.com/getsentry/sentry-elixir/pull/1073#issuecomment-4681911625

### Description
<!-- What changed and why? -->

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-elixir/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)