### PR TITLE
fix(rate-limiting): drop only the rate-limited attachments from an envelope

### DIFF
--- a/lib/sentry/transport.ex
+++ b/lib/sentry/transport.ex
@@ -26,77 +26,98 @@ defmodule Sentry.Transport do
           {:ok, envelope_id :: String.t()} | {:error, ClientError.t()}
   def encode_and_post_envelope(%Envelope{} = envelope, client, retries \\ @default_retries)
       when is_atom(client) and is_list(retries) do
-    result =
-      case Envelope.to_binary(envelope) do
-        {:ok, body} ->
-          {endpoint, headers} = get_endpoint_and_headers()
-          post_envelope_with_retries(client, endpoint, headers, body, retries, envelope.items)
-
-        {:error, reason} ->
-          {:error, ClientError.new({:invalid_json, reason})}
-      end
+    result = post_envelope_with_retries(client, envelope, retries)
 
     _ = maybe_log_send_result(result, envelope.items)
     result
   end
 
-  defp post_envelope_with_retries(
-         client,
-         endpoint,
-         headers,
-         payload,
-         retries_left,
-         envelope_items
-       ) do
-    case request(client, endpoint, headers, payload, envelope_items) do
+  # Limits are re-applied before every attempt, because a response handled while
+  # we slept may have introduced one. Retries recurse with the already-filtered
+  # envelope, so each pass only reports the items it newly discards.
+  defp post_envelope_with_retries(client, envelope, retries_left) do
+    case filter_rate_limited(envelope) do
+      {:send, filtered_envelope, discarded_items} ->
+        ClientReport.Sender.record_discarded_events(:ratelimit_backoff, discarded_items)
+
+        case Envelope.to_binary(filtered_envelope) do
+          {:ok, body} ->
+            post_filtered_envelope(client, filtered_envelope, body, retries_left)
+
+          {:error, reason} ->
+            {:error, ClientError.new({:invalid_json, reason})}
+        end
+
+      {:drop, discarded_items} ->
+        ClientReport.Sender.record_discarded_events(:ratelimit_backoff, discarded_items)
+        {:error, ClientError.new(:rate_limited)}
+    end
+  end
+
+  defp post_filtered_envelope(client, %Envelope{items: items} = envelope, body, retries_left) do
+    {endpoint, headers} = get_endpoint_and_headers()
+
+    case request(client, endpoint, headers, body) do
       {:ok, id} ->
         {:ok, id}
 
       {:error, :rate_limited} ->
-        ClientReport.Sender.record_discarded_events(:ratelimit_backoff, envelope_items)
+        ClientReport.Sender.record_discarded_events(:ratelimit_backoff, items)
         {:error, ClientError.new(:rate_limited)}
 
       {:error, {:envelope_too_large, {status, headers, body}}} ->
-        ClientReport.Sender.record_discarded_events(:send_error, envelope_items)
+        ClientReport.Sender.record_discarded_events(:send_error, items)
         {:error, ClientError.envelope_too_large(status, headers, body)}
 
       {:error, _reason} when retries_left != [] ->
         [sleep_interval | retries_left] = retries_left
         Process.sleep(sleep_interval)
-
-        post_envelope_with_retries(
-          client,
-          endpoint,
-          headers,
-          payload,
-          retries_left,
-          envelope_items
-        )
+        post_envelope_with_retries(client, envelope, retries_left)
 
       {:error, {:http, {status, headers, body}}} ->
-        ClientReport.Sender.record_discarded_events(:send_error, envelope_items)
+        ClientReport.Sender.record_discarded_events(:send_error, items)
         {:error, ClientError.server_error(status, headers, body)}
 
       {:error, reason} ->
-        ClientReport.Sender.record_discarded_events(:send_error, envelope_items)
+        ClientReport.Sender.record_discarded_events(:send_error, items)
         {:error, ClientError.new(reason)}
     end
   end
 
