### PR TITLE
fix: use LoggerUtils for diagnostics

### DIFF
--- a/lib/sentry.ex
+++ b/lib/sentry.ex
@@ -195,8 +195,6 @@ defmodule Sentry do
     TelemetryProcessor
   }
 
-  require Logger
-
   @typedoc """
   A callback to use with the `:before_send` configuration option.
   configuration options.k
@@ -530,11 +528,11 @@ defmodule Sentry do
       TelemetryProcessor.flush(TelemetryProcessor.default_name(), timeout)
     catch
       :exit, {:noproc, _} ->
-        Logger.warning("Sentry.flush/1 failed: TelemetryProcessor not running")
+        LoggerUtils.warning("Sentry.flush/1 failed: TelemetryProcessor not running")
         :ok
 
       :exit, reason ->
-        Logger.warning("Sentry.flush/1 failed unexpectedly: #{inspect(reason)}")
+        LoggerUtils.warning("Sentry.flush/1 failed unexpectedly: #{inspect(reason)}")
         :ok
     end
   end

--- a/lib/sentry/application.ex
+++ b/lib/sentry/application.ex
@@ -3,9 +3,8 @@ defmodule Sentry.Application do
 
   use Application
 
-  require Logger
-
   alias Sentry.Config
+  alias Sentry.LoggerUtils
 
   @compile {:no_warn_undefined, [NimbleOwnership]}
 
@@ -159,7 +158,7 @@ defmodule Sentry.Application do
               :ok
 
             {:error, reason} ->
-              Logger.warning("[Sentry] Failed to add logger handler: #{inspect(reason)}")
+              LoggerUtils.warning("[Sentry] Failed to add logger handler: #{inspect(reason)}")
           end
       end
     else

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -1287,9 +1287,7 @@ defmodule Sentry.Config do
 
     if not is_nil(traces_sample_rate) and
          not Sentry.OpenTelemetry.VersionChecker.tracing_compatible?() do
-      require Logger
-
-      Logger.warning("""
+      Sentry.LoggerUtils.warning("""
       Sentry tracing is configured with traces_sample_rate: #{inspect(traces_sample_rate)}, \
       but the required OpenTelemetry dependencies are not satisfied. \
       Tracing will be disabled. Please ensure you have compatible versions of: \

--- a/lib/sentry/integrations/oban/error_reporter.ex
+++ b/lib/sentry/integrations/oban/error_reporter.ex
@@ -4,7 +4,7 @@ defmodule Sentry.Integrations.Oban.ErrorReporter do
   # See this blog post:
   # https://getoban.pro/articles/enhancing-error-reporting
 
-  require Logger
+  alias Sentry.LoggerUtils
 
   @spec attach(keyword()) :: :ok
   def attach(config \\ []) when is_list(config) do
@@ -55,7 +55,7 @@ defmodule Sentry.Integrations.Oban.ErrorReporter do
           mod
 
         {:error, _} ->
-          Logger.warning(
+          LoggerUtils.warning(
             "Could not resolve Oban worker module from string: #{inspect(job.worker)}"
           )
 
@@ -66,7 +66,7 @@ defmodule Sentry.Integrations.Oban.ErrorReporter do
       callback.(worker, job) == true
     rescue
       error ->
-        Logger.warning("""
+        LoggerUtils.warning("""
         :should_report_error_callback failed for worker #{inspect(worker)} \
         (job ID #{job.id}):
 
@@ -160,7 +160,7 @@ defmodule Sentry.Integrations.Oban.ErrorReporter do
       if is_map(custom_tags) do
         Map.merge(base_tags, custom_tags)
       else
-        Logger.warning(
+        LoggerUtils.warning(
           "oban_tags_to_sentry_tags function returned a non-map value: #{inspect(custom_tags)}"
         )
 
@@ -168,7 +168,7 @@ defmodule Sentry.Integrations.Oban.ErrorReporter do
       end
     rescue
       error ->
-        Logger.warning("oban_tags_to_sentry_tags function failed: #{inspect(error)}")
+        LoggerUtils.warning("oban_tags_to_sentry_tags function failed: #{inspect(error)}")
 
         base_tags
     end

--- a/lib/sentry/integrations/quantum/cron.ex
+++ b/lib/sentry/integrations/quantum/cron.ex
@@ -2,7 +2,7 @@ defmodule Sentry.Integrations.Quantum.Cron do
   @moduledoc false
   alias Sentry.Integrations.CheckInIDMappings
 
-  require Logger
+  alias Sentry.LoggerUtils
 
   @events [
     [:quantum, :job, :start],
@@ -103,7 +103,7 @@ defmodule Sentry.Integrations.Quantum.Cron do
   defp timezone_to_string(_job_without_timezone_key_for_some_reason), do: "Etc/UTC"
 
   defp slugify(job_name) when is_reference(job_name) do
-    Logger.error(
+    LoggerUtils.error(
       """
       Sentry cannot report Quantum cron jobs correctly if they don't have a :name set up, and \
       will just report them as "quantum-generic-job".\

--- a/lib/sentry/live_view_hook.ex
+++ b/lib/sentry/live_view_hook.ex
@@ -80,8 +80,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     import Phoenix.LiveView, only: [attach_hook: 4, get_connect_info: 2]
 
     alias Sentry.Context
-
-    require Logger
+    alias Sentry.LoggerUtils
 
     @scrubber_pdict_key {__MODULE__, :scrubber}
 
@@ -139,7 +138,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
             result
 
           other ->
-            Logger.error(
+            LoggerUtils.error(
               "Sentry.LiveViewHook scrubber returned non-map value: #{inspect(other)}; " <>
                 "falling back to redacted data",
               event_source: :logger
@@ -151,7 +150,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         # We must NEVER raise an error in a hook, as it will crash the LiveView process
         # and we don't want Sentry to be responsible for that.
         kind, reason ->
-          Logger.error(
+          LoggerUtils.error(
             "Sentry.LiveViewHook scrubber raised an error: #{Exception.format(kind, reason)}; " <>
               "falling back to redacted data",
             event_source: :logger
@@ -202,7 +201,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       # We must NEVER raise an error in a hook, as it will crash the LiveView process
       # and we don't want Sentry to be responsible for that.
       kind, reason ->
-        Logger.error(
+        LoggerUtils.error(
           "Sentry.LiveView.on_mount hook errored out: #{Exception.format(kind, reason)}",
           event_source: :logger
         )

--- a/lib/sentry/logger_utils.ex
+++ b/lib/sentry/logger_utils.ex
@@ -109,9 +109,30 @@ defmodule Sentry.LoggerUtils do
     other
   end
 
+  # Logs at the configured :log_level, which documents itself as the level to use
+  # when Sentry fails to send data. Diagnostics that are not about a failed send
+  # use debug/2, warning/2, or error/2 below to keep their own level.
   @spec log(iodata() | (-> iodata()), keyword()) :: :ok
   def log(message_or_fun, meta \\ []) when is_list(meta) do
-    meta = Keyword.merge(meta, domain: [:sentry])
-    Logger.log(Config.log_level(), message_or_fun, meta)
+    log_at(Config.log_level(), message_or_fun, meta)
+  end
+
+  @spec debug(iodata() | (-> iodata()), keyword()) :: :ok
+  def debug(message_or_fun, meta \\ []) when is_list(meta) do
+    log_at(:debug, message_or_fun, meta)
+  end
+
+  @spec warning(iodata() | (-> iodata()), keyword()) :: :ok
+  def warning(message_or_fun, meta \\ []) when is_list(meta) do
+    log_at(:warning, message_or_fun, meta)
+  end
+
+  @spec error(iodata() | (-> iodata()), keyword()) :: :ok
+  def error(message_or_fun, meta \\ []) when is_list(meta) do
+    log_at(:error, message_or_fun, meta)
+  end
+
+  defp log_at(level, message_or_fun, meta) do
+    Logger.log(level, message_or_fun, Keyword.merge(meta, domain: [:sentry]))
   end
 end

--- a/lib/sentry/metric.ex
+++ b/lib/sentry/metric.ex
@@ -10,6 +10,7 @@ defmodule Sentry.Metric do
   @moduledoc since: "13.0.0"
 
   alias Sentry.Config
+  alias Sentry.LoggerUtils
 
   @type metric_type :: :counter | :gauge | :distribution
 
@@ -96,8 +97,7 @@ defmodule Sentry.Metric do
     function.(metric)
   rescue
     error ->
-      require Logger
-      Logger.warning("before_send_metric callback failed: #{inspect(error)}")
+      LoggerUtils.warning("before_send_metric callback failed: #{inspect(error)}")
       metric
   end
 
@@ -105,8 +105,7 @@ defmodule Sentry.Metric do
     apply(mod, fun, [metric])
   rescue
     error ->
-      require Logger
-      Logger.warning("before_send_metric callback failed: #{inspect(error)}")
+      LoggerUtils.warning("before_send_metric callback failed: #{inspect(error)}")
       metric
   end
 

--- a/lib/sentry/metrics.ex
+++ b/lib/sentry/metrics.ex
@@ -42,7 +42,7 @@ defmodule Sentry.Metrics do
   """
   @moduledoc since: "13.0.0"
 
-  alias Sentry.{ClientReport, Config, Metric, TelemetryProcessor}
+  alias Sentry.{ClientReport, Config, LoggerUtils, Metric, TelemetryProcessor}
 
   @doc """
   Records a counter metric.
@@ -163,8 +163,7 @@ defmodule Sentry.Metrics do
     end
   rescue
     e in [UndefinedFunctionError, ArgumentError] ->
-      require Logger
-      Logger.debug("Failed to extract OpenTelemetry trace context: #{inspect(e)}")
+      LoggerUtils.debug("Failed to extract OpenTelemetry trace context: #{inspect(e)}")
       {nil, nil}
   end
 

--- a/lib/sentry/opentelemetry/propagator.ex
+++ b/lib/sentry/opentelemetry/propagator.ex
@@ -10,7 +10,7 @@ if Sentry.OpenTelemetry.VersionChecker.tracing_compatible?() do
     import Bitwise
 
     require Record
-    require Logger
+    alias Sentry.LoggerUtils
     alias OpenTelemetry.Tracer, as: Tracer
 
     @behaviour :otel_propagator_text_map
@@ -85,7 +85,7 @@ if Sentry.OpenTelemetry.VersionChecker.tracing_compatible?() do
                     "org ID missing (strict mode)"
                   end
 
-                Logger.warning(
+                LoggerUtils.warning(
                   "[Sentry] Not continuing trace: #{reason} (sdk: #{inspect(sdk_org_id)}, incoming: #{inspect(baggage_org_id)})"
                 )
 

--- a/lib/sentry/opentelemetry/sampler.ex
+++ b/lib/sentry/opentelemetry/sampler.ex
@@ -6,7 +6,7 @@ if Sentry.OpenTelemetry.VersionChecker.tracing_compatible?() do
     alias Sentry.ClientReport
     alias SamplingContext
 
-    require Logger
+    alias Sentry.LoggerUtils
 
     @behaviour :otel_sampler
 
@@ -155,7 +155,7 @@ if Sentry.OpenTelemetry.VersionChecker.tracing_compatible?() do
         if is_float(sample_rate) and sample_rate >= 0.0 and sample_rate <= 1.0 do
           make_sampling_decision(sample_rate)
         else
-          Logger.warning(
+          LoggerUtils.warning(
             "traces_sampler function returned an invalid sample rate: #{inspect(sample_rate)}"
           )
 
@@ -163,7 +163,7 @@ if Sentry.OpenTelemetry.VersionChecker.tracing_compatible?() do
         end
       rescue
         error ->
-          Logger.warning("traces_sampler function failed: #{inspect(error)}")
+          LoggerUtils.warning("traces_sampler function failed: #{inspect(error)}")
 
           make_sampling_decision(0.0)
       end

--- a/lib/sentry/opentelemetry/span_processor.ex
+++ b/lib/sentry/opentelemetry/span_processor.ex
@@ -10,7 +10,7 @@ if Sentry.OpenTelemetry.VersionChecker.tracing_compatible?() do
     alias OpenTelemetry.SemConv.Incubating.URLAttributes, as: URLAttributes
     require OpenTelemetry.SemConv.Incubating.MessagingAttributes, as: MessagingAttributes
 
-    require Logger
+    alias Sentry.LoggerUtils
 
     alias Sentry.{Transaction, OpenTelemetry.SpanStorage, OpenTelemetry.SpanRecord}
     alias Sentry.Interfaces.Span
@@ -102,7 +102,7 @@ if Sentry.OpenTelemetry.VersionChecker.tracing_compatible?() do
             true
 
           {:error, error} ->
-            Logger.warning("Failed to send transaction to Sentry: #{inspect(error)}")
+            LoggerUtils.log(fn -> "Failed to send transaction to Sentry: #{inspect(error)}" end)
             {:error, :invalid_span}
         end
 

--- a/lib/sentry/telemetry/scheduler.ex
+++ b/lib/sentry/telemetry/scheduler.ex
@@ -30,8 +30,6 @@ defmodule Sentry.Telemetry.Scheduler do
 
   use GenServer
 
-  require Logger
-
   alias __MODULE__
 
   alias Sentry.Telemetry.{Buffer, Category}
@@ -43,6 +41,7 @@ defmodule Sentry.Telemetry.Scheduler do
     Envelope,
     Event,
     LogEvent,
+    LoggerUtils,
     Metric,
     Transaction,
     Transport
@@ -200,7 +199,9 @@ defmodule Sentry.Telemetry.Scheduler do
   @impl true
   def handle_info({:DOWN, ref, :process, _pid, reason}, %{active_ref: ref} = state) do
     if reason != :normal do
-      Logger.warning("Sentry transport send process exited abnormally: #{inspect(reason)}")
+      LoggerUtils.log(fn ->
+        "Sentry transport send process exited abnormally: #{inspect(reason)}"
+      end)
     end
 
     state = %{
@@ -365,7 +366,7 @@ defmodule Sentry.Telemetry.Scheduler do
     function.(log_event)
   rescue
     error ->
-      Logger.warning("before_send_log callback failed: #{inspect(error)}")
+      LoggerUtils.warning("before_send_log callback failed: #{inspect(error)}")
 
       log_event
   end
@@ -374,7 +375,7 @@ defmodule Sentry.Telemetry.Scheduler do
     apply(mod, fun, [log_event])
   rescue
     error ->
-      Logger.warning("before_send_log callback failed: #{inspect(error)}")
+      LoggerUtils.warning("before_send_log callback failed: #{inspect(error)}")
 
       log_event
   end
@@ -409,7 +410,7 @@ defmodule Sentry.Telemetry.Scheduler do
     item_count = Envelope.item_count(envelope)
 
     if state.size + item_count > state.capacity do
-      Logger.warning("Sentry: transport queue full, dropping #{item_count} item(s)")
+      LoggerUtils.log(fn -> "Sentry: transport queue full, dropping #{item_count} item(s)" end)
 
       ClientReport.Sender.record_discarded_events(:queue_overflow, envelope.items)
       state
@@ -442,7 +443,9 @@ defmodule Sentry.Telemetry.Scheduler do
           :ok
 
         {:error, error} ->
-          Logger.warning("Sentry: failed to send envelope: #{Exception.message(error)}")
+          LoggerUtils.log(fn ->
+            "Sentry: failed to send envelope: #{Exception.message(error)}"
+          end)
 
           {:error, error}
       end

--- a/lib/sentry/test/registry.ex
+++ b/lib/sentry/test/registry.ex
@@ -3,7 +3,7 @@ defmodule Sentry.Test.Registry do
 
   use GenServer
 
-  require Logger
+  alias Sentry.LoggerUtils
 
   # Bypass and Plug.Conn may not be available at compile time (optional deps).
   @compile {:no_warn_undefined,
@@ -438,7 +438,7 @@ defmodule Sentry.Test.Registry do
   def maybe_warn_about_dsn_override(new_dsn) do
     case Sentry.Config.dsn() do
       %Sentry.DSN{original_dsn: existing} ->
-        Logger.warning("""
+        LoggerUtils.warning("""
         [Sentry] test_mode is enabled but a DSN was already configured \
         (#{inspect(existing)}). Overriding it with the local Bypass sink at \
         #{new_dsn} to prevent test events from being sent to a real Sentry \

--- a/test/sentry/integrations/oban/error_reporter_test.exs
+++ b/test/sentry/integrations/oban/error_reporter_test.exs
@@ -185,9 +185,16 @@ defmodule Sentry.Integrations.Oban.ErrorReporterTest do
     end
 
     test "handles oban_tags_to_sentry_tags errors gracefully" do
-      emit_telemetry_for_failed_job(:error, %RuntimeError{message: "oops"}, [],
-        oban_tags_to_sentry_tags: fn _job -> raise "tag transform error" end
-      )
+      log =
+        capture_log([metadata: [:domain]], fn ->
+          emit_telemetry_for_failed_job(:error, %RuntimeError{message: "oops"}, [],
+            oban_tags_to_sentry_tags: fn _job -> raise "tag transform error" end
+          )
+        end)
+
+      assert log =~ "oban_tags_to_sentry_tags function failed"
+      assert log =~ "tag transform error"
+      assert log =~ ~r/domain=(\w+\.)*sentry/
 
       assert_sentry_report(:event, [])
     end
@@ -201,11 +208,17 @@ defmodule Sentry.Integrations.Oban.ErrorReporterTest do
         nil
       ]
 
-      Enum.each(test_cases, fn invalid_value ->
-        emit_telemetry_for_failed_job(:error, %RuntimeError{message: "oops"}, [],
-          oban_tags_to_sentry_tags: fn _job -> invalid_value end
-        )
-      end)
+      log =
+        capture_log([metadata: [:domain]], fn ->
+          Enum.each(test_cases, fn invalid_value ->
+            emit_telemetry_for_failed_job(:error, %RuntimeError{message: "oops"}, [],
+              oban_tags_to_sentry_tags: fn _job -> invalid_value end
+            )
+          end)
+        end)
+
+      assert log =~ "oban_tags_to_sentry_tags function returned a non-map value"
+      assert log =~ ~r/domain=(\w+\.)*sentry/
 
       events = SentryTest.pop_sentry_reports()
       assert length(events) == length(test_cases)
@@ -302,7 +315,7 @@ defmodule Sentry.Integrations.Oban.ErrorReporterTest do
 
     test "should_report_error_callback handles errors gracefully and defaults to reporting" do
       log =
-        capture_log(fn ->
+        capture_log([metadata: [:domain]], fn ->
           emit_telemetry_for_failed_job(:error, %RuntimeError{message: "oops"}, [],
             should_report_error_callback: fn _worker, _job -> raise "callback error" end
           )
@@ -311,11 +324,47 @@ defmodule Sentry.Integrations.Oban.ErrorReporterTest do
       assert log =~ "should_report_error_callback failed"
       assert log =~ "Sentry.Integrations.Oban.ErrorReporterTest.MyWorker"
       assert log =~ "callback error"
+      assert log =~ ~r/domain=(\w+\.)*sentry/
 
       event = assert_sentry_report(:event, [])
       assert [exception] = event.exception
       assert exception.type == "RuntimeError"
       assert exception.value == "oops"
+    end
+
+    test "should_report_error_callback receives a nil worker when the job worker doesn't resolve" do
+      test_pid = self()
+
+      job =
+        %{"id" => "123"}
+        |> MyWorker.new()
+        |> Ecto.Changeset.apply_action!(:validate)
+        |> Map.put(:worker, "NotA.Real.Worker")
+
+      log =
+        capture_log([metadata: [:domain]], fn ->
+          assert :ok =
+                   ErrorReporter.handle_event(
+                     [:oban, :job, :exception],
+                     %{},
+                     %{
+                       job: job,
+                       kind: :error,
+                       reason: %RuntimeError{message: "oops"},
+                       stacktrace: []
+                     },
+                     should_report_error_callback: fn worker, _job ->
+                       send(test_pid, {:callback_worker, worker})
+                       true
+                     end
+                   )
+        end)
+
+      assert log =~ ~s(Could not resolve Oban worker module from string: "NotA.Real.Worker")
+      assert log =~ ~r/domain=(\w+\.)*sentry/
+
+      assert_receive {:callback_worker, nil}
+      assert_sentry_report(:event, [])
     end
 
     test "scrubs sensitive values from the job args in the event extra" do

--- a/test/sentry/integrations/quantum/cron_test.exs
+++ b/test/sentry/integrations/quantum/cron_test.exs
@@ -3,6 +3,7 @@ defmodule Sentry.Integrations.Quantum.CronTest do
 
   alias Sentry.Integrations.CheckInIDMappings
 
+  import ExUnit.CaptureLog
   import Sentry.Test.Assertions
 
   alias Sentry.Test, as: SentryTest
@@ -171,10 +172,16 @@ defmodule Sentry.Integrations.Quantum.CronTest do
 
     duration = System.convert_time_unit(12_099, :millisecond, :native)
 
-    :telemetry.execute([:quantum, :job, :stop], %{duration: duration}, %{
-      job: Scheduler.new_job(schedule: Crontab.CronExpression.Parser.parse!("@daily")),
-      telemetry_span_context: span_ref
-    })
+    log =
+      capture_log([metadata: [:domain]], fn ->
+        :telemetry.execute([:quantum, :job, :stop], %{duration: duration}, %{
+          job: Scheduler.new_job(schedule: Crontab.CronExpression.Parser.parse!("@daily")),
+          telemetry_span_context: span_ref
+        })
+      end)
+
+    assert log =~ "Sentry cannot report Quantum cron jobs correctly if they don't have a :name"
+    assert log =~ ~r/domain=(\w+\.)*sentry/
 
     [check_in_body] = SentryTest.collect_sentry_check_ins(ref, 1)
     assert_sentry_report(check_in_body, monitor_slug: "quantum-generic-job")

--- a/test/sentry/live_view_hook_test.exs
+++ b/test/sentry/live_view_hook_test.exs
@@ -285,13 +285,14 @@ defmodule Sentry.LiveViewHookTest do
 
   test "logs error and uses empty data when scrubber raises", %{conn: conn} do
     {view, log} =
-      ExUnit.CaptureLog.with_log(fn ->
+      ExUnit.CaptureLog.with_log([metadata: [:domain]], fn ->
         {:ok, view, _html} = live(conn, "/raising_scrubber")
         render_hook(view, :submit, %{"foo" => "bar"})
         view
       end)
 
     assert log =~ "Sentry.LiveViewHook scrubber raised an error"
+    assert log =~ ~r/domain=(\w+\.)*sentry/
 
     [event_breadcrumb | _] = get_sentry_context(view).breadcrumbs
     assert event_breadcrumb.category == "web.live_view.event"
@@ -300,13 +301,14 @@ defmodule Sentry.LiveViewHookTest do
 
   test "logs error and uses empty data when scrubber returns a non-map", %{conn: conn} do
     {view, log} =
-      ExUnit.CaptureLog.with_log(fn ->
+      ExUnit.CaptureLog.with_log([metadata: [:domain]], fn ->
         {:ok, view, _html} = live(conn, "/non_map_scrubber")
         render_hook(view, :submit, %{"foo" => "bar"})
         view
       end)
 
     assert log =~ "Sentry.LiveViewHook scrubber returned non-map value"
+    assert log =~ ~r/domain=(\w+\.)*sentry/
 
     [event_breadcrumb | _] = get_sentry_context(view).breadcrumbs
     assert event_breadcrumb.category == "web.live_view.event"

--- a/test/sentry/metrics_test.exs
+++ b/test/sentry/metrics_test.exs
@@ -246,13 +246,37 @@ defmodule Sentry.MetricsTest do
       import ExUnit.CaptureLog
 
       log =
-        capture_log(fn ->
+        capture_log([metadata: [:domain]], fn ->
           assert :ok = Metrics.count("test.counter", 42)
           TelemetryProcessor.flush()
         end)
 
       assert log =~ "before_send_metric callback failed"
       assert log =~ "callback error"
+      assert log =~ ~r/domain=(\w+\.)*sentry/
+    end
+
+    test "returns original metric when a {module, function} callback raises" do
+      defmodule RaisingCallback do
+        def before_send_metric(_metric), do: raise("MFA callback error")
+      end
+
+      put_test_config(
+        enable_metrics: true,
+        before_send_metric: {RaisingCallback, :before_send_metric}
+      )
+
+      import ExUnit.CaptureLog
+
+      log =
+        capture_log([metadata: [:domain]], fn ->
+          assert :ok = Metrics.count("test.counter", 42)
+          TelemetryProcessor.flush()
+        end)
+
+      assert log =~ "before_send_metric callback failed"
+      assert log =~ "MFA callback error"
+      assert log =~ ~r/domain=(\w+\.)*sentry/
     end
 
     test "drops metric when callback returns invalid type" do

--- a/test/sentry/opentelemetry/propagator_test.exs
+++ b/test/sentry/opentelemetry/propagator_test.exs
@@ -1,6 +1,7 @@
 defmodule Sentry.OpenTelemetry.PropagatorTest do
   use Sentry.Case, async: false
 
+  import ExUnit.CaptureLog
   import Sentry.TestHelpers
 
   alias Sentry.OpenTelemetry.Propagator
@@ -312,9 +313,17 @@ defmodule Sentry.OpenTelemetry.PropagatorTest do
           _, _ -> :undefined
         end
 
-        ctx = Propagator.extract(:otel_ctx.new(), %{}, nil, getter, [])
+        {ctx, log} =
+          with_log([metadata: [:domain]], fn ->
+            Propagator.extract(:otel_ctx.new(), %{}, nil, getter, [])
+          end)
 
         assert Tracer.current_span_ctx(ctx) == :undefined
+
+        assert log =~
+                 "[Sentry] Not continuing trace: org ID mismatch (sdk: \"99\", incoming: \"42\")"
+
+        assert log =~ ~r/domain=(\w+\.)*sentry/
       end
 
       test "strict=true, baggage missing org ID: trace is NOT continued" do
@@ -332,9 +341,17 @@ defmodule Sentry.OpenTelemetry.PropagatorTest do
           _, _ -> :undefined
         end
 
-        ctx = Propagator.extract(:otel_ctx.new(), %{}, nil, getter, [])
+        {ctx, log} =
+          with_log([metadata: [:domain]], fn ->
+            Propagator.extract(:otel_ctx.new(), %{}, nil, getter, [])
+          end)
 
         assert Tracer.current_span_ctx(ctx) == :undefined
+
+        assert log =~
+                 "[Sentry] Not continuing trace: org ID missing (strict mode) (sdk: \"99\", incoming: nil)"
+
+        assert log =~ ~r/domain=(\w+\.)*sentry/
       end
 
       test "inject adds sentry-org_id to outgoing baggage when SDK org is configured" do

--- a/test/sentry/opentelemetry/sampler_test.exs
+++ b/test/sentry/opentelemetry/sampler_test.exs
@@ -5,6 +5,7 @@ defmodule Sentry.Opentelemetry.SamplerTest do
   alias Sentry.ClientReport
   alias SamplingContext
 
+  import ExUnit.CaptureLog
   import Sentry.TestHelpers
 
   require Record
@@ -462,8 +463,15 @@ defmodule Sentry.Opentelemetry.SamplerTest do
 
       test_ctx = create_test_span_context()
 
-      assert {:drop, [], _tracestate} =
-               Sampler.should_sample(test_ctx, 123, nil, "test span", nil, %{}, drop: [])
+      log =
+        capture_log([metadata: [:domain]], fn ->
+          assert {:drop, [], _tracestate} =
+                   Sampler.should_sample(test_ctx, 123, nil, "test span", nil, %{}, drop: [])
+        end)
+
+      assert log =~ "traces_sampler function failed"
+      assert log =~ "sampler error"
+      assert log =~ ~r/domain=(\w+\.)*sentry/
     end
 
     test "handles invalid traces_sampler return values gracefully" do
@@ -478,17 +486,23 @@ defmodule Sentry.Opentelemetry.SamplerTest do
         nil
       ]
 
-      Enum.each(test_cases, fn invalid_value ->
-        put_test_config(traces_sampler: fn _ -> invalid_value end)
+      log =
+        capture_log([metadata: [:domain]], fn ->
+          Enum.each(test_cases, fn invalid_value ->
+            put_test_config(traces_sampler: fn _ -> invalid_value end)
 
-        test_ctx = create_test_span_context()
+            test_ctx = create_test_span_context()
 
-        result = Sampler.should_sample(test_ctx, 123, nil, "test span", nil, %{}, drop: [])
+            result = Sampler.should_sample(test_ctx, 123, nil, "test span", nil, %{}, drop: [])
 
-        assert {:drop, [], tracestate} = result
-        assert {"sentry-sample_rate", "0.0"} in tracestate
-        assert {"sentry-sampled", "false"} in tracestate
-      end)
+            assert {:drop, [], tracestate} = result
+            assert {"sentry-sample_rate", "0.0"} in tracestate
+            assert {"sentry-sampled", "false"} in tracestate
+          end)
+        end)
+
+      assert log =~ "traces_sampler function returned an invalid sample rate"
+      assert log =~ ~r/domain=(\w+\.)*sentry/
     end
 
     test "supports MFA tuple for traces_sampler" do

--- a/test/sentry/opentelemetry/span_processor_test.exs
+++ b/test/sentry/opentelemetry/span_processor_test.exs
@@ -8,6 +8,7 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
   alias OpenTelemetry.SemConv.ClientAttributes, as: ClientAttributes
   alias OpenTelemetry.SemConv.Incubating.MessagingAttributes, as: MessagingAttributes
 
+  import ExUnit.CaptureLog
   import Sentry.Test.Assertions
   import Sentry.TestHelpers
 
@@ -114,6 +115,23 @@ defmodule Sentry.Opentelemetry.SpanProcessorTest do
              SpanStorage.get_child_spans(tx["contexts"]["trace"]["span_id"],
                table_name: table_name
              )
+  end
+
+  @tag span_storage: true
+  test "logs at the configured :log_level when the transaction cannot be sent", %{bypass: bypass} do
+    put_test_config(environment_name: "test", traces_sample_rate: 1.0, log_level: :info)
+
+    Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
+      Plug.Conn.resp(conn, 500, ~s<{"error": "internal"}>)
+    end)
+
+    log =
+      capture_log([metadata: [:domain]], fn ->
+        TestEndpoint.child_instrumented_function("one")
+      end)
+
+    # Elixir < 1.15 pads the level, so the gap before the message is not always one space.
+    assert log =~ ~r/domain=(\w+\.)*sentry \[info\]\s+Failed to send transaction to Sentry/
   end
 
   defp assert_valid_iso8601(timestamp) do

--- a/test/sentry/telemetry/scheduler_test.exs
+++ b/test/sentry/telemetry/scheduler_test.exs
@@ -175,7 +175,9 @@ defmodule Sentry.Telemetry.SchedulerTest do
       buffers = start_test_buffers(batch_size: 1)
       test_pid = self()
 
+      # A broken callback is not a failed send, so :log_level must not demote it.
       put_test_config(
+        log_level: :debug,
         before_send_log: fn _log_event ->
           raise "boom"
         end
@@ -189,7 +191,7 @@ defmodule Sentry.Telemetry.SchedulerTest do
         )
 
       log =
-        capture_log(fn ->
+        capture_log([metadata: [:domain]], fn ->
           Buffer.add(buffers.log, make_log_event("test"))
           Scheduler.signal(pid)
 
@@ -198,7 +200,7 @@ defmodule Sentry.Telemetry.SchedulerTest do
           assert [%Sentry.LogBatch{log_events: [%LogEvent{body: "test"}]}] = envelope.items
         end)
 
-      assert log =~ "before_send_log callback failed"
+      assert log =~ ~r/domain=(\w+\.)*sentry \[warning\]\s+before_send_log callback failed/
 
       GenServer.stop(pid)
       stop_buffers(buffers)
@@ -316,15 +318,47 @@ defmodule Sentry.Telemetry.SchedulerTest do
       for i <- 1..5, do: Buffer.add(buffers.log, make_log_event("log_#{i}"))
 
       log =
-        capture_log(fn ->
+        capture_log([metadata: [:domain]], fn ->
           Scheduler.signal(pid)
           Process.sleep(50)
         end)
 
       assert log =~ "transport queue full, dropping 5 item(s)"
+      assert log =~ ~r/domain=(\w+\.)*sentry/
+      # Diagnostics use the default :log_level.
+      assert log =~ "[warning]"
 
       state = :sys.get_state(pid)
       assert state.size == 0
+
+      GenServer.stop(pid)
+      stop_buffers(buffers)
+    end
+
+    test "logs the diagnostic at the configured :log_level" do
+      buffers = start_test_buffers(batch_size: 5)
+      uid = System.unique_integer([:positive])
+
+      put_test_config(dsn: "http://public:secret@localhost:9999/1", log_level: :info)
+
+      {:ok, pid} =
+        Scheduler.start_link(
+          buffers: buffers,
+          capacity: 3,
+          name: :"test_scheduler_log_level_#{uid}"
+        )
+
+      for i <- 1..5, do: Buffer.add(buffers.log, make_log_event("log_#{i}"))
+
+      log =
+        capture_log([metadata: [:domain]], fn ->
+          Scheduler.signal(pid)
+          Process.sleep(50)
+        end)
+
+      assert log =~ "[info]"
+      assert log =~ "transport queue full, dropping 5 item(s)"
+      assert log =~ ~r/domain=(\w+\.)*sentry/
 
       GenServer.stop(pid)
       stop_buffers(buffers)
@@ -351,7 +385,7 @@ defmodule Sentry.Telemetry.SchedulerTest do
       end)
 
       log =
-        capture_log(fn ->
+        capture_log([metadata: [:domain]], fn ->
           send(pid, {:DOWN, fake_ref, :process, self(), {:error, :something_broke}})
           # Synchronize: :sys.get_state goes through the mailbox, ensuring :DOWN is processed
           :sys.get_state(pid)
@@ -359,6 +393,7 @@ defmodule Sentry.Telemetry.SchedulerTest do
 
       assert log =~ "Sentry transport send process exited abnormally"
       assert log =~ "something_broke"
+      assert log =~ ~r/domain=(\w+\.)*sentry/
 
       GenServer.stop(pid)
       stop_buffers(buffers)
@@ -424,11 +459,12 @@ defmodule Sentry.Telemetry.SchedulerTest do
 
       # Flush uses the direct send path which logs failures
       log =
-        capture_log(fn ->
+        capture_log([metadata: [:domain]], fn ->
           Scheduler.flush(pid)
         end)
 
       assert log =~ "failed to send envelope"
+      assert log =~ ~r/domain=(\w+\.)*sentry/
 
       GenServer.stop(pid)
       stop_buffers(buffers)

--- a/test/sentry/test/registry_test.exs
+++ b/test/sentry/test/registry_test.exs
@@ -11,13 +11,14 @@ defmodule Sentry.Test.RegistryTest do
       on_exit(fn -> Sentry.put_config(:dsn, nil) end)
 
       log =
-        capture_log(fn ->
+        capture_log([metadata: [:domain]], fn ->
           Registry.maybe_warn_about_dsn_override("http://public:secret@localhost:4000/1")
         end)
 
       assert log =~ "test_mode is enabled but a DSN was already configured"
       assert log =~ "example.com"
       assert log =~ "localhost:4000"
+      assert log =~ ~r/domain=(\w+\.)*sentry/
     end
 
     test "stays silent when no DSN is configured" do

--- a/test/sentry_test.exs
+++ b/test/sentry_test.exs
@@ -395,13 +395,22 @@ defmodule SentryTest do
   end
 
   describe "flush/1" do
-    test "returns :ok silently when TelemetryProcessor is not running" do
-      # Default TelemetryProcessor is not started in test — this is the :noproc path
+    test "warns and returns :ok when the TelemetryProcessor is not running" do
+      # The default TelemetryProcessor runs under the application supervisor, so it has
+      # to be taken down to reach the :noproc path.
+      :ok = Supervisor.terminate_child(Sentry.Supervisor, Sentry.TelemetryProcessor)
+
+      on_exit(fn ->
+        {:ok, _} = Supervisor.restart_child(Sentry.Supervisor, Sentry.TelemetryProcessor)
+      end)
+
       log =
-        capture_log(fn ->
+        capture_log([metadata: [:domain]], fn ->
           assert :ok = Sentry.flush()
         end)
 
+      assert log =~ "Sentry.flush/1 failed: TelemetryProcessor not running"
+      assert log =~ ~r/domain=(\w+\.)*sentry/
       refute log =~ "failed unexpectedly"
     end
   end


### PR DESCRIPTION
For diagnostic logging we must use `LoggerUtils` because it ensures `:sentry` domain is used, and that is one of the excluded domains by default in the structured logging feature.