### PR TITLE
fix(client-reports): report every buffered attachment a rate limit discards

### DIFF
--- a/lib/sentry/client.ex
+++ b/lib/sentry/client.ex
@@ -239,8 +239,11 @@ defmodule Sentry.Client do
   defp encode_and_send(%Event{} = event, _result_type = :none, client, _request_retries) do
     if Config.telemetry_processor_category?(:error) do
       case TelemetryProcessor.add(event) do
-        {:ok, {:rate_limited, data_category}} ->
-          ClientReport.Sender.record_discarded_events(:ratelimit_backoff, data_category)
+        {:ok, {:rate_limited, _data_category}} ->
+          ClientReport.Sender.record_discarded_events(
+            :ratelimit_backoff,
+            [event | event.attachments]
+          )
 
         :ok ->
           :ok

--- a/test/sentry/telemetry_processor_integration_test.exs
+++ b/test/sentry/telemetry_processor_integration_test.exs
@@ -477,6 +477,91 @@ defmodule Sentry.TelemetryProcessorIntegrationTest do
       assert ratelimit_event["quantity"] == 1
     end
 
+    test "records attachments when a global limit drops an error before buffering", ctx do
+      put_test_config(telemetry_processor_categories: [:error, :log])
+
+      error_buffer = TelemetryProcessor.get_buffer(ctx.processor, :error)
+
+      set_rate_limit(:global)
+
+      :ok =
+        Sentry.Context.add_attachment(%Sentry.Attachment{filename: "report.txt", data: "report"})
+
+      on_exit(&Sentry.Context.clear_attachments/0)
+
+      Sentry.capture_message("pre-buffer-global-limit", result: :none)
+
+      assert Buffer.size(error_buffer) == 0
+
+      assert collect_discarded_outcomes(ctx.ref, "ratelimit_backoff") == %{
+               "attachment" => 1,
+               "error" => 1
+             }
+    end
+
+    test "sends an error without attachments when attachments are rate limited", ctx do
+      put_test_config(telemetry_processor_categories: [:error, :log])
+
+      set_rate_limit("attachment", scope: :scheduler)
+
+      :ok =
+        Sentry.Context.add_attachment(%Sentry.Attachment{filename: "report.txt", data: "report"})
+
+      on_exit(&Sentry.Context.clear_attachments/0)
+
+      Sentry.capture_message("pre-buffer-attachment-limit", result: :none)
+
+      assert [[{%{"type" => "event"}, event}]] = collect_envelopes(ctx.ref, 1, timeout: 2000)
+      assert event["message"]["formatted"] == "pre-buffer-attachment-limit"
+
+      assert collect_discarded_outcomes(ctx.ref, "ratelimit_backoff") == %{
+               "attachment" => 1
+             }
+    end
+
+    test "sends an error without attachments when attachment items are rate limited", ctx do
+      put_test_config(telemetry_processor_categories: [:error, :log])
+
+      set_rate_limit("attachment_item", scope: :scheduler)
+
+      :ok =
+        Sentry.Context.add_attachment(%Sentry.Attachment{filename: "report.txt", data: "report"})
+
+      on_exit(&Sentry.Context.clear_attachments/0)
+
+      Sentry.capture_message("pre-buffer-attachment-item-limit", result: :none)
+
+      assert [[{%{"type" => "event"}, event}]] = collect_envelopes(ctx.ref, 1, timeout: 2000)
+      assert event["message"]["formatted"] == "pre-buffer-attachment-item-limit"
+
+      assert collect_discarded_outcomes(ctx.ref, "ratelimit_backoff") == %{
+               "attachment" => 1
+             }
+    end
+
+    test "sends an error while dropping all of its rate-limited attachments", ctx do
+      put_test_config(telemetry_processor_categories: [:error, :log])
+
+      set_rate_limit("attachment", scope: :scheduler)
+
+      :ok =
+        Sentry.Context.add_attachment(%Sentry.Attachment{filename: "first.txt", data: "first"})
+
+      :ok =
+        Sentry.Context.add_attachment(%Sentry.Attachment{filename: "second.txt", data: "second"})
+
+      on_exit(&Sentry.Context.clear_attachments/0)
+
+      Sentry.capture_message("pre-buffer-multiple-attachment-limit", result: :none)
+
+      assert [[{%{"type" => "event"}, event}]] = collect_envelopes(ctx.ref, 1, timeout: 2000)
+      assert event["message"]["formatted"] == "pre-buffer-multiple-attachment-limit"
+
+      assert collect_discarded_outcomes(ctx.ref, "ratelimit_backoff") == %{
+               "attachment" => 2
+             }
+    end
+
     test "drops rate-limited check-in events before they enter the buffer", ctx do
       put_test_config(telemetry_processor_categories: [:check_in, :log])
 


### PR DESCRIPTION
The buffered `TelemetryProcessor` path reported a rate-limited event as a single data category, so attachments dropped alongside it never appeared in client reports - the same gap #1151 fixes for the sync path.