-  defp check_rate_limited(envelope_items) do
-    rate_limited? =
-      Enum.any?(envelope_items, fn item ->
-        item
-        |> Envelope.get_data_category()
-        |> RateLimiter.rate_limited_for_category?()
-      end)
+  defp filter_rate_limited(%Envelope{items: items} = envelope) do
+    if envelope_rate_limited?(items) do
+      {:drop, items}
+    else
+      {discarded_items, retained_items} = Enum.split_with(items, &attachment_rate_limited?/1)
 
-    if rate_limited?, do: {:error, :rate_limited}, else: :ok
+      case retained_items do
+        [] -> {:drop, discarded_items}
+        _items -> {:send, %Envelope{envelope | items: retained_items}, discarded_items}
+      end
+    end
   end
 
-  defp request(client, endpoint, headers, body, envelope_items) do
-    with :ok <- check_rate_limited(envelope_items),
-         {:ok, 200, _headers, body} <-
+  # Attachments are excluded deliberately: a limit on them drops the attachments
+  # alone, never the error they belong to.
+  defp envelope_rate_limited?(items) do
+    RateLimiter.global_rate_limited?() or Enum.any?(items, &whole_envelope_rate_limited?/1)
+  end
+
+  defp whole_envelope_rate_limited?(%Sentry.Attachment{}), do: false
+
+  defp whole_envelope_rate_limited?(item) do
+    item
+    |> Envelope.get_data_category()
+    |> RateLimiter.rate_limited_for_category?()
+  end
+
+  defp attachment_rate_limited?(item) do
+    match?(%Sentry.Attachment{}, item) and
+      RateLimiter.rate_limited_for_category?(Envelope.get_data_category(item))
+  end
+
+  defp request(client, endpoint, headers, body) do
+    with {:ok, 200, _headers, body} <-
            client_post_and_validate_return_value(client, endpoint, headers, body),
          {:ok, json} <- Sentry.JSON.decode(body, Config.json_library()) do
       {:ok, Map.get(json, "id")}
@@ -109,9 +130,6 @@ defmodule Sentry.Transport do
 
       {:ok, status, headers, body} ->
         {:error, {:http, {status, headers, body}}}
-
-      {:error, :rate_limited} ->
-        {:error, :rate_limited}
 
       {:error, reason} ->
         {:error, {:request_failure, reason}}

--- a/lib/sentry/transport/rate_limiter.ex
+++ b/lib/sentry/transport/rate_limiter.ex
@@ -90,16 +90,22 @@ defmodule Sentry.Transport.RateLimiter do
     rate_limited?(category, now) or rate_limited?(:global, now)
   end
 
+  @spec global_rate_limited?() :: boolean()
+  def global_rate_limited? do
+    rate_limited?(:global, System.system_time(:second))
+  end
+
   @doc """
   Checks whether sending items of the given data category is currently limited.
 
-  Logs and metrics have a companion byte category (`log_byte` /
-  `trace_metric_byte`) that Sentry can limit independently of the count
-  category, so a limit on either one must suppress sending. Every other category
-  gates on itself alone.
+  Logs, metrics, and attachments have companion categories (`log_byte`,
+  `trace_metric_byte`, and `attachment_item`) that Sentry can limit
+  independently of the count category, so a limit on either one must suppress
+  sending. Every other category gates on itself alone.
 
-  So an active `log_byte` limit makes this return `true` for `"log_item"`, even
-  though `rate_limited?("log_item")` on its own is `false`.
+  So an active `log_byte` limit makes this return `true` for `"log_item"`, and
+  an active `attachment_item` limit does the same for `"attachment"`, even
+  though the corresponding `rate_limited?/1` call on its own is `false`.
   """
   @spec rate_limited_for_category?(String.t()) :: boolean()
   def rate_limited_for_category?("log_item"),
@@ -107,6 +113,9 @@ defmodule Sentry.Transport.RateLimiter do
 
   def rate_limited_for_category?("trace_metric"),
     do: rate_limited?("trace_metric") or rate_limited?("trace_metric_byte")
