### PR TITLE
fix(logs): stop reading logs config at runtime

### DIFF
--- a/lib/sentry/application.ex
+++ b/lib/sentry/application.ex
@@ -134,11 +134,13 @@ defmodule Sentry.Application do
 
   defp maybe_add_logger_handler do
     if Config.enable_logs?() do
-      # The :logs config drives both backends of the auto-attached handler: LogsBackend
-      # reads its options (level, excluded_domains, metadata) from Config at runtime,
-      # while the ErrorBackend options are passed here at attach time. The error-event
-      # options come from the separate :capture_* keys so they stay independent from the
-      # Logs UI ones (e.g. error-event metadata/excluded_domains are opt-in).
+      # The :logs config drives both backends of the auto-attached handler. Only the
+      # error-event (ErrorBackend) options are passed here explicitly; they come from the
+      # separate :capture_* keys so they stay independent from the Logs UI ones (e.g.
+      # error-event metadata/excluded_domains are opt-in). The LogsBackend options (level,
+      # excluded_domains, metadata) are read from the global :logs config by the handler
+      # itself when it is added or reconfigured, so they do not need to be threaded through
+      # here.
       handler_config = %{
         level: Config.logs_capture_level(),
         capture_log_messages: Config.logs_capture_log_messages?(),

--- a/lib/sentry/application.ex
+++ b/lib/sentry/application.ex
@@ -134,25 +134,13 @@ defmodule Sentry.Application do
 
   defp maybe_add_logger_handler do
     if Config.enable_logs?() do
-      # The :logs config drives both backends of the auto-attached handler. Only the
-      # error-event (ErrorBackend) options are passed here explicitly; they come from the
-      # separate :capture_* keys so they stay independent from the Logs UI ones (e.g.
-      # error-event metadata/excluded_domains are opt-in). The LogsBackend options (level,
-      # excluded_domains, metadata) are read from the global :logs config by the handler
-      # itself when it is added or reconfigured, so they do not need to be threaded through
-      # here.
-      handler_config = %{
-        level: Config.logs_capture_level(),
-        capture_log_messages: Config.logs_capture_log_messages?(),
-        metadata: Config.logs_capture_metadata(),
-        excluded_domains: Config.logs_capture_excluded_domains()
-      }
+      handler_config = logger_handler_config(Config.logs())
 
       cond do
         # The auto handler is still registered, which happens when the :sentry application
         # is stopped and restarted within the same VM: the handler lives in :logger, not in
         # our supervision tree, so it survives the stop. Re-sync its config so updated :logs
-        # settings reach the ErrorBackend, whose options are frozen at attach time and would
+        # settings reach the handler, whose options are frozen at attach time and would
         # otherwise stay stale across the restart.
         auto_logger_handler_registered?() ->
           _ = :logger.update_handler_config(:sentry_log_handler, :config, handler_config)
@@ -179,6 +167,19 @@ defmodule Sentry.Application do
     end
 
     :ok
+  end
+
+  defp logger_handler_config(logs) do
+    [
+      enable_logs: true,
+      capture_log_messages: Keyword.fetch!(logs, :capture_log_messages),
+      capture_level: Keyword.fetch!(logs, :capture_level),
+      capture_metadata: Keyword.fetch!(logs, :capture_metadata),
+      capture_excluded_domains: Keyword.fetch!(logs, :capture_excluded_domains),
+      logs_level: Keyword.fetch!(logs, :level),
+      logs_metadata: Keyword.fetch!(logs, :metadata),
+      logs_excluded_domains: Keyword.fetch!(logs, :excluded_domains)
+    ]
   end
 
   defp auto_logger_handler_registered? do

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -401,9 +401,9 @@ defmodule Sentry.Config do
       Whether to enable sending log events to Sentry. When enabled, the SDK will
       automatically attach a `Sentry.LoggerHandler` to capture and send structured
       log events according to the [Sentry Logs Protocol](https://develop.sentry.dev/sdk/telemetry/logs/).
-      The auto-attached handler also reports **crashes** to Sentry as error events, and
+      The auto-attached handler also reports **crashes** to Sentry as captured events, and
       can be configured (via the `:capture_log_messages` and `:capture_level` keys of the
-      `:logs` option) to report standalone `Logger` messages as error events too, so you
+      `:logs` option) to report standalone `Logger` messages as captured events too, so you
       do not need to add `Sentry.LoggerHandler` manually.
       The handler is not added if a `Sentry.LoggerHandler` is already registered.
       Use the `:logs` option to configure the auto-attached handler.
@@ -430,7 +430,7 @@ defmodule Sentry.Config do
       **structured logs** sent to Sentry's Logs Protocol, while the `:capture_*` keys
       (`:capture_log_messages`, `:capture_level`, `:capture_metadata`, and
       `:capture_excluded_domains`) configure whether (and how) `Logger` messages are also
-      reported as **error events**. *Available since 12.0.0*.
+      reported as captured Sentry events. *Available since 12.0.0*.
       """,
       keys: [
         level: [
@@ -449,7 +449,7 @@ defmodule Sentry.Config do
           type_doc: "list of `t:atom/0`",
           doc: """
           Domains to exclude from logs sent to Sentry's Logs Protocol. This does not affect
-          error events; use `:capture_excluded_domains` for those.
+          captured Sentry events; use `:capture_excluded_domains` for those.
           """
         ],
         metadata: [
@@ -459,7 +459,7 @@ defmodule Sentry.Config do
           doc: """
           Logger metadata keys to include as attributes in log events sent to Sentry's Logs
           Protocol. If set to `:all`, all metadata will be included. This does not affect
-          error events; use `:capture_metadata` for those.
+          captured Sentry events; use `:capture_metadata` for those.
           """
         ],
         capture_log_messages: [
@@ -467,7 +467,7 @@ defmodule Sentry.Config do
           default: false,
           doc: """
           When `true`, the auto-attached handler also reports standalone log messages
-          (such as `Logger.error("oops")`) to Sentry as **error events**, in addition to
+          (such as `Logger.error("oops")`) to Sentry as captured events, in addition to
           crash reports. Crash reports are sent whether or not this option is enabled, so
           you do not need to turn it on to capture crashes. Both crashes and messages are
           gated by `:capture_level`. This mirrors the `:capture_log_messages` option of
@@ -481,11 +481,11 @@ defmodule Sentry.Config do
           default: :error,
           type_doc: "`t:Logger.level/0`",
           doc: """
-          The minimum Logger level for **error events**, including crashes. At the default
+          The minimum Logger level for captured Sentry events, including crashes. At the default
           `:error`, crashes (which are logged at `:error`) are reported; raising this above
           `:error` suppresses crashes too, mirroring the `:level` option of
           `Sentry.LoggerHandler`. When `:capture_log_messages` is `true`, this also gates
-          which standalone `Logger` messages become error events. This is independent of
+          which standalone `Logger` messages become captured events. This is independent of
           `:level`, which controls the level for structured logs sent to Sentry's Logs
           Protocol. *Available since 13.2.0*.
           """
@@ -495,7 +495,7 @@ defmodule Sentry.Config do
           default: [],
           type_doc: "list of `t:atom/0`, or `:all`",
           doc: """
-          Logger metadata keys to include in **error events** captured by the auto-attached
+          Logger metadata keys to include in captured Sentry events from the auto-attached
           handler, added under `:extra` as `logger_metadata`. If set to `:all`, all metadata
           will be included. This is independent of `:metadata`, which controls metadata for
           structured logs sent to Sentry's Logs Protocol. *Available since 13.2.0*.
@@ -506,7 +506,7 @@ defmodule Sentry.Config do
           default: [:cowboy, :bandit],
           type_doc: "list of `t:atom/0`",
           doc: """
-          Domains to exclude from **error events** captured by the auto-attached handler.
+          Domains to exclude from Sentry events captured by the auto-attached handler.
           Defaults to `[:cowboy, :bandit]` to avoid double-reporting events already captured
           by `Sentry.PlugCapture`. This is independent of `:excluded_domains`, which controls
           structured logs sent to Sentry's Logs Protocol. *Available since 13.2.0*.

--- a/lib/sentry/logger_handler.ex
+++ b/lib/sentry/logger_handler.ex
@@ -17,29 +17,43 @@ defmodule Sentry.LoggerHandler do
       type:
         {:in,
          [:emergency, :alert, :critical, :error, :warning, :warn, :notice, :info, :debug, nil]},
+      doc: false
+    ],
+    excluded_domains: [
+      type: {:list, :atom},
+      doc: false
+    ],
+    metadata: [
+      type: {:or, [{:list, :atom}, {:in, [:all]}]},
+      doc: false
+    ],
+    capture_level: [
+      type:
+        {:in,
+         [:emergency, :alert, :critical, :error, :warning, :warn, :notice, :info, :debug, nil]},
       default: :error,
       type_doc: "`t:Logger.level/0`",
       doc: """
       The minimum [`Logger`
-      level](https://hexdocs.pm/logger/Logger.html#module-levels) to send events for.
+      level](https://hexdocs.pm/logger/Logger.html#module-levels) to send Sentry events for.
       """
     ],
