### PR TITLE
fix(tracing): report spans whose parent lives on another node

### DIFF
--- a/lib/sentry/opentelemetry/span_processor.ex
+++ b/lib/sentry/opentelemetry/span_processor.ex
@@ -16,10 +16,49 @@ if Sentry.OpenTelemetry.VersionChecker.tracing_compatible?() do
     alias Sentry.Interfaces.Span
 
     @impl :otel_span_processor
-    def on_start(_ctx, otel_span, _config) do
+    def on_start(ctx, otel_span, _config) do
+      otel_span = mark_parent_is_remote(ctx, otel_span)
+
       span_record = SpanRecord.new(otel_span)
       SpanStorage.store_span(span_record)
       otel_span
+    end
+
+    if SpanRecord.parent_is_remote_on_record?() do
+      defp mark_parent_is_remote(_ctx, otel_span), do: otel_span
+    else
+      # Older opentelemetry releases don't carry parent_span_is_remote on the
+      # span record, but the parent's span context always knows whether it came
+      # off the wire. Recording it as an attribute here is the only point where
+      # that context is still reachable; SpanRecord strips it again so it never
+      # reaches a reported payload.
+      require Record
+
+      Record.defrecordp(
+        :span_ctx,
+        Record.extract(:span_ctx, from_lib: "opentelemetry_api/include/opentelemetry.hrl")
+      )
+
+      Record.defrecordp(
+        :otel_span_rec,
+        Record.extract(:span, from_lib: "opentelemetry/include/otel_span.hrl")
+      )
+
+      defp mark_parent_is_remote(ctx, otel_span) do
+        case :otel_tracer.current_span_ctx(ctx) do
+          span_ctx(is_remote: true) ->
+            attributes =
+              :otel_attributes.set(
+                %{SpanRecord.parent_is_remote_attribute() => true},
+                otel_span_rec(otel_span, :attributes)
+              )
+
+            otel_span_rec(otel_span, attributes: attributes)
+
+          _ ->
+            otel_span
+        end
+      end
     end
 
     @impl :otel_span_processor
@@ -55,6 +94,16 @@ if Sentry.OpenTelemetry.VersionChecker.tracing_compatible?() do
         # Parent exists locally - this is a child span, not a transaction root
         has_local_parent_span?(span_record.parent_span_id) ->
           true
+
+        # A remote parent never appears in this node's storage, so this span is
+        # the local root of a trace continued from elsewhere. Must stay below
+        # the local-parent check: OTel copies the parent's span_ctx into every
+        # child, so is_remote stays true for the whole local subtree - checked
+        # any earlier, every span in the trace becomes its own transaction.
+        # Compared to true explicitly because the field is :undefined for
+        # parentless spans, which is truthy.
+        span_record.parent_span_is_remote == true ->
+          build_and_send_transaction(span_record)
 
         # Parent is remote (distributed tracing) - treat server spans as
         # transaction roots

--- a/lib/sentry/opentelemetry/span_record.ex
+++ b/lib/sentry/opentelemetry/span_record.ex
@@ -9,7 +9,24 @@ if Sentry.OpenTelemetry.VersionChecker.tracing_compatible?() do
     @fields Record.extract(:span, from_lib: "opentelemetry/include/otel_span.hrl")
     Record.defrecordp(:span, @fields)
 
-    defstruct @fields ++ [:origin]
+    # opentelemetry < 1.6 has no parent_span_is_remote on the span record. The
+    # struct always exposes it so callers stay version-agnostic; on those
+    # versions the span processor supplies the value through
+    # @parent_is_remote_attribute instead.
+    @parent_is_remote_on_record Keyword.has_key?(@fields, :parent_span_is_remote)
+    @parent_is_remote_attribute "sentry.parent_is_remote"
+
+    @extra_fields if @parent_is_remote_on_record,
+                    do: [:origin],
+                    else: [:origin, parent_span_is_remote: false]
+
+    defstruct @fields ++ @extra_fields
+
+    @doc false
+    def parent_is_remote_on_record?, do: @parent_is_remote_on_record
+
+    @doc false
+    def parent_is_remote_attribute, do: @parent_is_remote_attribute
 
     def new(span() = otel_span) do
       otel_attrs = span(otel_span)
@@ -25,6 +42,8 @@ if Sentry.OpenTelemetry.VersionChecker.tracing_compatible?() do
             :undefined
         end
 
+      {parent_is_remote, attributes} = pop_parent_is_remote(normalize_attributes(attributes))
+
       attrs =
         otel_attrs
         |> Keyword.delete(:attributes)
@@ -36,12 +55,22 @@ if Sentry.OpenTelemetry.VersionChecker.tracing_compatible?() do
           origin: origin,
           start_time: cast_timestamp(otel_attrs[:start_time]),
           end_time: cast_timestamp(otel_attrs[:end_time]),
-          attributes: normalize_attributes(attributes),
+          attributes: attributes,
           links: cast_links(otel_attrs[:links])
         )
         |> Map.new()
+        |> Map.merge(parent_is_remote)
 
       struct(__MODULE__, attrs)
+    end
+
+    if @parent_is_remote_on_record do
+      defp pop_parent_is_remote(attributes), do: {%{}, attributes}
+    else
+      defp pop_parent_is_remote(attributes) do
+        {remote?, attributes} = Map.pop(attributes, @parent_is_remote_attribute, false)
+        {%{parent_span_is_remote: remote?}, attributes}
+      end
     end
 
     defp normalize_attributes(attributes) do

