### PR TITLE
fix(logs): default to Config.enable_logs? if handler config does not specify it

### DIFF
--- a/lib/sentry/application.ex
+++ b/lib/sentry/application.ex
@@ -171,7 +171,6 @@ defmodule Sentry.Application do
 
   defp logger_handler_config(logs) do
     [
-      enable_logs: true,
       capture_log_messages: Keyword.fetch!(logs, :capture_log_messages),
       capture_level: Keyword.fetch!(logs, :capture_level),
       capture_metadata: Keyword.fetch!(logs, :capture_metadata),

--- a/lib/sentry/logger_handler.ex
+++ b/lib/sentry/logger_handler.ex
@@ -353,6 +353,7 @@ defmodule Sentry.LoggerHandler do
 
   @moduledoc since: "9.0.0"
 
+  alias Sentry.Config
   alias Sentry.LoggerHandler.{ErrorBackend, LogsBackend, RateLimiter}
 
   # The config for this logger handler.
@@ -386,7 +387,14 @@ defmodule Sentry.LoggerHandler do
 
     handler_config = cast_config(%__MODULE__{}, sentry_config)
 
-    enable_logs? = handler_config.enable_logs == true
+    # A handler-level :enable_logs takes precedence; when it's not set (nil), fall
+    # back to the global config so a manually-added handler still forwards structured
+    # logs when logs are enabled globally. This runs once at attach time, not per log.
+    enable_logs? =
+      case handler_config.enable_logs do
+        nil -> Config.enable_logs?()
+        bool -> bool
+      end
 
     backends = [ErrorBackend] ++ if enable_logs?, do: [LogsBackend], else: []
     handler_config = %{handler_config | backends: backends}

--- a/lib/sentry/logger_handler.ex
+++ b/lib/sentry/logger_handler.ex
@@ -387,17 +387,7 @@ defmodule Sentry.LoggerHandler do
 
     handler_config = cast_config(%__MODULE__{}, sentry_config)
 
-    # A handler-level :enable_logs takes precedence; when it's not set (nil), fall
-    # back to the global config so a manually-added handler still forwards structured
-    # logs when logs are enabled globally. This runs once at attach time, not per log.
-    enable_logs? =
-      case handler_config.enable_logs do
-        nil -> Config.enable_logs?()
-        bool -> bool
-      end
-
-    backends = [ErrorBackend] ++ if enable_logs?, do: [LogsBackend], else: []
-    handler_config = %{handler_config | backends: backends}
+    handler_config = put_backends(handler_config)
 
     config = Map.put(config, :config, handler_config)
 
@@ -441,7 +431,11 @@ defmodule Sentry.LoggerHandler do
 
     updated_config =
       old_config
-      |> update_in([:config], &cast_config(&1, new_sentry_config))
+      |> update_in([:config], fn config ->
+        config
+        |> cast_config(new_sentry_config)
+        |> put_backends()
+      end)
 
     _ignored =
       cond do
@@ -543,4 +537,13 @@ defmodule Sentry.LoggerHandler do
     validated_config
     |> Keyword.drop([:level, :excluded_domains, :metadata])
   end
+
+  defp put_backends(%__MODULE__{} = config) do
+    backends = [ErrorBackend] ++ if enable_logs?(config), do: [LogsBackend], else: []
+
+    %{config | backends: backends}
+  end
+
+  defp enable_logs?(%__MODULE__{enable_logs: nil}), do: Config.enable_logs?()
+  defp enable_logs?(%__MODULE__{enable_logs: enable_logs?}), do: enable_logs?
 end

--- a/test/sentry/logger_handler/logs_test.exs
+++ b/test/sentry/logger_handler/logs_test.exs
@@ -235,6 +235,43 @@ defmodule Sentry.LoggerHandler.LogsTest do
       assert_sentry_log(:info, "Inherited enable_logs message")
     end
 
+    test "runtime handler config update disables structured logs", %{handler_name: handler_name} do
+      assert :ok =
+               :logger.update_handler_config(handler_name, :config, %{enable_logs: false})
+
+      initial_size = TelemetryProcessor.buffer_size(:log)
+
+      Logger.info("Runtime disabled message")
+
+      wait_for_buffer_stable(nil, initial_size)
+      assert TelemetryProcessor.buffer_size(:log) == initial_size
+    end
+
+    test "runtime handler config update enables structured logs", %{handler_name: handler_name} do
+      :ok = :logger.remove_handler(handler_name)
+
+      disabled_handler_name =
+        :"sentry_logs_handler_runtime_enable_#{System.unique_integer([:positive])}"
+
+      put_test_config(enable_logs: false)
+
+      assert :ok =
+               :logger.add_handler(disabled_handler_name, Sentry.LoggerHandler, %{
+                 config: %{enable_logs: false}
+               })
+
+      on_exit(fn -> _ = :logger.remove_handler(disabled_handler_name) end)
+
+      assert :ok =
+               :logger.update_handler_config(disabled_handler_name, :config, %{
+                 enable_logs: true
+               })
+
+      Logger.info("Runtime enabled message")
+
+      assert_sentry_log(:info, "Runtime enabled message")
+    end
+
     test "rejects non-boolean :enable_logs in handler config", %{handler_name: handler_name} do
       :ok = :logger.remove_handler(handler_name)
 

--- a/test/sentry/logger_handler/logs_test.exs
+++ b/test/sentry/logger_handler/logs_test.exs
@@ -215,6 +215,26 @@ defmodule Sentry.LoggerHandler.LogsTest do
       assert TelemetryProcessor.buffer_size(:log) == initial_size
     end
 
+    test "manually-added handler with no enable_logs inherits global enable_logs: true", %{
+      handler_name: handler_name
+    } do
+      :ok = :logger.remove_handler(handler_name)
+
+      inherit_handler_name =
+        :"sentry_logs_handler_inherit_#{System.unique_integer([:positive])}"
+
+      put_test_config(enable_logs: true)
+
+      assert :ok =
+               :logger.add_handler(inherit_handler_name, Sentry.LoggerHandler, %{config: %{}})
+
+      on_exit(fn -> _ = :logger.remove_handler(inherit_handler_name) end)
+
+      Logger.info("Inherited enable_logs message")
+
+      assert_sentry_log(:info, "Inherited enable_logs message")
+    end
+
     test "rejects non-boolean :enable_logs in handler config", %{handler_name: handler_name} do
       :ok = :logger.remove_handler(handler_name)
 


### PR DESCRIPTION
So, actually, PR #1103 made a change that would break enabled logs IF the user manually configures a handler and omits the `enable_logs` key, so we gotta fill that in using global `Config.enable_logs?`.