-    excluded_domains: [
+    capture_excluded_domains: [
       type: {:list, :atom},
-      default: [:cowboy],
+      default: [:cowboy, :bandit],
       type_doc: "list of `t:atom/0`",
       doc: """
-      Any messages with a domain in the configured list will not be sent. The default is so as
-      to avoid double-reporting events from `Sentry.PlugCapture`.
+      Any messages with a domain in the configured list will not be sent as Sentry events.
+      The default avoids double-reporting events from `Sentry.PlugCapture`.
       """
     ],
-    metadata: [
+    capture_metadata: [
       type: {:or, [{:list, :atom}, {:in, [:all]}]},
       default: [],
       type_doc: "list of `t:atom/0`, or `:all`",
       doc: """
-      Use this to include non-Sentry logger metadata in reports. If it's a list of keys, metadata
-      in those keys will be added in the `:extra` context (see
+      Use this to include non-Sentry logger metadata in captured Sentry events. If it's a
+      list of keys, metadata in those keys will be added in the `:extra` context (see
       `Sentry.Context.set_extra_context/1`) under the `:logger_metadata` key.
       If set to `:all`, all metadata will be included.
       """
@@ -57,9 +71,9 @@ defmodule Sentry.LoggerHandler do
       default: false,
       doc: """
       When `true`, this module will report all logged messages to Sentry (provided they're not
-      filtered by `:excluded_domains` and `:level`). The default of `false` means that the
-      handler will only send **crash reports**, which are messages with metadata that has the
-      shape of an exit reason and a stacktrace.
+      filtered by `:capture_excluded_domains` and `:capture_level`). The default of `false`
+      means that the handler will only send **crash reports**, which are messages with
+      metadata that has the shape of an exit reason and a stacktrace.
       """
     ],
     rate_limiting: [
@@ -108,6 +122,22 @@ defmodule Sentry.LoggerHandler do
       type: {:or, [:boolean, nil]},
       default: nil,
       doc: false
+    ],
+    logs_level: [
+      type:
+        {:in, [:emergency, :alert, :critical, :error, :warning, :warn, :notice, :info, :debug]},
+      default: :info,
+      doc: false
+    ],
+    logs_excluded_domains: [
+      type: {:list, :atom},
+      default: [],
+      doc: false
+    ],
+    logs_metadata: [
+      type: {:or, [{:list, :atom}, {:in, [:all]}]},
+      default: [],
+      doc: false
     ]
   ]
 
@@ -121,8 +151,8 @@ defmodule Sentry.LoggerHandler do
 
   This handler can do **two distinct things** with the messages it receives:
 
-    * **Error events** — report crashes and (optionally) `Logger` messages such as
-      `Logger.error("oops")` to Sentry as **errors/messages**, the same way
+    * **Captured Sentry events** — report crashes and (optionally) `Logger` messages such as
+      `Logger.error("oops")` to Sentry as events, the same way
       `Sentry.capture_exception/2` and `Sentry.capture_message/2` do. This is always
       active when the handler is attached.
 
@@ -130,8 +160,8 @@ defmodule Sentry.LoggerHandler do
       UI](https://develop.sentry.dev/sdk/telemetry/logs/) as structured log events. This
       is active when `:enable_logs` is `true` in your Sentry configuration.
 
-  The two are independent: a single log can become an error event, a structured log, both,
-  or neither, depending on configuration.
+  The two are independent: a single log can become a captured Sentry event, a structured
+  log, both, or neither, depending on configuration.
 
   > #### You usually don't add this handler manually {: .tip}
   >
@@ -205,7 +235,7 @@ defmodule Sentry.LoggerHandler do
 
       config :my_app, :logger, [
         {:handler, :my_sentry_handler, Sentry.LoggerHandler, %{
-          config: %{metadata: [:file, :line]}
+          config: %{capture_metadata: [:file, :line]}
         }}
       ]
 
@@ -224,7 +254,7 @@ defmodule Sentry.LoggerHandler do
 
       def start(_type, _args) do
         :logger.add_handler(:my_sentry_handler, Sentry.LoggerHandler, %{
-          config: %{metadata: [:file, :line]}
+          config: %{capture_metadata: [:file, :line]}
         })
 
         # ...
@@ -232,7 +262,7 @@ defmodule Sentry.LoggerHandler do
 
   ## Sending logs to Sentry
 
-  To send structured logs to [Sentry's Logs UI](https://develop.sentry.dev/sdk/telemetry/logs/),
+  To send structured logs to [Sentry's logs feature](https://develop.sentry.dev/sdk/telemetry/logs/),
   enable logs in your Sentry configuration. This auto-attaches the handler — there is
   **no need** to configure `:logger` or call `:logger.add_handler/3`:
 
@@ -242,42 +272,42 @@ defmodule Sentry.LoggerHandler do
         logs: [level: :info, metadata: [:request_id]]
 
   With this configuration, every `Logger` call at `:info` or above becomes a structured log
-  event in Sentry, and crashes are still reported as **error events** (just like the manual
+  event in Sentry, and crashes are still reported as captured Sentry events (just like the manual
   setup above). The `:logs` options are documented in the
   [Sentry configuration](Sentry.html#module-configuration).
 
-  ### Also capturing `Logger` messages as error events
+  ### Also capturing `Logger` messages as Sentry events
 
-  By default the auto-attached handler reports **crashes** as error events but leaves
+  By default the auto-attached handler reports **crashes** as Sentry events but leaves
   standalone messages (such as `Logger.error("oops")`) as structured logs only. To also
-  report those messages as error events — for example, to turn `Logger.error/1` calls into
+  report those messages as Sentry events — for example, to turn `Logger.error/1` calls into
   Sentry issues while keeping `Logger.info/1` out of your issues stream — use the `:capture_*`
   keys under `:logs`:
 
       config :sentry,
         enable_logs: true,
         logs: [
-          level: :info,                          # structured logs at :info and above -> Logs UI
-          capture_log_messages: true,            # also report messages as error events...
+          level: :info,                          # structured logs at :info and above
+          capture_log_messages: true,            # also report messages as Sentry events...
           capture_level: :error,                 # ...but only at :error and above
-          capture_metadata: :all,                # include Logger metadata in those error events
-          capture_excluded_domains: [:cowboy]    # domains to exclude from those error events
+          capture_metadata: :all,                # include Logger metadata in those events
+          capture_excluded_domains: [:cowboy]    # domains to exclude from those events
         ]
 
-  The `:capture_*` keys configure the **error-event** side and are independent from the
-  matching Logs-UI keys (`:metadata`/`:capture_metadata`,
+  The `:capture_*` keys configure captured Sentry events and are independent from the
+  matching logs feature keys (`:metadata`/`:capture_metadata`,
   `:excluded_domains`/`:capture_excluded_domains`).
 
   > #### Including `Logger` metadata {: .info}
   >
   > For the auto-attached handler, metadata for the two destinations is configured
   > separately. The `:metadata` key **under `:logs`** lists the `Logger` metadata attached
-  > as attributes on **structured logs** (shown in the Logs UI). The `:capture_metadata`
-  > key lists the metadata attached under `:extra` (as `logger_metadata`) on **error
-  > events**. Both accept a list of keys or `:all`, and both default to `[]`. So if your
-  > custom metadata is missing from a captured *error event*, set
+  > as attributes on **structured logs**. The `:capture_metadata`
+  > key lists the metadata attached under `:extra` (as `logger_metadata`) on captured
+  > Sentry events. Both accept a list of keys or `:all`, and both default to `[]`. So if your
+  > custom metadata is missing from a captured event, set
   > `config :sentry, logs: [capture_metadata: [...]]` (or `:all`). When you add the handler
-  > manually instead, use this module's own `:metadata`
+  > manually instead, use this module's own `:capture_metadata`
   > [configuration option](#module-configuration).
 
   ## Configuration
@@ -286,6 +316,10 @@ defmodule Sentry.LoggerHandler do
 
   #{NimbleOptions.docs(@options_schema)}
 
+  The previous handler option names `:level`, `:excluded_domains`, and `:metadata` are
+  still accepted as aliases for `:capture_level`, `:capture_excluded_domains`, and
+  `:capture_metadata`, respectively.
+
   ## Examples
 
   To log all messages with level `:error` and above to Sentry, set `:capture_log_messages`
@@ -293,7 +327,11 @@ defmodule Sentry.LoggerHandler do
 
       config :my_app, :logger, [
         {:handler, :my_sentry_handler, Sentry.LoggerHandler, %{
-          config: %{metadata: [:file, :line], capture_log_messages: true, level: :error}
+          config: %{
+            capture_metadata: [:file, :line],
+            capture_log_messages: true,
+            capture_level: :error
+          }
         }}
       ]
 
@@ -315,19 +353,16 @@ defmodule Sentry.LoggerHandler do
 
   @moduledoc since: "9.0.0"
 
-  alias Sentry.Config
   alias Sentry.LoggerHandler.{ErrorBackend, LogsBackend, RateLimiter}
 
   # The config for this logger handler.
   #
-  # The `:level`, `:excluded_domains`, `:metadata`, and other fields above `:backends`
-  # configure the error-event side (ErrorBackend). The `:logs_*` fields hold the
-  # structured-logs side (LogsBackend) settings, read from the global `:logs`
-  # configuration when the handler is set up.
+  # The `:capture_*` fields configure captured Sentry events. The `:logs_*` fields
+  # configure structured logs for the auto-attached handler.
   defstruct [
-    :level,
-    :excluded_domains,
-    :metadata,
+    :capture_level,
+    :capture_excluded_domains,
+    :capture_metadata,
     :tags_from_metadata,
     :capture_log_messages,
     :rate_limiting,
@@ -351,19 +386,10 @@ defmodule Sentry.LoggerHandler do
 
     handler_config = cast_config(%__MODULE__{}, sentry_config)
 
-    # When :enable_logs is set on the handler config, it takes precedence over
-    # the global Config.enable_logs?() — which may not resolve correctly in the
-    # logger-server process during async tests.
-    enable_logs? =
-      case handler_config.enable_logs do
-        nil -> Config.enable_logs?()
-        bool -> bool
-      end
+    enable_logs? = handler_config.enable_logs == true
 
     backends = [ErrorBackend] ++ if enable_logs?, do: [LogsBackend], else: []
     handler_config = %{handler_config | backends: backends}
-
-    handler_config = prepare_logs_config(handler_config)
 
     config = Map.put(config, :config, handler_config)
 
@@ -397,23 +423,17 @@ defmodule Sentry.LoggerHandler do
     new_sentry_config =
       if is_struct(new_config.config, __MODULE__) do
         # Drop the internally-managed fields that are not part of the user-facing
-        # options schema so they don't trip NimbleOptions validation: :backends is
-        # carried over from the existing config, and the :logs_* settings are
-        # re-derived from the current global config by prepare_logs_config/1 below.
+        # options schema so they don't trip NimbleOptions validation.
         new_config.config
         |> Map.from_struct()
-        |> Map.drop([:backends, :logs_level, :logs_excluded_domains, :logs_metadata])
+        |> Map.drop([:backends])
       else
         new_config.config
       end
 
-    # Re-read the structured-logs settings whenever the handler is reconfigured, so
-    # updating (or re-adding via the application's auto-attach path) refreshes the
-    # :logs_* values instead of leaving stale ones.
     updated_config =
       old_config
       |> update_in([:config], &cast_config(&1, new_sentry_config))
-      |> update_in([:config], &prepare_logs_config/1)
 
     _ignored =
       cond do
@@ -470,30 +490,15 @@ defmodule Sentry.LoggerHandler do
 
   ## Helpers
 
-  # Reads the structured-logs settings (level, excluded domains, metadata) from the
-  # global :logs configuration into the handler config. Only done when LogsBackend is
-  # active for the handler; otherwise the :logs_* fields stay nil since they would never
-  # be read.
-  defp prepare_logs_config(%__MODULE__{backends: backends} = config) do
-    if LogsBackend in backends do
-      %{
-        config
-        | logs_level: Config.logs_level(),
-          logs_excluded_domains: Config.logs_excluded_domains(),
-          logs_metadata: Config.logs_metadata()
-      }
-    else
-      config
-    end
-  end
-
-  defp cast_config(%__MODULE__{} = existing_config, %{} = new_config) do
+  defp cast_config(%__MODULE__{} = existing_config, new_config)
+       when is_map(new_config) or is_list(new_config) do
     validated_config =
       new_config
-      |> Map.to_list()
+      |> config_to_list()
+      |> normalize_aliases()
       |> NimbleOptions.validate!(@options_schema)
 
-    config = struct!(existing_config, validated_config)
+    config = struct!(existing_config, canonical_config(validated_config))
 
     if config.sync_threshold && config.discard_threshold do
       raise ArgumentError,
@@ -501,5 +506,33 @@ defmodule Sentry.LoggerHandler do
     else
       config
     end
+  end
+
+  defp config_to_list(config) when is_map(config), do: Map.to_list(config)
+  defp config_to_list(config) when is_list(config), do: config
+
+  defp normalize_aliases(config) do
+    config
+    |> maybe_put_alias(:level, :capture_level)
+    |> maybe_put_alias(:excluded_domains, :capture_excluded_domains)
+    |> maybe_put_alias(:metadata, :capture_metadata)
+  end
+
+  defp maybe_put_alias(config, alias_key, canonical_key) do
+    cond do
+      Keyword.has_key?(config, canonical_key) ->
+        config
+
+      Keyword.has_key?(config, alias_key) ->
+        Keyword.put(config, canonical_key, Keyword.fetch!(config, alias_key))
+
+      true ->
+        config
+    end
+  end
+
+  defp canonical_config(validated_config) do
+    validated_config
+    |> Keyword.drop([:level, :excluded_domains, :metadata])
   end
 end

--- a/lib/sentry/logger_handler.ex
+++ b/lib/sentry/logger_handler.ex
@@ -319,6 +319,11 @@ defmodule Sentry.LoggerHandler do
   alias Sentry.LoggerHandler.{ErrorBackend, LogsBackend, RateLimiter}
 
   # The config for this logger handler.
+  #
+  # The `:level`, `:excluded_domains`, `:metadata`, and other fields above `:backends`
+  # configure the error-event side (ErrorBackend). The `:logs_*` fields hold the
+  # structured-logs side (LogsBackend) settings, read from the global `:logs`
+  # configuration when the handler is set up.
   defstruct [
     :level,
     :excluded_domains,
@@ -329,6 +334,9 @@ defmodule Sentry.LoggerHandler do
     :sync_threshold,
     :discard_threshold,
     :enable_logs,
+    :logs_level,
+    :logs_excluded_domains,
+    :logs_metadata,
     backends: []
   ]
 
@@ -354,6 +362,8 @@ defmodule Sentry.LoggerHandler do
 
     backends = [ErrorBackend] ++ if enable_logs?, do: [LogsBackend], else: []
     handler_config = %{handler_config | backends: backends}
+
+    handler_config = prepare_logs_config(handler_config)
 
     config = Map.put(config, :config, handler_config)
 
@@ -386,12 +396,24 @@ defmodule Sentry.LoggerHandler do
   def changing_config(:update, old_config, new_config) do
     new_sentry_config =
       if is_struct(new_config.config, __MODULE__) do
-        new_config.config |> Map.from_struct() |> Map.delete(:backends)
+        # Drop the internally-managed fields that are not part of the user-facing
+        # options schema so they don't trip NimbleOptions validation: :backends is
+        # carried over from the existing config, and the :logs_* settings are
+        # re-derived from the current global config by prepare_logs_config/1 below.
+        new_config.config
+        |> Map.from_struct()
+        |> Map.drop([:backends, :logs_level, :logs_excluded_domains, :logs_metadata])
       else
         new_config.config
       end
 
-    updated_config = update_in(old_config.config, &cast_config(&1, new_sentry_config))
+    # Re-read the structured-logs settings whenever the handler is reconfigured, so
+    # updating (or re-adding via the application's auto-attach path) refreshes the
+    # :logs_* values instead of leaving stale ones.
+    updated_config =
+      old_config
+      |> update_in([:config], &cast_config(&1, new_sentry_config))
+      |> update_in([:config], &prepare_logs_config/1)
 
     _ignored =
       cond do
@@ -447,6 +469,23 @@ defmodule Sentry.LoggerHandler do
   end
 
   ## Helpers
+
+  # Reads the structured-logs settings (level, excluded domains, metadata) from the
+  # global :logs configuration into the handler config. Only done when LogsBackend is
+  # active for the handler; otherwise the :logs_* fields stay nil since they would never
+  # be read.
+  defp prepare_logs_config(%__MODULE__{backends: backends} = config) do
+    if LogsBackend in backends do
+      %{
+        config
+        | logs_level: Config.logs_level(),
+          logs_excluded_domains: Config.logs_excluded_domains(),
+          logs_metadata: Config.logs_metadata()
+      }
+    else
+      config
+    end
+  end
 
   defp cast_config(%__MODULE__{} = existing_config, %{} = new_config) do
     validated_config =

--- a/lib/sentry/logger_handler/error_backend.ex
+++ b/lib/sentry/logger_handler/error_backend.ex
@@ -16,10 +16,13 @@ defmodule Sentry.LoggerHandler.ErrorBackend do
   @impl true
   def handle_event(%{level: log_level, meta: log_meta} = log_event, config, handler_id) do
     cond do
-      Logger.compare_levels(log_level, config.level) == :lt ->
+      Logger.compare_levels(log_level, config.capture_level) == :lt ->
         :ok
 
-      LoggerUtils.excluded_domain?(Map.get(log_meta, :domain, []), config.excluded_domains) ->
+      LoggerUtils.excluded_domain?(
+        Map.get(log_meta, :domain, []),
+        config.capture_excluded_domains
+      ) ->
         :ok
 
       config.rate_limiting && RateLimiter.increment(handler_id) == :rate_limited ->
@@ -38,7 +41,7 @@ defmodule Sentry.LoggerHandler.ErrorBackend do
             log_level,
             log_meta[:sentry],
             log_meta,
-            config.metadata,
+            config.capture_metadata,
             config.tags_from_metadata
           )
 

--- a/lib/sentry/logger_handler/logs_backend.ex
+++ b/lib/sentry/logger_handler/logs_backend.ex
@@ -4,29 +4,31 @@ defmodule Sentry.LoggerHandler.LogsBackend do
   # Backend that sends log events to Sentry's Logs Protocol.
   #
   # This backend is enabled at handler setup time when `enable_logs: true` is set
-  # in Sentry configuration. Logs configuration (level, excluded_domains, metadata)
-  # is read from `Sentry.Config` at runtime.
+  # in Sentry configuration. Its configuration (level, excluded_domains, metadata) is
+  # frozen into the `%Sentry.LoggerHandler{}` config struct when the handler is set up,
+  # so this backend reads those settings from the config it is given for each event
+  # rather than reading `Sentry.Config` on the logging hot path.
 
   @behaviour Sentry.LoggerHandler.Backend
 
-  alias Sentry.{Config, LogEvent, LoggerUtils, TelemetryProcessor}
+  alias Sentry.{LogEvent, LoggerUtils, TelemetryProcessor}
 
   @impl true
-  def handle_event(%{level: log_level, meta: log_meta} = log_event, _config, _handler_id) do
+  def handle_event(%{level: log_level, meta: log_meta} = log_event, config, _handler_id) do
     cond do
-      Logger.compare_levels(log_level, Config.logs_level()) == :lt ->
+      Logger.compare_levels(log_level, config.logs_level) == :lt ->
         :ok
 
-      LoggerUtils.excluded_domain?(Map.get(log_meta, :domain, []), Config.logs_excluded_domains()) ->
+      LoggerUtils.excluded_domain?(Map.get(log_meta, :domain, []), config.logs_excluded_domains) ->
         :ok
 
       true ->
-        send_log_event(log_event)
+        send_log_event(log_event, config.logs_metadata)
     end
   end
 
-  defp send_log_event(%{meta: log_meta} = log_event) do
-    attributes = extract_metadata(log_meta, Config.logs_metadata())
+  defp send_log_event(%{meta: log_meta} = log_event, logs_metadata) do
+    attributes = extract_metadata(log_meta, logs_metadata)
 
     # Extract parameters for message template interpolation (if provided via metadata)
     parameters = Map.get(log_meta, :parameters)

--- a/test/sentry/application_test.exs
+++ b/test/sentry/application_test.exs
@@ -15,22 +15,22 @@ defmodule Sentry.ApplicationTest do
     test "attaches :sentry_log_handler with defaults" do
       restart_sentry_with(dsn: "https://public@sentry.example.com/1", enable_logs: true)
 
-      assert {:ok, config} = :logger.get_handler_config(:sentry_log_handler)
-      assert config.module == Sentry.LoggerHandler
+      assert {:ok, handler} = :logger.get_handler_config(:sentry_log_handler)
+      assert handler.module == Sentry.LoggerHandler
       assert Sentry.Config.logs_level() == :info
       assert Sentry.Config.logs_excluded_domains() == []
       assert Sentry.Config.logs_metadata() == []
 
-      assert config.config.capture_log_messages == false
-      assert config.config.level == :error
-      assert config.config.metadata == []
-      assert config.config.excluded_domains == [:cowboy, :bandit]
+      assert handler.config.capture_log_messages == false
+      assert handler.config.level == :error
+      assert handler.config.metadata == []
+      assert handler.config.excluded_domains == [:cowboy, :bandit]
 
-      # The structured-logs (LogsBackend) settings are frozen from the global :logs
-      # config into the handler config struct.
-      assert config.config.logs_level == :info
-      assert config.config.logs_excluded_domains == []
-      assert config.config.logs_metadata == []
+      # The logs feature settings are frozen from the global :logs config into
+      # the handler config struct used by LogsBackend.
+      assert handler.config.logs_level == :info
+      assert handler.config.logs_excluded_domains == []
+      assert handler.config.logs_metadata == []
     end
 
     test "respects logs.capture_log_messages and logs.capture_level config" do
@@ -40,9 +40,9 @@ defmodule Sentry.ApplicationTest do
         logs: [capture_log_messages: true, capture_level: :warning]
       )
 
-      assert {:ok, config} = :logger.get_handler_config(:sentry_log_handler)
-      assert config.config.capture_log_messages == true
-      assert config.config.level == :warning
+      assert {:ok, handler} = :logger.get_handler_config(:sentry_log_handler)
+      assert handler.config.capture_log_messages == true
+      assert handler.config.level == :warning
     end
 
     test "respects logs.level config" do
@@ -52,9 +52,9 @@ defmodule Sentry.ApplicationTest do
         logs: [level: :warning]
       )
 
-      assert {:ok, config} = :logger.get_handler_config(:sentry_log_handler)
+      assert {:ok, handler} = :logger.get_handler_config(:sentry_log_handler)
       assert Sentry.Config.logs_level() == :warning
-      assert config.config.logs_level == :warning
+      assert handler.config.logs_level == :warning
     end
 
     test "respects logs.excluded_domains config" do
@@ -64,13 +64,14 @@ defmodule Sentry.ApplicationTest do
         logs: [excluded_domains: [:cowboy, :ranch]]
       )
 
-      assert {:ok, config} = :logger.get_handler_config(:sentry_log_handler)
+      assert {:ok, handler} = :logger.get_handler_config(:sentry_log_handler)
       assert Sentry.Config.logs_excluded_domains() == [:cowboy, :ranch]
-      # :excluded_domains is for the Logs UI only; error-event exclusions are governed by
-      # the separate :capture_excluded_domains option (defaults to [:cowboy, :bandit]).
-      assert config.config.excluded_domains == [:cowboy, :bandit]
-      # The Logs UI exclusions are frozen into the handler config for the LogsBackend.
-      assert config.config.logs_excluded_domains == [:cowboy, :ranch]
+
+      # :excluded_domains is for the logs feature; captured Sentry event exclusions are
+      # governed by the separate :capture_excluded_domains option.
+      assert handler.config.excluded_domains == [:cowboy, :bandit]
+      # The logs feature exclusions are frozen into the handler config for LogsBackend.
+      assert handler.config.logs_excluded_domains == [:cowboy, :ranch]
     end
 
     test "respects logs.capture_excluded_domains config" do
@@ -80,8 +81,8 @@ defmodule Sentry.ApplicationTest do
         logs: [capture_excluded_domains: [:cowboy, :ranch]]
       )
 
-      assert {:ok, config} = :logger.get_handler_config(:sentry_log_handler)
-      assert config.config.excluded_domains == [:cowboy, :ranch]
+      assert {:ok, handler} = :logger.get_handler_config(:sentry_log_handler)
+      assert handler.config.excluded_domains == [:cowboy, :ranch]
     end
 
     test "respects logs.metadata config" do
@@ -91,13 +92,14 @@ defmodule Sentry.ApplicationTest do
         logs: [metadata: [:request_id, :user_id]]
       )
 
-      assert {:ok, config} = :logger.get_handler_config(:sentry_log_handler)
+      assert {:ok, handler} = :logger.get_handler_config(:sentry_log_handler)
       assert Sentry.Config.logs_metadata() == [:request_id, :user_id]
-      # :metadata is for the Logs UI only; it must not leak into error-event metadata,
+
+      # :metadata is for the logs feature; it must not leak into captured event metadata,
       # which is governed by the separate :capture_metadata option.
-      assert config.config.metadata == []
-      # The Logs UI metadata selection is frozen into the handler config for the LogsBackend.
-      assert config.config.logs_metadata == [:request_id, :user_id]
+      assert handler.config.metadata == []
+      # The logs feature metadata selection is set in the handler config for LogsBackend.
+      assert handler.config.logs_metadata == [:request_id, :user_id]
     end
 
     test "respects logs.capture_metadata config" do
@@ -107,8 +109,8 @@ defmodule Sentry.ApplicationTest do
         logs: [capture_metadata: [:request_id, :user_id]]
       )
 
-      assert {:ok, config} = :logger.get_handler_config(:sentry_log_handler)
-      assert config.config.metadata == [:request_id, :user_id]
+      assert {:ok, handler} = :logger.get_handler_config(:sentry_log_handler)
+      assert handler.config.metadata == [:request_id, :user_id]
     end
 
     test "re-syncs the handler's capture config when restarted while already registered" do
@@ -118,21 +120,21 @@ defmodule Sentry.ApplicationTest do
         logs: [capture_metadata: [:request_id], capture_excluded_domains: [:cowboy]]
       )
 