+
+  def rate_limited_for_category?("attachment"),
+    do: rate_limited?("attachment") or rate_limited?("attachment_item")
 
   def rate_limited_for_category?(category) when is_binary(category),
     do: rate_limited?(category)

--- a/test/sentry/transport/rate_limiter_test.exs
+++ b/test/sentry/transport/rate_limiter_test.exs
@@ -87,6 +87,27 @@ defmodule Sentry.Transport.RateLimiterTest do
       assert RateLimiter.rate_limited?("trace_metric") == false
     end
 
+    test "gates attachments on the attachment limit" do
+      set_rate_limit("attachment")
+
+      assert RateLimiter.rate_limited_for_category?("attachment") == true
+      assert RateLimiter.rate_limited?("attachment") == true
+    end
+
+    test "gates attachments on the attachment_item limit" do
+      set_rate_limit("attachment_item")
+
+      assert RateLimiter.rate_limited_for_category?("attachment") == true
+      assert RateLimiter.rate_limited?("attachment") == false
+    end
+
+    test "does not gate errors on attachment limits" do
+      set_rate_limit("attachment")
+      set_rate_limit("attachment_item")
+
+      assert RateLimiter.rate_limited_for_category?("error") == false
+    end
+
     test "gates a category on itself when it has no companion byte category" do
       set_rate_limit("error")
 

--- a/test/sentry/transport_test.exs
+++ b/test/sentry/transport_test.exs
@@ -4,7 +4,16 @@ defmodule Sentry.TransportTest do
   import Sentry.TestHelpers
   import ExUnit.CaptureLog
 
-  alias Sentry.{ClientError, Envelope, Event, FinchClient, HackneyClient, Transport}
+  alias Sentry.{
+    Attachment,
+    ClientError,
+    ClientReport,
+    Envelope,
+    Event,
+    FinchClient,
+    HackneyClient,
+    Transport
+  }
 
   describe "encode_and_post_envelope/2" do
     setup do
@@ -267,6 +276,60 @@ defmodule Sentry.TransportTest do
       assert_received {:request, ^ref}
     end
 
+    test "stops retrying when a failed response carried a rate limit", %{bypass: bypass} do
+      envelope = Envelope.from_event(Event.create_event(message: "Hello"))
+      test_pid = self()
+      ref = make_ref()
+
+      Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
+        send(test_pid, {:request, ref})
+
+        conn
+        |> Plug.Conn.put_resp_header("X-Sentry-Rate-Limits", "60:error:key")
+        |> Plug.Conn.resp(500, ~s<{}>)
+      end)
+
+      assert {:error, %ClientError{reason: :rate_limited}} =
+               Transport.encode_and_post_envelope(envelope, FinchClient, _retries = [0])
+
+      assert_received {:request, ^ref}
+      refute_received {:request, ^ref}
+    end
+
+    test "strips newly rate-limited attachments before retrying", %{bypass: bypass} do
+      test_pid = self()
+      ref = make_ref()
+
+      stub_attachment_limit_on_first_attempt(bypass, test_pid, ref)
+
+      assert {:ok, "retried"} =
+               Transport.encode_and_post_envelope(
+                 envelope_with_attachment(),
+                 FinchClient,
+                 _retries = [0]
+               )
+
+      assert_received {:sent_attachment?, ^ref, true}
+      assert_received {:sent_attachment?, ^ref, false}
+    end
+
+    test "records a retry-stripped attachment once", %{bypass: bypass} do
+      assert :ok = ClientReport.Sender.flush()
+
+      stub_attachment_limit_on_first_attempt(bypass, self(), make_ref())
+
+      assert {:ok, "retried"} =
+               Transport.encode_and_post_envelope(
+                 envelope_with_attachment(),
+                 FinchClient,
+                 _retries = [0]
+               )
+
+      assert wait_until(fn -> :sys.get_state(ClientReport.Sender) != %{} end)
+
+      assert :sys.get_state(ClientReport.Sender) == %{{:ratelimit_backoff, "attachment"} => 1}
+    end
+
     test "fails immediately when Sentry replies with 413 (envelope too large)", %{bypass: bypass} do
       envelope = Envelope.from_event(Event.create_event(message: "Hello"))
       test_pid = self()
