### PR TITLE
test(tracing): add e2e scenarios for async trace continuation

### DIFF
--- a/lib/sentry/opentelemetry/span_processor.ex
+++ b/lib/sentry/opentelemetry/span_processor.ex
@@ -56,6 +56,13 @@ if Sentry.OpenTelemetry.VersionChecker.tracing_compatible?() do
         has_local_parent_span?(span_record.parent_span_id) ->
           true
 
+        # Parent lives on another node: this span is the local root of a trace
+        # continued from elsewhere, so it starts its own segment. Compared
+        # explicitly because the field is :undefined for spans with no parent,
+        # which is truthy.
+        span_record.parent_span_is_remote == true ->
+          build_and_send_transaction(span_record)
+
         # Parent is remote (distributed tracing) - treat server spans as
         # transaction roots
         server_span?(span_record) ->

--- a/test/sentry/opentelemetry/distributed_traces_test.exs
+++ b/test/sentry/opentelemetry/distributed_traces_test.exs
@@ -1,0 +1,81 @@
+defmodule Sentry.Opentelemetry.DistributedTracesTest do
+  # Asserts only on reported envelopes, never on span-processing internals,
+  # so this coverage holds across changes to how spans are processed.
+
+  use Sentry.Case, async: false
+
+  require OpenTelemetry.Tracer, as: Tracer
+
+  import Sentry.TestHelpers
+
+  @trace_id String.duplicate("a", 32)
+  @remote_span_id String.duplicate("b", 16)
+
+  setup do
+    setup_bypass()
+  end
+
+  describe "a trace continued from an upstream service" do
+    test "is reported even when its local root is not a server span", %{bypass: bypass} do
+      put_test_config(environment_name: "test", traces_sample_rate: 1.0)
+      ref = setup_bypass_envelope_collector(bypass)
+
+      continue_remote_trace()
+
+      Tracer.with_span "job.run" do
+        Tracer.with_span "job.step" do
+          Process.sleep(1)
+        end
+      end
+
+      assert [tx] = collect_sentry_transactions(ref, 1, timeout: 1000),
+             "nothing was reported for a non-server span under a remote parent"
+
+      assert tx["transaction"] == "job.run"
+
+      trace = tx["contexts"]["trace"]
+      assert trace["trace_id"] == @trace_id
+      assert trace["parent_span_id"] == @remote_span_id
+
+      assert [step] = tx["spans"]
+      assert step["description"] == "job.step"
+      assert step["parent_span_id"] == trace["span_id"]
+      assert step["trace_id"] == @trace_id
+    end
+
+    test "is reported as a single transaction, not one per span", %{bypass: bypass} do
+      put_test_config(environment_name: "test", traces_sample_rate: 1.0)
+      ref = setup_bypass_envelope_collector(bypass)
+
+      continue_remote_trace()
+
+      Tracer.with_span "job.run" do
+        Tracer.with_span "job.step" do
+          Tracer.with_span "job.substep" do
+            Process.sleep(1)
+          end
+        end
+      end
+
+      transactions = collect_sentry_transactions(ref, 5, timeout: 1000)
+
+      assert length(transactions) == 1,
+             "expected one transaction for the whole trace, got: " <>
+               inspect(Enum.map(transactions, & &1["transaction"]))
+
+      [tx] = transactions
+      assert tx["transaction"] == "job.run"
+
+      span_descriptions = tx["spans"] |> Enum.map(& &1["description"]) |> Enum.sort()
+      assert span_descriptions == ["job.step", "job.substep"]
+    end
+  end
+
+  defp continue_remote_trace do
+    :otel_propagator_text_map.extract([
+      {"traceparent", "00-#{@trace_id}-#{@remote_span_id}-01"}
+    ])
+
+    :ok
+  end
+end