-      assert {:ok, config} = :logger.get_handler_config(:sentry_log_handler)
-      assert config.config.metadata == [:request_id]
-      assert config.config.excluded_domains == [:cowboy]
+      assert {:ok, handler} = :logger.get_handler_config(:sentry_log_handler)
+      assert handler.config.metadata == [:request_id]
+      assert handler.config.excluded_domains == [:cowboy]
 
       # Restart again WITHOUT removing the handler first. The handler survives the stop, so
-      # the start path must re-sync the ErrorBackend's frozen options to the new config.
+      # the start path must re-sync the event-capture backend's frozen options to the new config.
       restart_sentry_with(
         dsn: "https://public@sentry.example.com/1",
         enable_logs: true,
         logs: [capture_metadata: [:request_id, :user_id], capture_excluded_domains: [:ranch]]
       )
 
-      assert {:ok, config} = :logger.get_handler_config(:sentry_log_handler)
-      assert config.config.metadata == [:request_id, :user_id]
-      assert config.config.excluded_domains == [:ranch]
+      assert {:ok, handler} = :logger.get_handler_config(:sentry_log_handler)
+      assert handler.config.metadata == [:request_id, :user_id]
+      assert handler.config.excluded_domains == [:ranch]
     end
 
     test "re-freezes the handler's structured-logs config when restarted while already registered" do
