### PR TITLE
fix(tests): address warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -72,11 +72,31 @@ defmodule Sentry.Mixfile do
     if Version.match?(System.version(), ">= 1.20.0") do
       [
         elixirc_options: [
-          no_warn_undefined: [Finch, :hackney, :hackney_pool, Plug.Conn, :telemetry]
+          no_warn_undefined: [
+            Finch,
+            :hackney,
+            :hackney_pool,
+            Plug.Conn,
+            :telemetry,
+            :otel_tracer,
+            :otel_span
+          ]
         ]
       ]
     else
-      [xref: [exclude: [Finch, :hackney, :hackney_pool, Plug.Conn, :telemetry]]]
+      [
+        xref: [
+          exclude: [
+            Finch,
+            :hackney,
+            :hackney_pool,
+            Plug.Conn,
+            :telemetry,
+            :otel_tracer,
+            :otel_span
+          ]
+        ]
+      ]
     end
   end
 

--- a/test/sentry/config_test.exs
+++ b/test/sentry/config_test.exs
@@ -428,7 +428,7 @@ defmodule Sentry.ConfigTest do
 
     test "validates the given key" do
       assert_raise ArgumentError, ~r/unknown option :non_existing/, fn ->
-        Config.put_config(:non_existing, "value")
+        Config.put_config(invalid_value(:non_existing), "value")
       end
     end
   end

--- a/test/sentry/live_view_hook_test.exs
+++ b/test/sentry/live_view_hook_test.exs
@@ -271,7 +271,15 @@ defmodule Sentry.LiveViewHookTest do
     assert_raise ArgumentError,
                  ~r/expected :scrubber to be a \{module, function, args\} tuple/,
                  fn ->
-                   Sentry.LiveViewHook.on_mount([scrubber: :not_a_tuple], %{}, %{}, %{})
+                   # The socket is laundered to term() so the type checker does not
+                   # reject the throwaway %{} placeholder; the point of the test is
+                   # the invalid :scrubber option, which is validated at runtime.
+                   Sentry.LiveViewHook.on_mount(
+                     [scrubber: :not_a_tuple],
+                     %{},
+                     %{},
+                     Sentry.TestHelpers.invalid_value(%{})
+                   )
                  end
   end
 

--- a/test/sentry/logger_handler_test.exs
+++ b/test/sentry/logger_handler_test.exs
@@ -144,21 +144,21 @@ defmodule Sentry.LoggerHandlerTest do
     test "doesn't send error messages by default", %{sender_ref: ref} do
       Logger.error("Testing error")
 
-      refute_received {^ref, _event}, 100
+      refute_receive {^ref, _event}, 100
     end
 
     @tag handler_config: %{capture_log_messages: false}
     test "doesn't send structured logs keyword", %{sender_ref: ref} do
       Logger.error(foo: "bar")
 
-      refute_received {^ref, _event}, 100
+      refute_receive {^ref, _event}, 100
     end
 
     @tag handler_config: %{capture_log_messages: false}
     test "doesn't send structured logs map", %{sender_ref: ref} do
       Logger.error(%{foo: "bar"})
 
-      refute_received {^ref, _event}, 100
+      refute_receive {^ref, _event}, 100
     end
 
     @tag handler_config: %{capture_log_messages: false}
@@ -184,7 +184,7 @@ defmodule Sentry.LoggerHandlerTest do
       assert_receive {^ref, event}
       assert event.message.formatted == "Testing error"
 
-      refute_received {^ref, _event}, 100
+      refute_receive {^ref, _event}, 100
     end
 
     @tag handler_config: %{capture_log_messages: true}
@@ -194,7 +194,7 @@ defmodule Sentry.LoggerHandlerTest do
       assert_receive {^ref, event}
       assert event.message.formatted == "[foo: \"bar\"]"
 
-      refute_received {^ref, _event}, 100
+      refute_receive {^ref, _event}, 100
     end
 
     @tag handler_config: %{capture_log_messages: true}
@@ -204,7 +204,7 @@ defmodule Sentry.LoggerHandlerTest do
       assert_receive {^ref, event}
       assert event.message.formatted == "%{foo: \"bar\"}"
 
-      refute_received {^ref, _event}, 100
+      refute_receive {^ref, _event}, 100
     end
 
     defmodule Foo do
