### PR TITLE
test(client-reports): disable the periodic flush in test mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ The SDK starts as an OTP application with a `:one_for_one` supervisor. Key child
 1. **Registry** — `Sentry.Transport.SenderRegistry` for sender worker lookup
 2. **Sentry.Sources** — Source code context for error reports
 3. **Sentry.Dedupe** — Event deduplication
-4. **Sentry.ClientReport.Sender** — Reports discarded events to Sentry
+4. **Sentry.ClientReport.Sender** — Reports discarded events to Sentry (not started in test mode; `Sentry.Test` starts one per test)
 5. **HTTP Client** — Pluggable (Finch or Hackney), started if it has `child_spec/0`
 6. **Sentry.OpenTelemetry.SpanStorage** — ETS-backed span storage (when tracing is enabled)
 7. **Sentry.TelemetryProcessor** — Buffered event processing pipeline

--- a/lib/sentry/application.ex
+++ b/lib/sentry/application.ex
@@ -68,13 +68,13 @@ defmodule Sentry.Application do
           {Registry, keys: :unique, name: Sentry.Transport.SenderRegistry},
           Sentry.Sources,
           Sentry.Dedupe,
-          Sentry.ClientReport.Sender,
           {Sentry.Integrations.CheckInIDMappings,
            [
              max_expected_check_in_time:
                Keyword.fetch!(integrations_config, :max_expected_check_in_time)
            ]}
         ] ++
+        maybe_client_report_sender() ++
         maybe_http_client_spec ++
         maybe_span_storage ++
         telemetry_processor ++
@@ -195,6 +195,13 @@ defmodule Sentry.Application do
     defp maybe_rate_limiter, do: []
   else
     defp maybe_rate_limiter, do: [Sentry.Transport.RateLimiter]
+  end
+
+  # In tests, we do not run a global client report sender; its periodic flush would
+  # deliver unowned outcomes to whichever DSN is bound when it fires. Tests get one
+  # per test from `Sentry.Test.setup_client_report_sender/0`.
+  defp maybe_client_report_sender do
+    if Config.test_mode?(), do: [], else: [Sentry.ClientReport.Sender]
   end
 
   defp maybe_put_test_processor_resolver(opts) do

--- a/lib/sentry/client_report/sender.ex
+++ b/lib/sentry/client_report/sender.ex
@@ -33,11 +33,11 @@ defmodule Sentry.ClientReport.Sender do
   Synchronously sends any pending client reports and clears the accumulated state.
   """
   @spec flush(GenServer.server()) :: :ok
-  def flush(server \\ __MODULE__) do
+  def flush(server \\ Config.client_report_sender()) do
     GenServer.call(server, :flush)
   end
 
-  def record_discarded_events(reason, info, genserver \\ __MODULE__)
+  def record_discarded_events(reason, info, genserver \\ Config.client_report_sender())
 
   @spec record_discarded_events(atom(), String.t(), GenServer.server()) :: :ok
   def record_discarded_events(reason, data_category, genserver)

--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -585,6 +585,21 @@ defmodule Sentry.Config do
       *Available since 12.0.0*.
       """
     ],