@@ -142,10 +144,10 @@ defmodule Sentry.ApplicationTest do
         logs: [level: :info, excluded_domains: [:cowboy], metadata: [:request_id]]
       )
 
-      assert {:ok, config} = :logger.get_handler_config(:sentry_log_handler)
-      assert config.config.logs_level == :info
-      assert config.config.logs_excluded_domains == [:cowboy]
-      assert config.config.logs_metadata == [:request_id]
+      assert {:ok, handler} = :logger.get_handler_config(:sentry_log_handler)
+      assert handler.config.logs_level == :info
+      assert handler.config.logs_excluded_domains == [:cowboy]
+      assert handler.config.logs_metadata == [:request_id]
 
       # Restart WITHOUT removing the handler first. The handler survives the stop, so the
       # start path must re-sync (re-freeze) the LogsBackend's frozen options to the new
@@ -156,10 +158,10 @@ defmodule Sentry.ApplicationTest do
         logs: [level: :warning, excluded_domains: [:ranch], metadata: :all]
       )
 
-      assert {:ok, config} = :logger.get_handler_config(:sentry_log_handler)
-      assert config.config.logs_level == :warning
-      assert config.config.logs_excluded_domains == [:ranch]
-      assert config.config.logs_metadata == :all
+      assert {:ok, handler} = :logger.get_handler_config(:sentry_log_handler)
+      assert handler.config.logs_level == :warning
+      assert handler.config.logs_excluded_domains == [:ranch]
+      assert handler.config.logs_metadata == :all
     end
 
     test "does not attach handler when enable_logs is false" do