@@ -218,7 +218,7 @@ defmodule Sentry.LoggerHandlerTest do
       assert_receive {^ref, event}
       assert event.message.formatted == "%Sentry.LoggerHandlerTest.Foo{bar: nil}"
 
-      refute_received {^ref, _event}, 100
+      refute_receive {^ref, _event}, 100
     end
 
     @tag handler_config: %{capture_log_messages: true, capture_level: :warning}

--- a/test/sentry/opentelemetry/span_processor_test.exs
+++ b/test/sentry/opentelemetry/span_processor_test.exs
@@ -2,11 +2,11 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
   use Sentry.Case, async: false
 
   require OpenTelemetry.Tracer, as: Tracer
-  require OpenTelemetry.SemConv.Incubating.HTTPAttributes, as: HTTPAttributes
-  require OpenTelemetry.SemConv.Incubating.URLAttributes, as: URLAttributes
-  require OpenTelemetry.SemConv.Incubating.DBAttributes, as: DBAttributes
-  require OpenTelemetry.SemConv.ClientAttributes, as: ClientAttributes
-  require OpenTelemetry.SemConv.Incubating.MessagingAttributes, as: MessagingAttributes
+  alias OpenTelemetry.SemConv.Incubating.HTTPAttributes, as: HTTPAttributes
+  alias OpenTelemetry.SemConv.Incubating.URLAttributes, as: URLAttributes
+  alias OpenTelemetry.SemConv.Incubating.DBAttributes, as: DBAttributes
+  alias OpenTelemetry.SemConv.ClientAttributes, as: ClientAttributes
+  alias OpenTelemetry.SemConv.Incubating.MessagingAttributes, as: MessagingAttributes
 
   import Sentry.Test.Assertions
   import Sentry.TestHelpers

--- a/test/sentry/scrubber_test.exs
+++ b/test/sentry/scrubber_test.exs
@@ -526,7 +526,7 @@ defmodule Sentry.ScrubberTest do
 
     test "validates the opts shape on put" do
       assert_raise FunctionClauseError, fn ->
-        Scrubber.put_conn_scrubber({"not", "an", "mfa"})
+        Scrubber.put_conn_scrubber(Sentry.TestHelpers.invalid_value({"not", "an", "mfa"}))
       end
     end
   end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -34,6 +34,19 @@ defmodule Sentry.TestHelpers do
     Enum.sort(for {{:sentry_config, key}, value} <- :persistent_term.get(), do: {key, value})
   end
 
+  @doc """
+  Returns `value` unchanged, but typed as `term()`.
+
+  Negative tests that intentionally pass an invalid value to a function (to
+  exercise its runtime validation) otherwise trip the Elixir 1.20 type
+  checker, which narrows the literal argument and reports an "incompatible
+  types" warning. Routing the deliberately-wrong value through this function
+  presents a `term()` to the checker while still feeding the bad value at
+  runtime, so the test keeps asserting the expected failure.
+  """
+  @spec invalid_value(term()) :: term()
+  def invalid_value(value), do: value
+
   def create_span(attrs \\ %{}) do
     Map.merge(
       %Span{

--- a/test_integrations/phoenix_app/test/phoenix_app/repo_test.exs
+++ b/test_integrations/phoenix_app/test/phoenix_app/repo_test.exs
@@ -3,7 +3,6 @@ defmodule PhoenixApp.RepoTest do
 
   alias PhoenixApp.{Repo, Accounts.User}
 
-  import Sentry.TestHelpers
   import Sentry.Test.Assertions
 
   setup do

--- a/test_integrations/phoenix_app/test/phoenix_app_web/live/user_live_test.exs
+++ b/test_integrations/phoenix_app/test/phoenix_app_web/live/user_live_test.exs
@@ -1,7 +1,6 @@
 defmodule PhoenixAppWeb.UserLiveTest do
   use PhoenixAppWeb.ConnCase, async: false
 
-  import Sentry.TestHelpers
   import Sentry.Test.Assertions
   import Phoenix.LiveViewTest
   import PhoenixApp.AccountsFixtures


### PR DESCRIPTION
This addresses most of the warnings that started showing up under `1.20.x`. Remaining two warnings will be addressed in separate PRs.

---

#skip-changelog