--- a/test/sentry/opentelemetry/distributed_traces_test.exs
+++ b/test/sentry/opentelemetry/distributed_traces_test.exs
@@ -1,0 +1,84 @@
+defmodule Sentry.Opentelemetry.DistributedTracesTest do
+  # Asserts only on reported envelopes, never on span-processing internals,
+  # so this coverage holds across changes to how spans are processed.
+
+  use Sentry.Case, async: false
+
+  require OpenTelemetry.Tracer, as: Tracer
+
+  import Sentry.TestHelpers
+
+  @trace_id String.duplicate("a", 32)
+  @remote_span_id String.duplicate("b", 16)
+
+  setup do
+    setup_bypass()
+  end
+
+  describe "a trace continued from an upstream service" do
+    test "is reported even when its local root is not a server span", %{bypass: bypass} do
+      put_test_config(environment_name: "test", traces_sample_rate: 1.0)
+      ref = setup_bypass_envelope_collector(bypass)
+
+      continue_remote_trace()
+
+      Tracer.with_span "job.run" do
+        Tracer.with_span "job.step" do
+          Process.sleep(1)
+        end
+      end
+
+      assert [tx] = collect_sentry_transactions(ref, 1, timeout: 1000),
+             "nothing was reported for a non-server span under a remote parent"
+
+      assert tx["transaction"] == "job.run"
+
+      trace = tx["contexts"]["trace"]
+      assert trace["trace_id"] == @trace_id
+      assert trace["parent_span_id"] == @remote_span_id
+
+      assert [step] = tx["spans"]
+      assert step["description"] == "job.step"
+      assert step["parent_span_id"] == trace["span_id"]
+      assert step["trace_id"] == @trace_id
+
+      refute Map.has_key?(trace["data"], "sentry.parent_is_remote")
+      refute Enum.any?(tx["spans"], &Map.has_key?(&1["data"], "sentry.parent_is_remote"))
+    end
+
+    test "is reported as a single transaction, not one per span", %{bypass: bypass} do
+      put_test_config(environment_name: "test", traces_sample_rate: 1.0)
+      ref = setup_bypass_envelope_collector(bypass)
+
+      continue_remote_trace()
+
+      Tracer.with_span "job.run" do
+        Tracer.with_span "job.step" do
+          Tracer.with_span "job.substep" do
+            Process.sleep(1)
+          end
+        end
+      end
+
+      transactions = collect_sentry_transactions(ref, 5, timeout: 1000)
+
+      assert length(transactions) == 1,
+             "expected one transaction for the whole trace, got: " <>
+               inspect(Enum.map(transactions, & &1["transaction"]))
+
+      [tx] = transactions
+      assert tx["transaction"] == "job.run"
+
+      span_descriptions = tx["spans"] |> Enum.map(& &1["description"]) |> Enum.sort()
+      assert span_descriptions == ["job.step", "job.substep"]
+    end
+  end
+
+  defp continue_remote_trace do
+    :otel_propagator_text_map.extract([
+      {"traceparent", "00-#{@trace_id}-#{@remote_span_id}-01"}
+    ])
+
+    :ok
+  end
+end

--- a/test_integrations/phoenix_app/test/phoenix_app/distributed_traces_test.exs
+++ b/test_integrations/phoenix_app/test/phoenix_app/distributed_traces_test.exs
@@ -1,0 +1,38 @@
+defmodule PhoenixApp.DistributedTracesTest do
+  use PhoenixAppWeb.ConnCase, async: false
+
+  require OpenTelemetry.Tracer, as: Tracer
+
+  import Sentry.TestHelpers
+
+  @trace_id String.duplicate("a", 32)
+  @remote_span_id String.duplicate("b", 16)
+
+  setup do
+    Sentry.Test.setup_sentry(collect_envelopes: true, traces_sample_rate: 1.0)
+  end
+
+  test "work continuing an upstream trace is reported with its instrumented spans", %{ref: ref} do
+    :otel_propagator_text_map.extract([
+      {"traceparent", "00-#{@trace_id}-#{@remote_span_id}-01"}
+    ])
+
+    Tracer.with_span "etl.sync" do
+      PhoenixApp.Repo.query!("SELECT 1")
+    end
+
+    assert [tx] = collect_sentry_transactions(ref, 1, timeout: 500),
+             "nothing was reported for work continuing an upstream trace"
+
+    assert tx["transaction"] == "etl.sync"
+
+    trace = tx["contexts"]["trace"]
+    assert trace["trace_id"] == @trace_id
+    assert trace["parent_span_id"] == @remote_span_id
+
+    assert [db_span] = tx["spans"]
+    assert db_span["op"] == "db"
+    assert db_span["parent_span_id"] == trace["span_id"]
+    assert db_span["trace_id"] == @trace_id
+  end
+end


### PR DESCRIPTION
When a service continued a trace from a `traceparent` and its local root was anything other than an HTTP-server / LiveView / Oban-consumer span etc., `process_span/1` fell through to the `server_span?/1` heuristic and the **entire local subtree was silently dropped**.

`SpanRecord` already carries OTel's `parent_span_is_remote`, so the local root of remotely-continued trace can be identified directly and reported as its own segment. `build_trace_context/2` already passes `parent_span_id` through, so it nests under the upstream transaction.

This works on every supported opentelemetry version.

⚠️ `parent_span_is_remote` only exists on the span record from opentelemetry >= `1.6`, so on `1.5.x` (what Elixir 1.13/1.14 lock) the span processor derives it from the parent span context at `on_start` and carries it via an internal attribute that never reaches a payload.

## Before

<img src="https://github.com/user-attachments/assets/2cd417ed-0a56-4faf-a275-449f731d6876 " alt="image" width="2026" data-linear-height="1377" />

## After

<img src="https://github.com/user-attachments/assets/42f6fd27-2125-41d8-a756-9189e47dc645 " alt="image" width="2040" data-linear-height="1383" />

---

Fixes getsentry/sentry-elixir#1166