--- a/test_integrations/phoenix_app/lib/phoenix_app_web/controllers/async_trace_controller.ex
+++ b/test_integrations/phoenix_app/lib/phoenix_app_web/controllers/async_trace_controller.ex
@@ -1,0 +1,83 @@
+defmodule PhoenixAppWeb.AsyncTraceController do
+  @moduledoc """
+  Scenarios where spans outlive the HTTP request that started them.
+
+  Exercised by the tracing e2e suite, and useful for manually verifying
+  reported traces in the Sentry UI: run the server with a real `SENTRY_DSN`
+  and click through `/async-traces`.
+  """
+
+  use PhoenixAppWeb, :controller
+
+  require OpenTelemetry.Tracer, as: Tracer
+
+  alias PhoenixApp.Repo
+
+  @task_work_ms 500
+
+  def index(conn, _params) do
+    html(conn, """
+    <html>
+      <head><title>Async trace scenarios</title></head>
+      <body>
+        <h1>Async trace scenarios</h1>
+        <ul>
+          <li><a id="in-flight" href="/async-traces/in-flight">In-flight report delivery</a></li>
+          <li><a id="nested" href="/async-traces/nested">Nested batch finalization</a></li>
+        </ul>
+      </body>
+    </html>
+    """)
+  end
+
+  def in_flight(conn, _params) do
+    caller = self()
+    ctx = :otel_ctx.get_current()
+
+    {:ok, _pid} =
+      Task.start(fn ->
+        token = :otel_ctx.attach(ctx)
+
+        try do
+          Tracer.with_span "deliver_report" do
+            send(caller, :report_started)
+            Process.sleep(@task_work_ms)
+          end
+        after
+          :otel_ctx.detach(token)
+        end
+      end)
+
+    receive do
+      :report_started -> :ok
+    after
+      1_000 -> :ok
+    end
+
+    json(conn, %{status: "report delivery in progress"})
+  end
+
+  def nested(conn, _params) do
+    Tracer.with_span "process_batch" do
+      Repo.query!("SELECT 1")
+      ctx = :otel_ctx.get_current()
+
+      {:ok, _pid} =
+        Task.start(fn ->
+          token = :otel_ctx.attach(ctx)
+
+          try do
+            Process.sleep(@task_work_ms)
+
+            Tracer.with_span "finalize_batch" do
+              Process.sleep(10)
+            end
+          after
+            :otel_ctx.detach(token)
+          end
+        end)
+    end
+
+    json(conn, %{status: "batch scheduled"})
+  end
+end

--- a/test_integrations/phoenix_app/lib/phoenix_app_web/router.ex
+++ b/test_integrations/phoenix_app/lib/phoenix_app_web/router.ex
@@ -39,6 +39,10 @@ defmodule PhoenixAppWeb.Router do
 
     live "/test-worker", TestWorkerLive
     live "/async-report", AsyncReportLive
+
+    get "/async-traces", AsyncTraceController, :index
+    get "/async-traces/in-flight", AsyncTraceController, :in_flight
+    get "/async-traces/nested", AsyncTraceController, :nested
     live "/tracing-test", TracingTestLive
 
     live "/users", UserLive.Index, :index

--- a/test_integrations/phoenix_app/test/phoenix_app/distributed_traces_test.exs
+++ b/test_integrations/phoenix_app/test/phoenix_app/distributed_traces_test.exs
@@ -1,0 +1,38 @@
+defmodule PhoenixApp.DistributedTracesTest do
+  use PhoenixAppWeb.ConnCase, async: false
+
+  require OpenTelemetry.Tracer, as: Tracer
+
+  import Sentry.TestHelpers
+
+  @trace_id String.duplicate("a", 32)
+  @remote_span_id String.duplicate("b", 16)
+
+  setup do
+    Sentry.Test.setup_sentry(collect_envelopes: true, traces_sample_rate: 1.0)
+  end
+
+  test "work continuing an upstream trace is reported with its instrumented spans", %{ref: ref} do
+    :otel_propagator_text_map.extract([
+      {"traceparent", "00-#{@trace_id}-#{@remote_span_id}-01"}
+    ])
+
+    Tracer.with_span "etl.sync" do
+      PhoenixApp.Repo.query!("SELECT 1")
+    end
+
+    assert [tx] = collect_sentry_transactions(ref, 1, timeout: 500),
+             "nothing was reported for work continuing an upstream trace"
+
+    assert tx["transaction"] == "etl.sync"
+
+    trace = tx["contexts"]["trace"]
+    assert trace["trace_id"] == @trace_id
+    assert trace["parent_span_id"] == @remote_span_id
+
+    assert [db_span] = tx["spans"]
+    assert db_span["op"] == "db"
+    assert db_span["parent_span_id"] == trace["span_id"]
+    assert db_span["trace_id"] == @trace_id
+  end
+end