+    client_report_sender: [
+      type: :atom,
+      default: Sentry.ClientReport.Sender,
+      doc: """
+      The registered name of the process that accumulates discarded-event outcomes
+      and flushes them to Sentry as client reports.
+
+      Defaults to the globally-supervised `Sentry.ClientReport.Sender`. When
+      `test_mode: true` is enabled, `Sentry.Test` starts one sender per test and
+      points this at it, so outcomes are attributed to the test that produced
+      them and never outlive it.
+
+      *Available since 14.0.0*.
+      """
+    ],
     namespace: [
       type: {:custom, __MODULE__, :__validate_namespace__, []},
       type_doc: "`{module(), atom()}`",
@@ -1102,6 +1117,11 @@ defmodule Sentry.Config do
   @doc deprecated: "Use Sentry.Test instead. This option will be removed in v13.0.0."
   @spec test_mode?() :: boolean()
   def test_mode?, do: fetch!(:test_mode)
+
+  # Read per call rather than cached, so that the caller's process lineage
+  # decides which sender receives the outcome.
+  @spec client_report_sender() :: atom()
+  def client_report_sender, do: fetch!(:client_report_sender)
 
   @spec enable_logs?() :: boolean()
   def enable_logs?, do: fetch!(:enable_logs)

--- a/lib/sentry/telemetry/scheduler.ex
+++ b/lib/sentry/telemetry/scheduler.ex
@@ -545,9 +545,10 @@ defmodule Sentry.Telemetry.Scheduler do
 
       true ->
         data_category = Category.data_category(category)
+        sender = Config.client_report_sender()
 
         Enum.each(items, fn _item ->
-          ClientReport.Sender.record_discarded_events(:ratelimit_backoff, data_category)
+          ClientReport.Sender.record_discarded_events(:ratelimit_backoff, data_category, sender)
         end)
     end
 

--- a/lib/sentry/test.ex
+++ b/lib/sentry/test.ex
@@ -68,10 +68,12 @@ defmodule Sentry.Test do
   that travel through the TelemetryProcessor pipeline (logs, metrics, or
   `send_result: :none`).
 
-  Returns a map with `:bypass` and `:telemetry_processor` for use in test
-  context. The `:telemetry_processor` value is the atom name of the
-  per-test processor and can be used to `stop_supervised!/1` and start
-  a custom-configured one when needed.
+  Returns a map with `:bypass`, `:telemetry_processor` and
+  `:client_report_sender` for use in test context. The
+  `:telemetry_processor` value is the atom name of the per-test processor
+  and can be used to `stop_supervised!/1` and start a custom-configured one
+  when needed. The `:client_report_sender` value names this test's
+  `Sentry.ClientReport.Sender` (see `setup_client_report_sender/0`).
 
   ## Options
 
@@ -128,6 +130,7 @@ defmodule Sentry.Test do
   @spec setup_sentry(keyword()) :: %{
           :bypass => term(),
           :telemetry_processor => atom(),
+          :client_report_sender => atom(),
           optional(:ref) => reference()
         }
   def setup_sentry(extra_config \\ []) do
@@ -143,6 +146,8 @@ defmodule Sentry.Test do
       Plug.Conn.resp(conn, 200, ~s<{"id": "#{Sentry.UUID.uuid4_hex()}"}>)
     end)
 
+    sender_name = setup_client_report_sender()
+
     # Start a per-test TelemetryProcessor before setup_collector/1 so that
     # the collector wires this test's scheduler into its registry.
     processor_name = setup_telemetry_processor(tp_opts)
@@ -153,7 +158,11 @@ defmodule Sentry.Test do
 
     case collect_envelopes do
       false ->
-        %{bypass: bypass, telemetry_processor: processor_name}
+        %{
+          bypass: bypass,
+          telemetry_processor: processor_name,
+          client_report_sender: sender_name
+        }
 
       collect ->
         collector_opts = if is_list(collect), do: collect, else: []
@@ -161,6 +170,7 @@ defmodule Sentry.Test do
         %{
           bypass: bypass,
           telemetry_processor: processor_name,
+          client_report_sender: sender_name,
           ref: setup_bypass_envelope_collector(bypass, collector_opts)
         }
     end
@@ -210,7 +220,7 @@ defmodule Sentry.Test do
     case Process.get(:sentry_telemetry_processor) do
       name when is_atom(name) and not is_nil(name) ->
         cond do
-          not processor_alive?(name) -> start_telemetry_processor(tp_opts)
+          not registered_alive?(name) -> start_telemetry_processor(tp_opts)
           tp_opts == [] -> name
           true -> restart_telemetry_processor(name, tp_opts)
         end
@@ -264,11 +274,54 @@ defmodule Sentry.Test do
     :ok
   end
 