--- a/test/sentry/application_test.exs
+++ b/test/sentry/application_test.exs
@@ -25,6 +25,12 @@ defmodule Sentry.ApplicationTest do
       assert config.config.level == :error
       assert config.config.metadata == []
       assert config.config.excluded_domains == [:cowboy, :bandit]
+
+      # The structured-logs (LogsBackend) settings are frozen from the global :logs
+      # config into the handler config struct.
+      assert config.config.logs_level == :info
+      assert config.config.logs_excluded_domains == []
+      assert config.config.logs_metadata == []
     end
 
     test "respects logs.capture_log_messages and logs.capture_level config" do
@@ -46,8 +52,9 @@ defmodule Sentry.ApplicationTest do
         logs: [level: :warning]
       )
 
-      assert {:ok, _config} = :logger.get_handler_config(:sentry_log_handler)
+      assert {:ok, config} = :logger.get_handler_config(:sentry_log_handler)
       assert Sentry.Config.logs_level() == :warning
+      assert config.config.logs_level == :warning
     end
 
     test "respects logs.excluded_domains config" do
@@ -62,6 +69,8 @@ defmodule Sentry.ApplicationTest do
       # :excluded_domains is for the Logs UI only; error-event exclusions are governed by
       # the separate :capture_excluded_domains option (defaults to [:cowboy, :bandit]).
       assert config.config.excluded_domains == [:cowboy, :bandit]
+      # The Logs UI exclusions are frozen into the handler config for the LogsBackend.
+      assert config.config.logs_excluded_domains == [:cowboy, :ranch]
     end
 
     test "respects logs.capture_excluded_domains config" do
@@ -87,6 +96,8 @@ defmodule Sentry.ApplicationTest do
       # :metadata is for the Logs UI only; it must not leak into error-event metadata,
       # which is governed by the separate :capture_metadata option.
       assert config.config.metadata == []
+      # The Logs UI metadata selection is frozen into the handler config for the LogsBackend.
+      assert config.config.logs_metadata == [:request_id, :user_id]
     end
 
     test "respects logs.capture_metadata config" do
@@ -122,6 +133,33 @@ defmodule Sentry.ApplicationTest do
       assert {:ok, config} = :logger.get_handler_config(:sentry_log_handler)
       assert config.config.metadata == [:request_id, :user_id]
       assert config.config.excluded_domains == [:ranch]
+    end
+
+    test "re-freezes the handler's structured-logs config when restarted while already registered" do
+      restart_sentry_with(
+        dsn: "https://public@sentry.example.com/1",
+        enable_logs: true,
+        logs: [level: :info, excluded_domains: [:cowboy], metadata: [:request_id]]
+      )
+
+      assert {:ok, config} = :logger.get_handler_config(:sentry_log_handler)
+      assert config.config.logs_level == :info
+      assert config.config.logs_excluded_domains == [:cowboy]
+      assert config.config.logs_metadata == [:request_id]
+
+      # Restart WITHOUT removing the handler first. The handler survives the stop, so the
+      # start path must re-sync (re-freeze) the LogsBackend's frozen options to the new
+      # config rather than leaving the stale ones in place.
+      restart_sentry_with(
+        dsn: "https://public@sentry.example.com/1",
+        enable_logs: true,
+        logs: [level: :warning, excluded_domains: [:ranch], metadata: :all]
+      )
+
+      assert {:ok, config} = :logger.get_handler_config(:sentry_log_handler)
+      assert config.config.logs_level == :warning
+      assert config.config.logs_excluded_domains == [:ranch]
+      assert config.config.logs_metadata == :all
     end
 
     test "does not attach handler when enable_logs is false" do

--- a/test/sentry/application_test.exs
+++ b/test/sentry/application_test.exs
@@ -22,12 +22,10 @@ defmodule Sentry.ApplicationTest do
       assert Sentry.Config.logs_metadata() == []
 
       assert handler.config.capture_log_messages == false
-      assert handler.config.level == :error
-      assert handler.config.metadata == []
-      assert handler.config.excluded_domains == [:cowboy, :bandit]
+      assert handler.config.capture_level == :error
+      assert handler.config.capture_metadata == []
+      assert handler.config.capture_excluded_domains == [:cowboy, :bandit]
 
-      # The logs feature settings are frozen from the global :logs config into
-      # the handler config struct used by LogsBackend.
       assert handler.config.logs_level == :info
       assert handler.config.logs_excluded_domains == []
       assert handler.config.logs_metadata == []
@@ -42,7 +40,7 @@ defmodule Sentry.ApplicationTest do
 
       assert {:ok, handler} = :logger.get_handler_config(:sentry_log_handler)
       assert handler.config.capture_log_messages == true
-      assert handler.config.level == :warning
+      assert handler.config.capture_level == :warning
     end
 
     test "respects logs.level config" do
@@ -66,11 +64,9 @@ defmodule Sentry.ApplicationTest do
 
       assert {:ok, handler} = :logger.get_handler_config(:sentry_log_handler)
       assert Sentry.Config.logs_excluded_domains() == [:cowboy, :ranch]
-
       # :excluded_domains is for the logs feature; captured Sentry event exclusions are
       # governed by the separate :capture_excluded_domains option.
-      assert handler.config.excluded_domains == [:cowboy, :bandit]
-      # The logs feature exclusions are frozen into the handler config for LogsBackend.
+      assert handler.config.capture_excluded_domains == [:cowboy, :bandit]
       assert handler.config.logs_excluded_domains == [:cowboy, :ranch]
     end
 
