### PR TITLE
fix(rate-limiting): keep the longest expiry for a rate-limited category

### DIFF
--- a/lib/sentry/transport/rate_limiter.ex
+++ b/lib/sentry/transport/rate_limiter.ex
@@ -137,9 +137,7 @@ defmodule Sentry.Transport.RateLimiter do
   """
   @spec update_global_rate_limit(pos_integer()) :: :ok
   def update_global_rate_limit(retry_after_seconds) when is_integer(retry_after_seconds) do
-    expiry = System.system_time(:millisecond) + retry_after_seconds * 1000
-    :ets.insert(name(), {:global, expiry})
-    :ok
+    store_max_expiry(:global, System.system_time(:millisecond) + retry_after_seconds * 1000)
   end
 
   @doc """
@@ -160,13 +158,46 @@ defmodule Sentry.Transport.RateLimiter do
 
     rate_limits_header
     |> parse_rate_limits_header()
-    |> Enum.map(fn {category, retry_after_ms} -> {category, now + retry_after_ms} end)
-    |> then(&:ets.insert(name(), &1))
+    |> Enum.each(fn {category, retry_after_ms} ->
+      store_max_expiry(category, now + retry_after_ms)
+    end)
 
     :ok
   end
 
   ## Private Helpers
+
+  # Rate limits may only ever be extended: a response carrying a shorter delay
+  # than the one already in flight must not let the SDK resume sending early.
+  #
+  # Senders handle responses concurrently, so this compares and swaps rather than
+  # reading and then writing: two responses racing on the same category would
+  # otherwise both read the old expiry and let the shorter one land last.
+  defp store_max_expiry(category, expiry) do
+    table = name()
+
+    if :ets.insert_new(table, {category, expiry}) do
+      :ok
+    else
+      replace_shorter_expiry(table, category, expiry)
+    end
+  end
+
+  defp replace_shorter_expiry(table, category, expiry) do
+    match_spec = [
+      {{category, :"$1"}, [{:<, :"$1", expiry}], [{{{:const, category}, {:const, expiry}}}]}
+    ]
+
+    case :ets.select_replace(table, match_spec) do
+      1 ->
+        :ok
+
+      0 ->
+        # Either the stored expiry is already the longer one, or the sweeper
+        # pruned the entry between the two calls and it has to be re-inserted.
+        if :ets.member(table, category), do: :ok, else: store_max_expiry(category, expiry)
+    end
+  end
 
   defp rate_limited?(category, now) do
     case :ets.lookup(name(), category) do

--- a/test/sentry/transport/rate_limiter_test.exs
+++ b/test/sentry/transport/rate_limiter_test.exs
@@ -138,14 +138,41 @@ defmodule Sentry.Transport.RateLimiterTest do
       assert_in_delta expiry, System.system_time(:millisecond) + 60_000, 1000
     end
 
-    test "overwrites existing rate limits" do
+    test "extends an active limit when a longer one arrives" do
       RateLimiter.update_rate_limits("1:error")
-      first_expiry = :ets.lookup(table_name(), "error") |> hd() |> elem(1)
+      first_expiry = stored_expiry("error")
 
       RateLimiter.update_rate_limits("15:error")
-      second_expiry = :ets.lookup(table_name(), "error") |> hd() |> elem(1)
 
-      assert second_expiry > first_expiry
+      assert stored_expiry("error") > first_expiry
+    end
+
+    test "keeps the existing expiry when a shorter limit arrives" do
+      RateLimiter.update_rate_limits("60:error")
+      expiry = stored_expiry("error")
+
+      RateLimiter.update_rate_limits("1:error")
+
+      assert stored_expiry("error") == expiry
+    end
+
+    test "applies a new limit over an expired entry that has not been swept yet" do
+      set_rate_limit("error", duration: -10)
+
+      RateLimiter.update_rate_limits("60:error")
+
+      assert RateLimiter.rate_limited?("error") == true
+    end
+
+    test "keeps the longest delay when a category repeats in one header" do
+      RateLimiter.update_rate_limits("1:error, 60:error")
+      RateLimiter.update_rate_limits("60:transaction, 1:transaction")
+
+      assert_in_delta stored_expiry("error"), System.system_time(:millisecond) + 60_000, 1000
+
+      assert_in_delta stored_expiry("transaction"),
+                      System.system_time(:millisecond) + 60_000,
+                      1000
     end
   end
 
@@ -155,6 +182,24 @@ defmodule Sentry.Transport.RateLimiterTest do
 
       assert [{:global, expiry}] = :ets.lookup(table_name(), :global)
       assert_in_delta expiry, System.system_time(:millisecond) + 60_000, 1000
+    end
+
+    test "keeps the existing expiry when a shorter global limit arrives" do
+      RateLimiter.update_global_rate_limit(60)
+      expiry = stored_expiry(:global)
+
+      RateLimiter.update_global_rate_limit(1)
+
+      assert stored_expiry(:global) == expiry
+    end
+
+    test "keeps the existing expiry when a shorter limit arrives from the header" do
+      RateLimiter.update_rate_limits("60::organization")
+      expiry = stored_expiry(:global)
+
+      RateLimiter.update_global_rate_limit(1)
+
+      assert stored_expiry(:global) == expiry
     end
   end
 
@@ -192,4 +237,9 @@ defmodule Sentry.Transport.RateLimiterTest do
   end
 
   defp table_name, do: Process.get(:rate_limiter_table_name)
+
+  defp stored_expiry(category) do
+    assert [{^category, expiry}] = :ets.lookup(table_name(), category)
+    expiry
+  end
 end

--- a/test/sentry/transport_test.exs
+++ b/test/sentry/transport_test.exs
@@ -562,6 +562,43 @@ defmodule Sentry.TransportTest do
                Transport.encode_and_post_envelope(envelope, FinchClient, _retries = [])
     end
 
+    test "keeps the longer error limit when a later response carries a shorter one", %{
+      bypass: bypass
+    } do
+      Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
+        assert {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+        rate_limits =
+          case decode_envelope!(body) do
+            [{%{"type" => "event"}, _item}] -> "60:error:key"
+            [{%{"type" => "log"}, _item}] -> "0:error:key"
+          end
+
+        conn
+        |> Plug.Conn.put_resp_header("X-Sentry-Rate-Limits", rate_limits)
+        |> Plug.Conn.resp(200, ~s<{"id":"accepted"}>)
+      end)
+
+      assert {:ok, "accepted"} =
+               Transport.encode_and_post_envelope(
+                 Envelope.from_event(Event.create_event(message: "First")),
+                 FinchClient
+               )
+
+      assert {:ok, "accepted"} =
+               Transport.encode_and_post_envelope(
+                 Envelope.from_log_events([make_log_event("keeps flowing")]),
+                 FinchClient
+               )
+
+      assert {:error, %ClientError{reason: :rate_limited}} =
+               Transport.encode_and_post_envelope(
+                 Envelope.from_event(Event.create_event(message: "Second")),
+                 FinchClient,
+                 _retries = []
+               )
+    end
+
     test "applies a fractional retry delay from the rate limits header", %{bypass: bypass} do
       Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
         conn


### PR DESCRIPTION
This ensures that longer expiry will be used instead of being overridden by a shorter one.