@@ -368,6 +431,137 @@ defmodule Sentry.TransportTest do
                Transport.encode_and_post_envelope(envelope2, HackneyClient, _retries = [])
     end
 
+    test "sends an event without attachments when attachments are rate limited", %{bypass: bypass} do
+      event = Event.create_event(message: "event with attachment")
+      event = %Event{event | attachments: [%Attachment{filename: "report.txt", data: "report"}]}
+
+      envelope = Envelope.from_event(event)
+      set_rate_limit("attachment")
+
+      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
+        assert {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert [{%{"type" => "event"}, _event}] = decode_envelope!(body)
+        Plug.Conn.resp(conn, 200, ~s<{"id":"event-id"}>)
+      end)
+
+      assert {:ok, "event-id"} = Transport.encode_and_post_envelope(envelope, FinchClient)
+    end
+
+    test "sends an event while dropping all of its rate-limited attachments", %{bypass: bypass} do
+      assert :ok = ClientReport.Sender.flush()
+
+      event = Event.create_event(message: "event with attachments")
+
+      event =
+        %Event{
+          event
+          | attachments: [
+              %Attachment{filename: "first.txt", data: "first"},
+              %Attachment{filename: "second.txt", data: "second"}
+            ]
+        }
+
+      envelope = Envelope.from_event(event)
+      set_rate_limit("attachment")
+
+      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
+        assert {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert [{%{"type" => "event"}, _event}] = decode_envelope!(body)
+        Plug.Conn.resp(conn, 200, ~s<{"id":"event-id"}>)
+      end)
+
+      assert {:ok, "event-id"} = Transport.encode_and_post_envelope(envelope, FinchClient)
+      assert wait_until(fn -> :sys.get_state(ClientReport.Sender) != %{} end)
+
+      assert :sys.get_state(ClientReport.Sender) == %{
+               {:ratelimit_backoff, "attachment"} => 2
+             }
+    end
+
+    test "sends an event without attachments when attachment items are rate limited", %{
+      bypass: bypass
+    } do
+      event = Event.create_event(message: "event with attachment")
+      event = %Event{event | attachments: [%Attachment{filename: "report.txt", data: "report"}]}
+      envelope = Envelope.from_event(event)
+      set_rate_limit("attachment_item")
+
+      Bypass.expect_once(bypass, "POST", "/api/1/envelope/", fn conn ->
+        assert {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert [{%{"type" => "event"}, _event}] = decode_envelope!(body)
+        Plug.Conn.resp(conn, 200, ~s<{"id":"event-id"}>)
+      end)
+
+      assert {:ok, "event-id"} = Transport.encode_and_post_envelope(envelope, FinchClient)
+    end
+
+    test "records only dropped attachments in the client report" do
+      assert :ok = ClientReport.Sender.flush()
+
+      event = Event.create_event(message: "event with attachment")
+      attachment = %Attachment{filename: "report.txt", data: "report"}
+      envelope = Envelope.from_event(%Event{event | attachments: [attachment]})
+      set_rate_limit("attachment")
+
+      assert {:ok, _event_id} =
+               Transport.encode_and_post_envelope(envelope, FinchClient, _retries = [])
+
+      assert wait_until(fn -> :sys.get_state(ClientReport.Sender) != %{} end)
+
+      assert :sys.get_state(ClientReport.Sender) == %{
+               {:ratelimit_backoff, "attachment"} => 1
+             }
+    end
+
+    test "drops an event and its attachments when the error category is rate limited" do
+      assert :ok = ClientReport.Sender.flush()
+
+      event = Event.create_event(message: "event with attachment")
+      event = %Event{event | attachments: [%Attachment{filename: "report.txt", data: "report"}]}
+      envelope = Envelope.from_event(event)
+      set_rate_limit("error")
+
+      assert {:error, %ClientError{reason: :rate_limited}} =
+               Transport.encode_and_post_envelope(envelope, FinchClient, _retries = [])
+
+      assert wait_until(fn -> :sys.get_state(ClientReport.Sender) != %{} end)
+
+      assert :sys.get_state(ClientReport.Sender) == %{
+               {:ratelimit_backoff, "attachment"} => 1,
+               {:ratelimit_backoff, "error"} => 1
+             }
+    end
+
+    test "drops an event and its attachments when error and attachment limits are active" do
+      assert :ok = ClientReport.Sender.flush()
+
+      event = Event.create_event(message: "event with attachment")
+      event = %Event{event | attachments: [%Attachment{filename: "report.txt", data: "report"}]}
+      envelope = Envelope.from_event(event)
+      set_rate_limit("error")
+      set_rate_limit("attachment")
+
+      assert {:error, %ClientError{reason: :rate_limited}} =
+               Transport.encode_and_post_envelope(envelope, FinchClient, _retries = [])
+
+      assert wait_until(fn -> :sys.get_state(ClientReport.Sender) != %{} end)
+
+      assert :sys.get_state(ClientReport.Sender) == %{
+               {:ratelimit_backoff, "attachment"} => 1,
+               {:ratelimit_backoff, "error"} => 1
+             }
+    end
+
+    test "drops an event and its attachments when a global rate limit is active" do
+      event = Event.create_event(message: "event with attachment")
+      event = %Event{event | attachments: [%Attachment{filename: "report.txt", data: "report"}]}
+      envelope = Envelope.from_event(event)
+      set_rate_limit(:global)
+
+      assert {:error, %ClientError{reason: :rate_limited}} =
+               Transport.encode_and_post_envelope(envelope, FinchClient, _retries = [])
+    end
+
     test "handles multiple categories in single X-Sentry-Rate-Limits header", %{bypass: bypass} do
       envelope = Envelope.from_event(Event.create_event(message: "Hello"))
 
@@ -451,5 +645,30 @@ defmodule Sentry.TransportTest do
     assert {:error, %ClientError{} = error} = fun.()
     assert is_binary(Exception.message(error))
     error.reason
+  end
+
+  defp envelope_with_attachment do
+    event = Event.create_event(message: "event with attachment")
+    attachment = %Attachment{filename: "report.txt", data: "report"}
+
+    Envelope.from_event(%Event{event | attachments: [attachment]})
+  end
+
+  # An attachment's payload is raw binary, so the envelope cannot go through
+  # decode_envelope!/1 here — match on the item header instead.
+  defp stub_attachment_limit_on_first_attempt(bypass, test_pid, ref) do
+    Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
+      assert {:ok, body, conn} = Plug.Conn.read_body(conn)
+      sent_attachment? = String.contains?(body, ~s("type":"attachment"))
+      send(test_pid, {:sent_attachment?, ref, sent_attachment?})
+
+      if sent_attachment? do
+        conn
+        |> Plug.Conn.put_resp_header("X-Sentry-Rate-Limits", "60:attachment:key")
+        |> Plug.Conn.resp(500, ~s<{}>)
+      else
+        Plug.Conn.resp(conn, 200, ~s<{"id":"retried"}>)
+      end
+    end)
   end
 end


### PR DESCRIPTION
Rate-limit enforcement now happens before serialization and can drop items individually (as opposed to dropping entire envelope just because some attachments need to be dropped).

- `attachment` / `attachment_item` limited - send the error, drop its attachments
- `error` or global limit - drop the whole envelope, attachments included
- filtered down to zero items - send nothing

`ratelimit_backoff` client reports now describe exactly the items discarded rather
than the whole envelope.

Also adds `RateLimiter.global_rate_limited?/0` and makes `attachment` gate on `attachment_item` as well.