@@ -82,7 +78,7 @@ defmodule Sentry.ApplicationTest do
       )
 
       assert {:ok, handler} = :logger.get_handler_config(:sentry_log_handler)
-      assert handler.config.excluded_domains == [:cowboy, :ranch]
+      assert handler.config.capture_excluded_domains == [:cowboy, :ranch]
     end
 
     test "respects logs.metadata config" do
@@ -94,11 +90,9 @@ defmodule Sentry.ApplicationTest do
 
       assert {:ok, handler} = :logger.get_handler_config(:sentry_log_handler)
       assert Sentry.Config.logs_metadata() == [:request_id, :user_id]
-
       # :metadata is for the logs feature; it must not leak into captured event metadata,
       # which is governed by the separate :capture_metadata option.
-      assert handler.config.metadata == []
-      # The logs feature metadata selection is set in the handler config for LogsBackend.
+      assert handler.config.capture_metadata == []
       assert handler.config.logs_metadata == [:request_id, :user_id]
     end
 
@@ -110,58 +104,49 @@ defmodule Sentry.ApplicationTest do
       )
 
       assert {:ok, handler} = :logger.get_handler_config(:sentry_log_handler)
-      assert handler.config.metadata == [:request_id, :user_id]
+      assert handler.config.capture_metadata == [:request_id, :user_id]
     end
 
     test "re-syncs the handler's capture config when restarted while already registered" do
       restart_sentry_with(
         dsn: "https://public@sentry.example.com/1",
         enable_logs: true,
-        logs: [capture_metadata: [:request_id], capture_excluded_domains: [:cowboy]]
-      )
-
-      assert {:ok, handler} = :logger.get_handler_config(:sentry_log_handler)
-      assert handler.config.metadata == [:request_id]
-      assert handler.config.excluded_domains == [:cowboy]
-
-      # Restart again WITHOUT removing the handler first. The handler survives the stop, so
-      # the start path must re-sync the event-capture backend's frozen options to the new config.
-      restart_sentry_with(
-        dsn: "https://public@sentry.example.com/1",
-        enable_logs: true,
-        logs: [capture_metadata: [:request_id, :user_id], capture_excluded_domains: [:ranch]]
-      )
-
-      assert {:ok, handler} = :logger.get_handler_config(:sentry_log_handler)
-      assert handler.config.metadata == [:request_id, :user_id]
-      assert handler.config.excluded_domains == [:ranch]
-    end
-
-    test "re-freezes the handler's structured-logs config when restarted while already registered" do
-      restart_sentry_with(
-        dsn: "https://public@sentry.example.com/1",
-        enable_logs: true,
-        logs: [level: :info, excluded_domains: [:cowboy], metadata: [:request_id]]
+        logs: [
+          level: :info,
+          excluded_domains: [:cowboy],
+          metadata: [:trace_id],
+          capture_metadata: [:request_id],
+          capture_excluded_domains: [:cowboy]
+        ]
       )
 
       assert {:ok, handler} = :logger.get_handler_config(:sentry_log_handler)
       assert handler.config.logs_level == :info
       assert handler.config.logs_excluded_domains == [:cowboy]
-      assert handler.config.logs_metadata == [:request_id]
+      assert handler.config.logs_metadata == [:trace_id]
+      assert handler.config.capture_metadata == [:request_id]
+      assert handler.config.capture_excluded_domains == [:cowboy]
 
-      # Restart WITHOUT removing the handler first. The handler survives the stop, so the
-      # start path must re-sync (re-freeze) the LogsBackend's frozen options to the new
-      # config rather than leaving the stale ones in place.
+      # Restart again WITHOUT removing the handler first. The handler survives the stop, so
+      # the start path must re-sync the handler's frozen options to the new config.
       restart_sentry_with(
         dsn: "https://public@sentry.example.com/1",
         enable_logs: true,
-        logs: [level: :warning, excluded_domains: [:ranch], metadata: :all]
+        logs: [
+          level: :warning,
+          excluded_domains: [:ranch],
+          metadata: :all,
+          capture_metadata: [:request_id, :user_id],
+          capture_excluded_domains: [:ranch]
+        ]
       )
 
       assert {:ok, handler} = :logger.get_handler_config(:sentry_log_handler)
       assert handler.config.logs_level == :warning
       assert handler.config.logs_excluded_domains == [:ranch]
       assert handler.config.logs_metadata == :all
+      assert handler.config.capture_metadata == [:request_id, :user_id]
+      assert handler.config.capture_excluded_domains == [:ranch]
     end
 
     test "does not attach handler when enable_logs is false" do

--- a/test/sentry/logger_handler/logs_test.exs
+++ b/test/sentry/logger_handler/logs_test.exs
@@ -33,8 +33,8 @@ defmodule Sentry.LoggerHandler.LogsTest do
       assert is_number(log.timestamp)
     end
 
-    test "filters logs below configured level" do
-      put_test_config(logs: [level: :warning])
+    test "filters logs below configured level", %{handler_name: handler_name} do
+      reconfigure_logs_handler(handler_name, level: :warning)
 
       initial_size = TelemetryProcessor.buffer_size(:log)
 
@@ -56,8 +56,8 @@ defmodule Sentry.LoggerHandler.LogsTest do
       assert_sentry_log(:error, "Error message")
     end
 
-    test "filters excluded domains" do
-      put_test_config(logs: [excluded_domains: [:cowboy]])
+    test "filters excluded domains", %{handler_name: handler_name} do
+      reconfigure_logs_handler(handler_name, excluded_domains: [:cowboy])
 
       initial_size = TelemetryProcessor.buffer_size(:log)
 
@@ -68,8 +68,8 @@ defmodule Sentry.LoggerHandler.LogsTest do
       assert TelemetryProcessor.buffer_size(:log) == initial_size
     end
 
-    test "includes logs from non-excluded domains" do
-      put_test_config(logs: [excluded_domains: [:cowboy]])
+    test "includes logs from non-excluded domains", %{handler_name: handler_name} do
+      reconfigure_logs_handler(handler_name, excluded_domains: [:cowboy])
 
       initial_size = TelemetryProcessor.buffer_size(:log)
 
@@ -79,8 +79,8 @@ defmodule Sentry.LoggerHandler.LogsTest do
       assert_buffer_size(nil, initial_size + 2)
     end
 
-    test "includes metadata as attributes" do
-      put_test_config(logs: [metadata: [:request_id, :user_id]])
+    test "includes metadata as attributes", %{handler_name: handler_name} do
+      reconfigure_logs_handler(handler_name, metadata: [:request_id, :user_id])
 
       Logger.metadata(request_id: "abc123", user_id: 42, other_meta: "should not be included")
       Logger.info("Request processed")
@@ -93,8 +93,8 @@ defmodule Sentry.LoggerHandler.LogsTest do
       refute Map.has_key?(log.attributes, :other_meta)
     end
 
-    test "safely serializes struct metadata as string attributes" do
-      put_test_config(logs: [metadata: [:my_uri]])
+    test "safely serializes struct metadata as string attributes", %{handler_name: handler_name} do
+      reconfigure_logs_handler(handler_name, metadata: [:my_uri])
 
       uri = URI.parse("https://example.com/path")
       Logger.metadata(my_uri: uri)
@@ -106,8 +106,8 @@ defmodule Sentry.LoggerHandler.LogsTest do
       assert log.attributes[:my_uri] == uri
     end
 
-    test "includes all metadata when configured with :all" do
-      put_test_config(logs: [metadata: :all])
+    test "includes all metadata when configured with :all", %{handler_name: handler_name} do
+      reconfigure_logs_handler(handler_name, metadata: :all)
 
       Logger.metadata(request_id: "abc123", user_id: 42, custom_field: "value")
       Logger.info("Request with metadata")
@@ -115,6 +115,41 @@ defmodule Sentry.LoggerHandler.LogsTest do
       assert_sentry_log(:info, "Request with metadata",
         attributes: %{request_id: "abc123", user_id: 42, custom_field: "value"}
       )
+    end
+
+    test "freezes structured-logs config at setup and ignores later config changes" do
+      # The handler was attached in setup with logs level :info. Raising the level
+      # afterwards must NOT affect the already-attached handler, because the logs
+      # settings are frozen into the handler config when it is set up.
+      put_test_config(logs: [level: :error])
+
+      Logger.info("Frozen info message")
+
+      assert_sentry_log(:info, "Frozen info message")
+    end
+
+    test "reconfiguring the handler through its own mechanism picks up new logs settings",
+         %{handler_name: handler_name} do
+      # The handler was attached in setup at logs level :info. Reconfiguring it through
+      # the handler's own OTP mechanism re-freezes the logs settings from the current
+      # global config, so a subsequently raised level takes effect on this same handler
+      # (unlike a bare put_test_config, which the frozen config ignores).
+      assert {:ok, %{config: config}} = :logger.get_handler_config(handler_name)
+
+      put_test_config(logs: [level: :warning])
+      assert :ok = :logger.update_handler_config(handler_name, :config, config)
+
+      initial_size = TelemetryProcessor.buffer_size(:log)
+
+      # Below the new level: now filtered by the reconfigured handler.
+      Logger.info("Info message should now be filtered")
+      wait_for_buffer_stable(nil, initial_size)
+      assert TelemetryProcessor.buffer_size(:log) == initial_size
+
+      # At or above the new level: still captured, confirming the handler picked up
+      # the new settings rather than being disabled.
+      Logger.warning("Warning message should be captured")
+      assert_sentry_log(:warn, "Warning message should be captured")
     end
 
     test "does not send logs when enable_logs is false at handler setup time", %{
@@ -511,6 +546,25 @@ defmodule Sentry.LoggerHandler.LogsTest do
     end)
 
     %{handler_name: handler_name}