-  defp processor_alive?(name) do
+  defp registered_alive?(name) do
     case Process.whereis(name) do
       pid when is_pid(pid) -> Process.alive?(pid)
       _ -> false
     end
+  end
+
+  @doc """
+  Starts a `Sentry.ClientReport.Sender` owned by the current test and points
+  the `:client_report_sender` configuration at it.
+
+  Discarded-event outcomes recorded by this test — or by any process whose
+  lineage resolves to it, the way `Sentry.Config.dsn/0` resolves — accumulate
+  in that sender and die with the test, instead of collecting in a VM-global
+  process that outlives it. Returns the sender's registered name.
+
+  Called for you by `Sentry.Case` and `setup_sentry/1`; calling it again
+  reuses the sender this test already owns.
+  """
+  @doc since: "14.0.0"
+  @spec setup_client_report_sender() :: atom()
+  def setup_client_report_sender do
+    case Process.get(:sentry_client_report_sender) do
+      name when is_atom(name) and not is_nil(name) ->
+        if registered_alive?(name), do: name, else: start_client_report_sender()
+
+      _ ->
+        start_client_report_sender()
+    end
+  end
+
+  defp start_client_report_sender do
+    uid = System.unique_integer([:positive])
+    name = :"test_client_report_sender_#{uid}"
+
+    # The sender posts from its own process, where `Sentry.Transport.RateLimiter`
+    # resolves its table out of the process dictionary, so it needs this test's
+    # table to be subject to the limits the test sets.
+    ExUnit.Callbacks.start_supervised!(
+      {Sentry.ClientReport.Sender,
+       name: name, rate_limiter_table_name: Process.get(:rate_limiter_table_name)},
+      id: name
+    )
+
+    Process.put(:sentry_client_report_sender, name)
+    Sentry.Test.Config.put(client_report_sender: name)
+
+    name
   end
 
   @doc """

--- a/test/sentry/config_test.exs
+++ b/test/sentry/config_test.exs
@@ -459,6 +459,18 @@ defmodule Sentry.ConfigTest do
     end
   end
 
+  describe ":client_report_sender" do
+    test "defaults to the globally-supervised sender" do
+      config = Config.validate!([])
+      assert config[:client_report_sender] == Sentry.ClientReport.Sender
+    end
+
+    test "resolves to the sender configured for the current scope" do
+      put_test_config(client_report_sender: :some_other_sender)
+      assert Config.client_report_sender() == :some_other_sender
+    end
+  end
+
   describe ":before_send_metric" do
     test "accepts a function callback" do
       callback = fn metric -> metric end

--- a/test/sentry/opentelemetry/sampler_test.exs
+++ b/test/sentry/opentelemetry/sampler_test.exs
@@ -2,7 +2,6 @@ defmodule Sentry.Opentelemetry.SamplerTest do
   use Sentry.Case, async: false
 
   alias Sentry.OpenTelemetry.Sampler
-  alias Sentry.ClientReport
   alias SamplingContext
 
   import ExUnit.CaptureLog
@@ -28,9 +27,8 @@ defmodule Sentry.Opentelemetry.SamplerTest do
   end
 
   describe "span name dropping" do
-    test "drops spans with the given name and records discarded event" do
-      :sys.replace_state(ClientReport.Sender, fn _ -> %{} end)
-
+    test "drops spans with the given name and records discarded event",
+         %{client_report_sender: sender} do
       test_ctx = create_test_span_context()
 
       assert {:drop, [], []} =
@@ -38,7 +36,7 @@ defmodule Sentry.Opentelemetry.SamplerTest do
                  drop: ["Elixir.Oban.Stager process"]
                )
 
-      state = :sys.get_state(ClientReport.Sender)
+      state = :sys.get_state(sender)
       assert state == %{{:sample_rate, "transaction"} => 1, {:sample_rate, "span"} => 1}
     end
 
@@ -79,9 +77,8 @@ defmodule Sentry.Opentelemetry.SamplerTest do
   end
 
   describe "sampling based on traces_sample_rate" do
-    test "always drops when sample rate is 0.0 and records discarded event" do
-      :sys.replace_state(ClientReport.Sender, fn _ -> %{} end)
-
+    test "always drops when sample rate is 0.0 and records discarded event",
+         %{client_report_sender: sender} do
       put_test_config(traces_sample_rate: 0.0)
 
       test_ctx = create_test_span_context()
@@ -92,7 +89,7 @@ defmodule Sentry.Opentelemetry.SamplerTest do
       assert {"sentry-sample_rate", "0.0"} in tracestate
       assert {"sentry-sampled", "false"} in tracestate
 
-      state = :sys.get_state(ClientReport.Sender)
+      state = :sys.get_state(sender)
       assert state == %{{:sample_rate, "transaction"} => 1, {:sample_rate, "span"} => 1}
     end
 
@@ -128,9 +125,8 @@ defmodule Sentry.Opentelemetry.SamplerTest do
       assert sampled_count > 30 and sampled_count < 70
     end
 
-    test "records discarded events when randomly dropped by sample rate" do
-      :sys.replace_state(ClientReport.Sender, fn _ -> %{} end)
-
+    test "records discarded events when randomly dropped by sample rate",
+         %{client_report_sender: sender} do
       put_test_config(traces_sample_rate: 0.001)
 
       Enum.each(1..50, fn trace_id ->
@@ -138,14 +134,13 @@ defmodule Sentry.Opentelemetry.SamplerTest do
         Sampler.should_sample(test_ctx, trace_id, nil, "test span", nil, nil, drop: [])
       end)
 
-      state = :sys.get_state(ClientReport.Sender)
+      state = :sys.get_state(sender)
       discarded_count = Map.get(state, {:sample_rate, "transaction"}, 0)
       assert discarded_count > 0, "Expected some spans to be dropped and recorded"
     end
 
-    test "always drops when sample rate is nil (tracing disabled) and records discarded event" do
-      :sys.replace_state(ClientReport.Sender, fn _ -> %{} end)
-
+    test "always drops when sample rate is nil (tracing disabled) and records discarded event",
+         %{client_report_sender: sender} do
       put_test_config(traces_sample_rate: nil)
 
       test_ctx = create_test_span_context()
@@ -153,7 +148,7 @@ defmodule Sentry.Opentelemetry.SamplerTest do
       assert {:drop, [], []} =
                Sampler.should_sample(test_ctx, 123, nil, "test span", nil, nil, drop: [])
 
-      state = :sys.get_state(ClientReport.Sender)
+      state = :sys.get_state(sender)
       assert state == %{{:sample_rate, "transaction"} => 1, {:sample_rate, "span"} => 1}
     end
   end
@@ -171,9 +166,8 @@ defmodule Sentry.Opentelemetry.SamplerTest do
       )
     end
 
-    test "all spans in trace inherit sampling decision to drop when trace was not sampled" do
-      :sys.replace_state(ClientReport.Sender, fn _ -> %{} end)
-
+    test "all spans in trace inherit sampling decision to drop when trace was not sampled",
+         %{client_report_sender: sender} do
       trace_id = 12_345_678_901_234_567_890_123_456_789_012
 
       trace_tracestate = [
@@ -197,7 +191,7 @@ defmodule Sentry.Opentelemetry.SamplerTest do
         assert {:drop, [], returned_tracestate} = result
         assert returned_tracestate == trace_tracestate
 
-        state = :sys.get_state(ClientReport.Sender)
+        state = :sys.get_state(sender)
         assert state == %{{:sample_rate, "transaction"} => 1, {:sample_rate, "span"} => 1}
       after
         :otel_ctx.detach(token)

--- a/test/sentry/telemetry_processor_integration_test.exs
+++ b/test/sentry/telemetry_processor_integration_test.exs
@@ -254,7 +254,6 @@ defmodule Sentry.TelemetryProcessorIntegrationTest do
         }
       )
 
-      Sentry.ClientReport.Sender.flush()
       flush_ref_messages(ctx.ref)
 
       :ok
@@ -341,8 +340,6 @@ defmodule Sentry.TelemetryProcessorIntegrationTest do
         Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
       end)
 
-      Sentry.ClientReport.Sender.flush()
-
       on_exit(fn -> reset_rate_limits(scope: :scheduler) end)
 
       :ok
@@ -364,7 +361,7 @@ defmodule Sentry.TelemetryProcessorIntegrationTest do
 
       Sentry.capture_message("rate-limited-error", result: :none)
 
-      outcomes = collect_discarded_outcomes(ref, "ratelimit_backoff")
+      outcomes = collect_discarded_outcomes(ctx.client_report_sender, ref, "ratelimit_backoff")
 
       assert outcomes["error"] == 1
     end
@@ -380,7 +377,6 @@ defmodule Sentry.TelemetryProcessorIntegrationTest do
       )
 
       put_test_config(client: Sentry.FinchClient)
-      Sentry.ClientReport.Sender.flush()
       flush_ref_messages(ctx.ref)
 
       on_exit(fn -> reset_rate_limits(scope: :scheduler) end)
@@ -400,7 +396,7 @@ defmodule Sentry.TelemetryProcessorIntegrationTest do
 
       Sentry.Metrics.count("rate.limited.metric", 1)
 
-      outcomes = collect_discarded_outcomes(ref, "ratelimit_backoff")
+      outcomes = collect_discarded_outcomes(ctx.client_report_sender, ref, "ratelimit_backoff")
 
       assert outcomes["trace_metric"] == 1
       assert is_integer(outcomes["trace_metric_byte"]) and outcomes["trace_metric_byte"] > 0
@@ -420,7 +416,7 @@ defmodule Sentry.TelemetryProcessorIntegrationTest do
 
       Logger.info("rate limited log")
 
-      outcomes = collect_discarded_outcomes(ref, "ratelimit_backoff")
+      outcomes = collect_discarded_outcomes(ctx.client_report_sender, ref, "ratelimit_backoff")
 
       assert outcomes["log_item"] == 1
       assert is_integer(outcomes["log_byte"]) and outcomes["log_byte"] > 0
@@ -429,7 +425,6 @@ defmodule Sentry.TelemetryProcessorIntegrationTest do
 
   describe "pre-buffer rate limit checks" do
     setup ctx do
-      Sentry.ClientReport.Sender.flush()
       flush_ref_messages(ctx.ref)
 
       :ok
@@ -493,10 +488,13 @@ defmodule Sentry.TelemetryProcessorIntegrationTest do
 
       assert Buffer.size(error_buffer) == 0
 
-      assert collect_discarded_outcomes(ctx.ref, "ratelimit_backoff") == %{
-               "attachment" => 1,
-               "error" => 1
-             }
+      reset_rate_limits()
+
+      assert collect_discarded_outcomes(ctx.client_report_sender, ctx.ref, "ratelimit_backoff") ==
+               %{
+                 "attachment" => 1,
+                 "error" => 1
+               }
     end
 
     test "sends an error without attachments when attachments are rate limited", ctx do
@@ -514,9 +512,10 @@ defmodule Sentry.TelemetryProcessorIntegrationTest do
       assert [[{%{"type" => "event"}, event}]] = collect_envelopes(ctx.ref, 1, timeout: 2000)
       assert event["message"]["formatted"] == "pre-buffer-attachment-limit"
 
-      assert collect_discarded_outcomes(ctx.ref, "ratelimit_backoff") == %{
-               "attachment" => 1
-             }
+      assert collect_discarded_outcomes(ctx.client_report_sender, ctx.ref, "ratelimit_backoff") ==
+               %{
+                 "attachment" => 1
+               }
     end
 
     test "sends an error without attachments when attachment items are rate limited", ctx do
@@ -534,9 +533,10 @@ defmodule Sentry.TelemetryProcessorIntegrationTest do
       assert [[{%{"type" => "event"}, event}]] = collect_envelopes(ctx.ref, 1, timeout: 2000)
       assert event["message"]["formatted"] == "pre-buffer-attachment-item-limit"
 
-      assert collect_discarded_outcomes(ctx.ref, "ratelimit_backoff") == %{
-               "attachment" => 1
-             }
+      assert collect_discarded_outcomes(ctx.client_report_sender, ctx.ref, "ratelimit_backoff") ==
+               %{
+                 "attachment" => 1
+               }
     end
 
     test "sends an error while dropping all of its rate-limited attachments", ctx do
@@ -557,9 +557,10 @@ defmodule Sentry.TelemetryProcessorIntegrationTest do
       assert [[{%{"type" => "event"}, event}]] = collect_envelopes(ctx.ref, 1, timeout: 2000)
       assert event["message"]["formatted"] == "pre-buffer-multiple-attachment-limit"
 
-      assert collect_discarded_outcomes(ctx.ref, "ratelimit_backoff") == %{
-               "attachment" => 2
-             }
+      assert collect_discarded_outcomes(ctx.client_report_sender, ctx.ref, "ratelimit_backoff") ==
+               %{
+                 "attachment" => 2
+               }
     end
 
     test "drops rate-limited check-in events before they enter the buffer", ctx do
@@ -639,7 +640,8 @@ defmodule Sentry.TelemetryProcessorIntegrationTest do
 
       assert Buffer.size(log_buffer) == 0
 
-      outcomes = collect_discarded_outcomes(ctx.ref, "ratelimit_backoff")
+      outcomes =
+        collect_discarded_outcomes(ctx.client_report_sender, ctx.ref, "ratelimit_backoff")
 
       assert outcomes["log_item"] == 1
       assert is_integer(outcomes["log_byte"]) and outcomes["log_byte"] > 0
@@ -657,7 +659,8 @@ defmodule Sentry.TelemetryProcessorIntegrationTest do
 
       assert Buffer.size(metric_buffer) == 0
 
-      outcomes = collect_discarded_outcomes(ctx.ref, "ratelimit_backoff")
+      outcomes =
+        collect_discarded_outcomes(ctx.client_report_sender, ctx.ref, "ratelimit_backoff")
 
       assert outcomes["trace_metric"] == 1
       assert is_integer(outcomes["trace_metric_byte"]) and outcomes["trace_metric_byte"] > 0
@@ -667,7 +670,6 @@ defmodule Sentry.TelemetryProcessorIntegrationTest do
   describe "scheduler draining a rate-limited buffer" do
     setup ctx do
       put_test_config(telemetry_processor_categories: [:transaction, :log])
-      Sentry.ClientReport.Sender.flush()
       flush_ref_messages(ctx.ref)
 
       :ok
@@ -792,10 +794,10 @@ defmodule Sentry.TelemetryProcessorIntegrationTest do
   # Outcomes are recorded with a cast from whichever process dropped the item, so
   # wait for the Sender to have something to report before flushing — an empty
   # buffer is not enough, since items are drained before the outcome is recorded.
-  defp collect_discarded_outcomes(ref, reason) do
-    poll_until(fn -> :sys.get_state(Sentry.ClientReport.Sender) != %{} end)
+  defp collect_discarded_outcomes(sender, ref, reason) do
+    poll_until(fn -> :sys.get_state(sender) != %{} end)
 
-    Sentry.ClientReport.Sender.flush()
+    Sentry.ClientReport.Sender.flush(sender)
 
     for event <- await_client_report(ref)["discarded_events"],
         event["reason"] == reason,

--- a/test/sentry/transport_test.exs
+++ b/test/sentry/transport_test.exs
@@ -7,7 +7,6 @@ defmodule Sentry.TransportTest do
   alias Sentry.{
     Attachment,
     ClientError,
-    ClientReport,
     Envelope,
     Event,
     FinchClient,
@@ -275,9 +274,8 @@ defmodule Sentry.TransportTest do
       assert_received {:request, ^ref}
     end
 
-    test "does not record a client report when Sentry replies with 429", %{bypass: bypass} do
-      assert :ok = ClientReport.Sender.flush()
-
+    test "does not record a client report when Sentry replies with 429",
+         %{bypass: bypass, client_report_sender: sender} do
       envelope = Envelope.from_event(Event.create_event(message: "Hello"))
 
       Bypass.expect(bypass, "POST", "/api/1/envelope/", fn conn ->
@@ -289,7 +287,7 @@ defmodule Sentry.TransportTest do
       assert {:error, %ClientError{reason: :rate_limited}} =
                Transport.encode_and_post_envelope(envelope, FinchClient, _retries = [])
 
-      assert :sys.get_state(ClientReport.Sender) == %{}
+      assert :sys.get_state(sender) == %{}
     end
 
     test "stops retrying when a failed response carried a rate limit", %{bypass: bypass} do
@@ -329,9 +327,8 @@ defmodule Sentry.TransportTest do
       assert_received {:sent_attachment?, ^ref, false}
     end
 
-    test "records a retry-stripped attachment once", %{bypass: bypass} do
-      assert :ok = ClientReport.Sender.flush()
-
+    test "records a retry-stripped attachment once",
+         %{bypass: bypass, client_report_sender: sender} do
       stub_attachment_limit_on_first_attempt(bypass, self(), make_ref())
 
       assert {:ok, "retried"} =
@@ -341,9 +338,7 @@ defmodule Sentry.TransportTest do
                  _retries = [0]
                )
 
-      assert wait_until(fn -> :sys.get_state(ClientReport.Sender) != %{} end)
-
-      assert :sys.get_state(ClientReport.Sender) == %{{:ratelimit_backoff, "attachment"} => 1}
+      assert :sys.get_state(sender) == %{{:ratelimit_backoff, "attachment"} => 1}
     end
 
     test "fails immediately when Sentry replies with 413 (envelope too large)", %{bypass: bypass} do
@@ -463,9 +458,8 @@ defmodule Sentry.TransportTest do
       assert {:ok, "event-id"} = Transport.encode_and_post_envelope(envelope, FinchClient)
     end
 
-    test "sends an event while dropping all of its rate-limited attachments", %{bypass: bypass} do
-      assert :ok = ClientReport.Sender.flush()
-
+    test "sends an event while dropping all of its rate-limited attachments",
+         %{bypass: bypass, client_report_sender: sender} do
       event = Event.create_event(message: "event with attachments")
 
       event =
@@ -487,9 +481,8 @@ defmodule Sentry.TransportTest do
       end)
 
       assert {:ok, "event-id"} = Transport.encode_and_post_envelope(envelope, FinchClient)
-      assert wait_until(fn -> :sys.get_state(ClientReport.Sender) != %{} end)
 
-      assert :sys.get_state(ClientReport.Sender) == %{
+      assert :sys.get_state(sender) == %{
                {:ratelimit_backoff, "attachment"} => 2
              }
     end
@@ -511,9 +504,7 @@ defmodule Sentry.TransportTest do
       assert {:ok, "event-id"} = Transport.encode_and_post_envelope(envelope, FinchClient)
     end
 
-    test "records only dropped attachments in the client report" do
-      assert :ok = ClientReport.Sender.flush()
-
+    test "records only dropped attachments in the client report", %{client_report_sender: sender} do
       event = Event.create_event(message: "event with attachment")
       attachment = %Attachment{filename: "report.txt", data: "report"}
       envelope = Envelope.from_event(%Event{event | attachments: [attachment]})
@@ -522,16 +513,13 @@ defmodule Sentry.TransportTest do
       assert {:ok, _event_id} =
                Transport.encode_and_post_envelope(envelope, FinchClient, _retries = [])
 
-      assert wait_until(fn -> :sys.get_state(ClientReport.Sender) != %{} end)
-
-      assert :sys.get_state(ClientReport.Sender) == %{
+      assert :sys.get_state(sender) == %{
                {:ratelimit_backoff, "attachment"} => 1
              }
     end
 
-    test "drops an event and its attachments when the error category is rate limited" do
-      assert :ok = ClientReport.Sender.flush()
-
+    test "drops an event and its attachments when the error category is rate limited",
+         %{client_report_sender: sender} do
       event = Event.create_event(message: "event with attachment")
       event = %Event{event | attachments: [%Attachment{filename: "report.txt", data: "report"}]}
       envelope = Envelope.from_event(event)
@@ -540,17 +528,14 @@ defmodule Sentry.TransportTest do
       assert {:error, %ClientError{reason: :rate_limited}} =
                Transport.encode_and_post_envelope(envelope, FinchClient, _retries = [])
 
-      assert wait_until(fn -> :sys.get_state(ClientReport.Sender) != %{} end)
-
-      assert :sys.get_state(ClientReport.Sender) == %{
+      assert :sys.get_state(sender) == %{
                {:ratelimit_backoff, "attachment"} => 1,
                {:ratelimit_backoff, "error"} => 1
              }
     end
 
-    test "drops an event and its attachments when error and attachment limits are active" do
-      assert :ok = ClientReport.Sender.flush()
-
+    test "drops an event and its attachments when error and attachment limits are active",
+         %{client_report_sender: sender} do
       event = Event.create_event(message: "event with attachment")
       event = %Event{event | attachments: [%Attachment{filename: "report.txt", data: "report"}]}
       envelope = Envelope.from_event(event)
@@ -560,9 +545,7 @@ defmodule Sentry.TransportTest do
       assert {:error, %ClientError{reason: :rate_limited}} =
                Transport.encode_and_post_envelope(envelope, FinchClient, _retries = [])
 
-      assert wait_until(fn -> :sys.get_state(ClientReport.Sender) != %{} end)
-
-      assert :sys.get_state(ClientReport.Sender) == %{
+      assert :sys.get_state(sender) == %{
                {:ratelimit_backoff, "attachment"} => 1,
                {:ratelimit_backoff, "error"} => 1
              }

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -14,6 +14,11 @@ defmodule Sentry.Case do
     # Start a fresh RateLimiter for each test with unique names for isolation.
     setup_rate_limiter()
 
+    # Start a fresh ClientReport.Sender for each test, after the rate limiter it
+    # reads and before the TelemetryProcessor that feeds it: ExUnit tears children
+    # down in reverse, so the sender outlives the buffers still draining into it.
+    client_report_sender = setup_client_report_sender()
+
     # Start a fresh TelemetryProcessor for each test with unique name for isolation.
     # Returns the processor name so tests can pass it to handlers for isolation.
     telemetry_processor = setup_telemetry_processor()
@@ -29,7 +34,10 @@ defmodule Sentry.Case do
         opts when is_list(opts) -> setup_span_storage(opts)
       end
 
-    Map.merge(%{telemetry_processor: telemetry_processor}, span_storage_result)
+    Map.merge(
+      %{telemetry_processor: telemetry_processor, client_report_sender: client_report_sender},
+      span_storage_result
+    )
   end
 
   defp setup_rate_limiter do
@@ -44,6 +52,8 @@ defmodule Sentry.Case do
   end
 
   defp setup_telemetry_processor, do: Sentry.Test.setup_telemetry_processor()
+
+  defp setup_client_report_sender, do: Sentry.Test.setup_client_report_sender()
 
   defp setup_sender_pool_counters do
     uid = System.unique_integer([:positive])


### PR DESCRIPTION
That's the last part of the long running "stop depending on globals when running test suite" saga and it adds support for configurable client report sender, which gets configured just like telemetry processor gets configured, so we can control it in test mode easily.

This makes testing easier and reduces flakiness further.