### PR TITLE
chore(config): remove bandit from capture_excluded_domains

### DIFF
--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -503,11 +503,11 @@ defmodule Sentry.Config do
         ],
         capture_excluded_domains: [
           type: {:list, :atom},
-          default: [:cowboy, :bandit],
+          default: [:cowboy],
           type_doc: "list of `t:atom/0`",
           doc: """
           Domains to exclude from **error events** captured by the auto-attached handler.
-          Defaults to `[:cowboy, :bandit]` to avoid double-reporting events already captured
+          Defaults to `[:cowboy]` to avoid double-reporting events already captured
           by `Sentry.PlugCapture`. This is independent of `:excluded_domains`, which controls
           structured logs sent to Sentry's Logs Protocol. *Available since 13.2.0*.
           """

--- a/test/sentry/application_test.exs
+++ b/test/sentry/application_test.exs
@@ -24,7 +24,7 @@ defmodule Sentry.ApplicationTest do
       assert config.config.capture_log_messages == false
       assert config.config.level == :error
       assert config.config.metadata == []
-      assert config.config.excluded_domains == [:cowboy, :bandit]
+      assert config.config.excluded_domains == [:cowboy]
     end
 
     test "respects logs.capture_log_messages and logs.capture_level config" do
@@ -60,8 +60,8 @@ defmodule Sentry.ApplicationTest do
       assert {:ok, config} = :logger.get_handler_config(:sentry_log_handler)
       assert Sentry.Config.logs_excluded_domains() == [:cowboy, :ranch]
       # :excluded_domains is for the Logs UI only; error-event exclusions are governed by
-      # the separate :capture_excluded_domains option (defaults to [:cowboy, :bandit]).
-      assert config.config.excluded_domains == [:cowboy, :bandit]
+      # the separate :capture_excluded_domains option.
+      assert config.config.excluded_domains == [:cowboy]
     end
 
     test "respects logs.capture_excluded_domains config" do

--- a/test/sentry/config_test.exs
+++ b/test/sentry/config_test.exs
@@ -88,7 +88,7 @@ defmodule Sentry.ConfigTest do
       assert defaults[:capture_log_messages] == false
       assert defaults[:capture_level] == :error
       assert defaults[:capture_metadata] == []
-      assert defaults[:capture_excluded_domains] == [:cowboy, :bandit]
+      assert defaults[:capture_excluded_domains] == [:cowboy]
 
       configured =
         Config.validate!(


### PR DESCRIPTION
Quick follow-up after https://github.com/getsentry/sentry-elixir/pull/1099

Long-story short: double reports may happen only with a bandit-based app that still has PlugCapture enabled, and that plug is cowboy-only.

We should probably improve PlugCapture to warn when it's enabled when the app is not using cowboy, but that's a follow-up work.