+  end
+
+  # The structured-logs settings (level, excluded_domains, metadata) are frozen into
+  # the handler config when the handler is set up, so changing the :logs config after
+  # the handler is attached has no effect. To exercise a different logs configuration,
+  # tests remove the handler added in setup, set the desired :logs config, and attach a
+  # fresh handler that snapshots it.
+  defp reconfigure_logs_handler(handler_name, logs_config) do
+    :ok = :logger.remove_handler(handler_name)
+
+    put_test_config(logs: logs_config)
+
+    new_handler_name = :"sentry_logs_handler_#{System.unique_integer([:positive])}"
+
+    assert :ok = :logger.add_handler(new_handler_name, Sentry.LoggerHandler, %{config: %{}})
+
+    on_exit(fn -> _ = :logger.remove_handler(new_handler_name) end)
+
+    new_handler_name
   end
 
   defp assert_buffer_size(_buffer, expected_size, timeout \\ 1000) do

--- a/test/sentry/logger_handler/logs_test.exs
+++ b/test/sentry/logger_handler/logs_test.exs
@@ -131,13 +131,16 @@ defmodule Sentry.LoggerHandler.LogsTest do
     test "reconfiguring the handler through its own mechanism picks up new logs settings",
          %{handler_name: handler_name} do
       # The handler was attached in setup at logs level :info. Reconfiguring it through
-      # the handler's own OTP mechanism re-freezes the logs settings from the current
-      # global config, so a subsequently raised level takes effect on this same handler
-      # (unlike a bare put_test_config, which the frozen config ignores).
-      assert {:ok, %{config: config}} = :logger.get_handler_config(handler_name)
+      # the handler's own OTP mechanism with a new config updates the frozen settings.
 
       put_test_config(logs: [level: :warning])
-      assert :ok = :logger.update_handler_config(handler_name, :config, config)
+
+      assert :ok =
+               :logger.update_handler_config(
+                 handler_name,
+                 :config,
+                 handler_config_from_logs()
+               )
 
       initial_size = TelemetryProcessor.buffer_size(:log)
 
@@ -259,7 +262,7 @@ defmodule Sentry.LoggerHandler.LogsTest do
     end
   end
 
-  describe "capturing Logger messages as error events (logs.capture_log_messages)" do
+  describe "capturing Logger messages as Sentry events (logs.capture_log_messages)" do
     setup %{handler_name: handler_name} do
       :ok = :logger.remove_handler(handler_name)
 
@@ -275,11 +278,7 @@ defmodule Sentry.LoggerHandler.LogsTest do
 
       name = :"sentry_capture_handler_#{System.unique_integer([:positive])}"
 
-      handler_config = %{
-        level: Sentry.Config.logs_capture_level(),
-        capture_log_messages: Sentry.Config.logs_capture_log_messages?(),
-        metadata: Sentry.Config.logs_capture_metadata()
-      }
+      handler_config = handler_config_from_logs()
 
       assert :ok = :logger.add_handler(name, Sentry.LoggerHandler, %{config: handler_config})
 
@@ -288,14 +287,14 @@ defmodule Sentry.LoggerHandler.LogsTest do
       %{handler_name: name}
     end
 
-    test "Logger.error is sent as both an error event and a structured log" do
+    test "Logger.error is sent as both a captured event and a structured log" do
       Logger.error("boom from logger")
 
       assert_sentry_report(:event, message: %{formatted: "boom from logger"})
       assert_sentry_log(:error, "boom from logger")
     end
 
-    test "messages below :capture_level are sent as logs but not as error events" do
+    test "messages below :capture_level are sent as logs but not as captured events" do
       Logger.info("just an info line")
       Logger.warning("a warning line")
 
@@ -305,26 +304,26 @@ defmodule Sentry.LoggerHandler.LogsTest do
       assert SentryTest.pop_sentry_reports() == []
     end
 
-    test "structured log keyword data is reported as an error event too" do
+    test "structured log keyword data is reported as a captured event too" do
       Logger.error(some: "structured", value: 42)
 
       event = assert_sentry_report(:event, [])
       assert event.message.formatted =~ "structured"
     end
 
-    test "includes custom Logger metadata in the captured error event" do
+    test "includes custom Logger metadata in the captured event" do
       Logger.error("Hello Buggy Bug", some_info: "boom!")
 
       event = assert_sentry_report(:event, message: %{formatted: "Hello Buggy Bug"})
       assert event.extra.logger_metadata.some_info == "boom!"
     end
 
-    test "logs.metadata feeds the Logs UI but not error events (capture_metadata governs that)",
+    test "logs.metadata feeds the logs feature but not captured events (capture_metadata governs that)",
          %{handler_name: handler_name} do
       :ok = :logger.remove_handler(handler_name)
 