--- a/test_integrations/tracing/tests/async_traces.spec.ts
+++ b/test_integrations/tracing/tests/async_traces.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from "@playwright/test";
+import {
+  clearLoggedEvents,
+  waitForEvents,
+  type SentryEvent,
+  type TransactionWithSpans,
+} from "./helpers";
+
+const PHOENIX_URL = process.env.SENTRY_E2E_PHOENIX_APP_URL;
+if (!PHOENIX_URL) {
+  throw new Error(
+    "Required environment variable SENTRY_E2E_PHOENIX_APP_URL is not set."
+  );
+}
+
+function transactions(events: SentryEvent[]): TransactionWithSpans[] {
+  return events.filter(
+    (e) => e.type === "transaction"
+  ) as TransactionWithSpans[];
+}
+
+function findByRoute(
+  events: SentryEvent[],
+  route: string
+): TransactionWithSpans | undefined {
+  return transactions(events).find(
+    (t) => t.contexts?.trace?.data?.["http.route"] === route
+  );
+}
+
+function findByName(
+  events: SentryEvent[],
+  name: string
+): TransactionWithSpans | undefined {
+  return transactions(events).find((t) => t.transaction === name);
+}
+
+test.describe("Async trace continuation", () => {
+  test.beforeEach(() => {
+    clearLoggedEvents();
+  });
+
+  test("work outliving the request is reported as a linked follow-up transaction", async ({
+    page,
+  }) => {
+    await page.goto(`${PHOENIX_URL}/async-traces/in-flight`);
+
+    const logged = await waitForEvents((l) =>
+      Boolean(
+        findByRoute(l.events, "/async-traces/in-flight") &&
+          findByName(l.events, "deliver_report")
+      )
+    );
+
+    const requestTx = findByRoute(logged.events, "/async-traces/in-flight");
+    const followUpTx = findByName(logged.events, "deliver_report");
+
+    expect(requestTx).toBeDefined();
+    expect(followUpTx).toBeDefined();
+
+    const requestTrace = requestTx!.contexts?.trace;
+    expect(requestTrace?.op).toBe("http.server");
+
+    const requestSpans = requestTx!.spans ?? [];
+    for (const span of requestSpans) {
+      expect(span.timestamp, `span ${span.description} has no end timestamp`)
+        .toBeTruthy();
+    }
+    expect(requestSpans.map((s) => s.description)).not.toContain(
+      "deliver_report"
+    );
+
+    const followUpTrace = followUpTx!.contexts?.trace;
+    expect(followUpTrace?.trace_id).toBe(requestTrace?.trace_id);
+    expect(followUpTrace?.parent_span_id).toBe(requestTrace?.span_id);
+    expect(followUpTrace?.data?.["sentry.parent_span_already_sent"]).toBe(
+      true
+    );
+  });
+
+  test("late work from a nested span is reported as a linked follow-up transaction", async ({
+    page,
+  }) => {
+    await page.goto(`${PHOENIX_URL}/async-traces/nested`);
+
+    const logged = await waitForEvents((l) =>
+      Boolean(
+        findByRoute(l.events, "/async-traces/nested") &&
+          findByName(l.events, "finalize_batch")
+      )
+    );
+
+    const requestTx = findByRoute(logged.events, "/async-traces/nested");
+    const followUpTx = findByName(logged.events, "finalize_batch");
+
+    expect(requestTx).toBeDefined();
+    expect(followUpTx).toBeDefined();
+
+    const requestSpans = requestTx!.spans ?? [];
+    const batchSpan = requestSpans.find(
+      (s) => s.description === "process_batch"
+    );
+    const dbSpan = requestSpans.find((s) => s.op === "db");
+
+    expect(batchSpan).toBeDefined();
+    expect(dbSpan).toBeDefined();
+    expect(dbSpan!.parent_span_id).toBe(batchSpan!.span_id);
+
+    const followUpTrace = followUpTx!.contexts?.trace;
+    expect(followUpTrace?.trace_id).toBe(
+      requestTx!.contexts?.trace?.trace_id
+    );
+    expect(followUpTrace?.parent_span_id).toBe(batchSpan!.span_id);
+    expect(followUpTrace?.data?.["sentry.parent_span_already_sent"]).toBe(
+      true
+    );
+  });
+
+  test("scenario index page links to both scenarios", async ({ page }) => {
+    await page.goto(`${PHOENIX_URL}/async-traces`);
+
+    await expect(page.locator("h1")).toContainText("Async trace scenarios");
+    await expect(page.locator("a#in-flight")).toBeVisible();
+    await expect(page.locator("a#nested")).toBeVisible();
+  });
+});

--- a/test_integrations/tracing/tests/helpers.ts
+++ b/test_integrations/tracing/tests/helpers.ts
@@ -147,6 +147,8 @@ export interface Span {
   parent_span_id?: string;
   op?: string;
   description?: string;
+  start_timestamp?: string | null;
+  timestamp?: string | null;
   data?: Record<string, any>;
 }
 


### PR DESCRIPTION
You can have as many unit tests as you want, but here's the real-deal coverage. This is also useful when doing manual smoke testing.