-      # Metadata is configured for the Logs UI, but capture_metadata is left at its
-      # default ([]), so error events must not include the metadata.
+      # Metadata is configured for the logs feature, but capture_metadata is left at its
+      # default ([]), so captured events must not include the metadata.
       put_test_config(
         logs: [
           level: :info,
@@ -337,11 +336,7 @@ defmodule Sentry.LoggerHandler.LogsTest do
 
       name = :"sentry_no_capture_meta_#{System.unique_integer([:positive])}"
 
-      handler_config = %{
-        level: Sentry.Config.logs_capture_level(),
-        capture_log_messages: Sentry.Config.logs_capture_log_messages?(),
-        metadata: Sentry.Config.logs_capture_metadata()
-      }
+      handler_config = handler_config_from_logs()
 
       assert :ok = :logger.add_handler(name, Sentry.LoggerHandler, %{config: handler_config})
       on_exit(fn -> _ = :logger.remove_handler(name) end)
@@ -356,11 +351,11 @@ defmodule Sentry.LoggerHandler.LogsTest do
       assert log.attributes[:secret_info] == "hidden"
     end
 
-    test "capture_excluded_domains drops error events but keeps the structured log",
+    test "capture_excluded_domains drops captured events but keeps the structured log",
          %{handler_name: handler_name} do
       :ok = :logger.remove_handler(handler_name)
 
-      # The domain is excluded from error events but not from the Logs UI.
+      # The domain is excluded from captured events but not from the logs feature.
       put_test_config(
         logs: [
           level: :info,
@@ -373,20 +368,16 @@ defmodule Sentry.LoggerHandler.LogsTest do
 
       name = :"sentry_excluded_domain_#{System.unique_integer([:positive])}"
 
-      handler_config = %{
-        level: Sentry.Config.logs_capture_level(),
-        capture_log_messages: Sentry.Config.logs_capture_log_messages?(),
-        excluded_domains: Sentry.Config.logs_capture_excluded_domains()
-      }
+      handler_config = handler_config_from_logs()
 
       assert :ok = :logger.add_handler(name, Sentry.LoggerHandler, %{config: handler_config})
       on_exit(fn -> _ = :logger.remove_handler(name) end)
 
       Logger.error("error from excluded domain", domain: [:myapp])
 
-      # The structured log is still captured (Logs UI :excluded_domains is []).
+      # The structured log is still captured (logs feature :excluded_domains is []).
       assert_sentry_log(:error, "error from excluded domain")
-      # But no error event, because the domain is in :capture_excluded_domains.
+      # But no captured event, because the domain is in :capture_excluded_domains.
       assert SentryTest.pop_sentry_reports() == []
     end
   end
@@ -537,7 +528,7 @@ defmodule Sentry.LoggerHandler.LogsTest do
   defp add_logs_handler(_context) do
     handler_name = :"sentry_logs_handler_#{System.unique_integer([:positive])}"
 
-    handler_config = %{config: %{}}
+    handler_config = %{config: handler_config_from_logs()}
 
     assert :ok = :logger.add_handler(handler_name, Sentry.LoggerHandler, handler_config)
 
@@ -552,7 +543,7 @@ defmodule Sentry.LoggerHandler.LogsTest do
   # the handler config when the handler is set up, so changing the :logs config after
   # the handler is attached has no effect. To exercise a different logs configuration,
   # tests remove the handler added in setup, set the desired :logs config, and attach a
-  # fresh handler that snapshots it.
+  # fresh handler with that config.
   defp reconfigure_logs_handler(handler_name, logs_config) do
     :ok = :logger.remove_handler(handler_name)
 
@@ -560,11 +551,29 @@ defmodule Sentry.LoggerHandler.LogsTest do
 
     new_handler_name = :"sentry_logs_handler_#{System.unique_integer([:positive])}"
 
-    assert :ok = :logger.add_handler(new_handler_name, Sentry.LoggerHandler, %{config: %{}})
+    assert :ok =
+             :logger.add_handler(new_handler_name, Sentry.LoggerHandler, %{
+               config: handler_config_from_logs()
+             })
 
     on_exit(fn -> _ = :logger.remove_handler(new_handler_name) end)
 
     new_handler_name
+  end
+
+  defp handler_config_from_logs do
+    logs = Sentry.Config.logs()
+
+    [
+      enable_logs: true,
+      capture_log_messages: Keyword.fetch!(logs, :capture_log_messages),
+      capture_level: Keyword.fetch!(logs, :capture_level),
+      capture_metadata: Keyword.fetch!(logs, :capture_metadata),
+      capture_excluded_domains: Keyword.fetch!(logs, :capture_excluded_domains),
+      logs_level: Keyword.fetch!(logs, :level),
+      logs_metadata: Keyword.fetch!(logs, :metadata),
+      logs_excluded_domains: Keyword.fetch!(logs, :excluded_domains)
+    ]
   end
 
   defp assert_buffer_size(_buffer, expected_size, timeout \\ 1000) do

--- a/test/sentry/logger_handler_test.exs
+++ b/test/sentry/logger_handler_test.exs
@@ -36,13 +36,25 @@ defmodule Sentry.LoggerHandlerTest do
     Logger.warning("Warning message")
 
     # Change the level to :info and make sure that :debug messages are not reported.
-    assert :ok = :logger.update_handler_config(handler_name, :level, :info)
+    assert :ok = :logger.update_handler_config(handler_name, :capture_level, :info)
 
     on_exit(fn ->
-      :logger.update_handler_config(handler_name, :level, :error)
+      :logger.update_handler_config(handler_name, :capture_level, :error)
     end)
 
     Logger.debug("Debug message")
+  end
+
+  @tag handler_config: %{
+         level: :warning,
+         excluded_domains: [:test_domain],
+         metadata: [:request_id]
+       }
+  test "accepts legacy capture option names", %{handler_name: handler_name} do
+    assert {:ok, %{config: config}} = :logger.get_handler_config(handler_name)
+    assert config.capture_level == :warning
+    assert config.capture_excluded_domains == [:test_domain]
+    assert config.capture_metadata == [:request_id]
   end
 
   test "a logged raised exception is reported", %{sender_ref: ref} do
@@ -74,7 +86,7 @@ defmodule Sentry.LoggerHandlerTest do
   describe "with Plug" do
     if System.otp_release() < "26", do: @describetag(:skip)
 
-    @tag handler_config: %{excluded_domains: []}
+    @tag handler_config: %{capture_excluded_domains: []}
     test "captures errors from spawn/0 in Plug app", %{sender_ref: ref} do
       :get
       |> Plug.Test.conn("/spawn_error_route")
@@ -96,7 +108,7 @@ defmodule Sentry.LoggerHandlerTest do
       assert event.original_exception == %RuntimeError{message: "Error"}
     end
 
-    @tag handler_config: %{excluded_domains: []}
+    @tag handler_config: %{capture_excluded_domains: []}
     test "sends two errors when a Plug process crashes if cowboy domain is not excluded",
          %{sender_ref: ref} do
       start_supervised!(Sentry.ExamplePlugApplication, restart: :temporary)
@@ -111,7 +123,7 @@ defmodule Sentry.LoggerHandlerTest do
       assert second_event.original_exception == %RuntimeError{message: "Error"}
     end
 
-    @tag handler_config: %{excluded_domains: []}
+    @tag handler_config: %{capture_excluded_domains: []}
     test "sends two errors when a Plug process crashes if PlugCapture is used and :bandit not excluded",
          %{sender_ref: ref} do
       start_supervised!({Sentry.ExamplePlugApplication, server: :bandit}, restart: :temporary)
@@ -209,8 +221,8 @@ defmodule Sentry.LoggerHandlerTest do
       refute_received {^ref, _event}, 100
     end
 
-    @tag handler_config: %{capture_log_messages: true, level: :warning}
-    test "respects the configured :level", %{sender_ref: ref} do
+    @tag handler_config: %{capture_log_messages: true, capture_level: :warning}
+    test "respects the configured :capture_level", %{sender_ref: ref} do
       Logger.log(:warning, "Testing warning")
       Logger.log(:info, "Testing info")
 
@@ -232,7 +244,7 @@ defmodule Sentry.LoggerHandlerTest do
       assert event.message.formatted == "Error"
     end
 
-    @tag handler_config: %{capture_log_messages: true, excluded_domains: [:test_domain]}
+    @tag handler_config: %{capture_log_messages: true, capture_excluded_domains: [:test_domain]}
     test "ignores log messages with excluded domains", %{sender_ref: ref} do
       Logger.error("no domain")
       Logger.error("test_domain", domain: [:test_domain])
@@ -377,7 +389,7 @@ defmodule Sentry.LoggerHandlerTest do
       assert Enum.find(stacktrace.frames, &(&1.function == "GenServer.call/3"))
     end
 
-    @tag handler_config: %{metadata: [:string, :number, :map, :list, :chardata]}
+    @tag handler_config: %{capture_metadata: [:string, :number, :map, :list, :chardata]}
     test "includes Logger metadata for keys configured to be included",
          %{sender_ref: ref, test_genserver: test_genserver} do
       run_and_catch_exit(test_genserver, fn ->
@@ -400,7 +412,7 @@ defmodule Sentry.LoggerHandlerTest do
       assert event.extra.logger_metadata.chardata == "π's unicode is π"
     end
 
-    @tag handler_config: %{metadata: []}
+    @tag handler_config: %{capture_metadata: []}
     test "does not include Logger metadata when disabled",
          %{sender_ref: ref, test_genserver: test_genserver} do
       run_and_catch_exit(test_genserver, fn ->
@@ -418,7 +430,7 @@ defmodule Sentry.LoggerHandlerTest do
       assert event.extra.logger_metadata == %{}
     end
 
-    @tag handler_config: %{metadata: :all}
+    @tag handler_config: %{capture_metadata: :all}
     test "supports :all for Logger metadata", %{sender_ref: ref, test_genserver: test_genserver} do
       run_and_catch_exit(test_genserver, fn ->
         Logger.metadata(my_string: "some string")

--- a/test_integrations/phoenix_app/config/test.exs
+++ b/test_integrations/phoenix_app/config/test.exs
@@ -44,7 +44,7 @@ config :sentry,
   logs: [
     level: :info,
     excluded_domains: [:cowboy, :ranch],
-    metadata: [:request_id, :user_id]
+    metadata: :all
   ]
 
 config :opentelemetry, span_processor: {Sentry.OpenTelemetry.SpanProcessor, []}

--- a/test_integrations/phoenix_app/test/phoenix_app_web/controllers/logs_test.exs
+++ b/test_integrations/phoenix_app/test/phoenix_app_web/controllers/logs_test.exs
@@ -2,7 +2,6 @@ defmodule Sentry.Integrations.Phoenix.LogsTest do
   use PhoenixAppWeb.ConnCase, async: false
 
   import Sentry.Test.Assertions
-  import Sentry.TestHelpers, only: [put_test_config: 1]
 
   setup do
     original_level = Logger.level()
@@ -85,8 +84,6 @@ defmodule Sentry.Integrations.Phoenix.LogsTest do
 
   describe "structured logging with complex metadata" do
     test "GET /logs-with-structs captures struct attributes", %{conn: conn} do
-      put_test_config(logs: [level: :info, excluded_domains: [:cowboy, :ranch], metadata: :all])
-
       get(conn, ~p"/logs-with-structs")
 
       log = assert_sentry_log(:info, "Log with struct metadata")


### PR DESCRIPTION
This is a log-related config handling clean-up:

1. **Decoupled config from logger handler** — logging backends now read from the handler's own config instead of `Sentry.Config`.

2. **Naming cleanup** — consistent use of the `capture_` prefix for the event-capture backend, matching the key names in the actual logs config.

**Context:** The original keys (`level`, `excluded_domains`, `metadata`) are used by the soon-to-be-deprecated `Sentry.LoggerBackend` and by the new `Sentry.LoggerHandler`'s capture path. After introducing the logs feature, they became ambiguous. That's why we now have a dedicated `logs` config namespace for the logs feature which includes log capturing feature, with distinctly named keys.