### PR TITLE
feat(scrubbing): adopt denylist defined by Data Collection spec

### DIFF
--- a/lib/sentry/config.ex
+++ b/lib/sentry/config.ex
@@ -613,6 +613,32 @@ defmodule Sentry.Config do
       *Available since v13.2.0*.
       """,
       keys: [
+        param_keys: [
+          type: {:list, :string},
+          default: [],
+          type_doc: "list of `t:String.t/0`",
+          doc: """
+          Additional sensitive parameter keys, redacted wherever the SDK scrubs a
+          map or a query string: request and query params, the request URL,
+          `Sentry.LiveViewHook` breadcrumb data, Oban job args, and maps captured
+          into stacktrace frame variables.
+
+          These *extend* the SDK default (see `Sentry.Scrubber.default_param_keys/0`),
+          which is the denylist required by the
+          [Sentry Data Collection spec](https://develop.sentry.dev/sdk/foundations/client/data-collection/).
+          The spec defines custom deny-mode terms as additive, so there is no way
+          to shrink the default list — that is deliberate.
+
+          Terms are matched as case-insensitive substrings of the key name, so
+          `"ref"` redacts `"internal_ref"` and `"REF_ID"` alike.
+
+          This does not affect header scrubbing, which uses its own list — see
+          `Sentry.Scrubber.default_header_keys/0` and the `:header_scrubber`
+          option of `Sentry.PlugContext`.
+
+          *Available since 14.0.0*.
+          """
+        ],
         conn_private_allow_list: [
           type: {:list, :atom},
           default: Sentry.Scrubber.default_private_allow_list(),

--- a/lib/sentry/live_view_hook.ex
+++ b/lib/sentry/live_view_hook.ex
@@ -106,7 +106,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     @doc """
     The default scrubber applied to LiveView breadcrumb data.
 
-    Delegates to `Sentry.Scrubber.scrub/2` with the default sensitive
+    Delegates to `Sentry.Scrubber.scrub/2` with the configured sensitive
     parameter keys.
     """
     @doc since: "13.1.0"

--- a/lib/sentry/plug_capture.ex
+++ b/lib/sentry/plug_capture.ex
@@ -83,7 +83,7 @@ defmodule Sentry.PlugCapture do
       * scrubs *all* cookies (`cookies` and `req_cookies`)
       * drops sensitive request headers (`authorization`, `authentication`, `cookie`)
       * scrubs `params` and `body_params` through the configured `body_scrubber`
-        (defaulting to the sensitive params `password`, `passwd`, `secret`; a
+        (defaulting to the sensitive params in `Sentry.Scrubber.default_param_keys/0`; a
         `nil` `body_scrubber` empties both), and scrubs the same sensitive params
         in `query_params` and `path_params`
       * derives `request_path`, `path_info` and `query_string` from the URL the

--- a/lib/sentry/plug_context.ex
+++ b/lib/sentry/plug_context.ex
@@ -46,6 +46,20 @@ defmodule Sentry.PlugContext do
 
       plug Sentry.PlugContext, body_scrubber: {MySentryScrubber, :scrub_params}
 
+  ### Configuring Sensitive Parameter Keys
+
+  *Available since 14.0.0.*
+
+  If you only need to add key names to the SDK's denylist, you do not need a
+  custom scrubber at all. The `:scrubber` configuration extends it globally, and
+  applies to body params, query params, the query string, the request URL, and
+  any map captured into a stacktrace frame variable:
+
+      config :sentry, scrubber: [param_keys: ["internal_ref"]]
+
+  Terms are matched as case-insensitive substrings of the key name. See
+  `Sentry.Scrubber.default_param_keys/0` for the built-in list.
+
   > #### Large Files {: .tip}
   >
   > If you are sending large files in `POST` requests, we recommend you
@@ -166,7 +180,6 @@ defmodule Sentry.PlugContext do
         opts
         |> Keyword.take(Sentry.Scrubber.scrubber_names())
         |> Keyword.put_new(:url_scrubber, {__MODULE__, :default_url_scrubber, []})
-        |> Keyword.put(:private_allow_list, Sentry.Config.scrubber()[:conn_private_allow_list])
 
       Sentry.Scrubber.put_conn_scrubber(conn_scrubber_opts)
 

--- a/lib/sentry/scrubber.ex
+++ b/lib/sentry/scrubber.ex
@@ -1,4 +1,32 @@
 defmodule Sentry.Scrubber do
+  # Bound above the @moduledoc, which interpolates them.
+  #
+  # The denylist required by the Sentry Data Collection spec, matched as a
+  # case-insensitive substring of the key name rather than for equality, so that
+  # "auth" covers "Authorization" and "X-Auth-Token".
+  # https://develop.sentry.dev/sdk/foundations/client/data-collection/
+  @default_scrubbed_param_keys [
+    "auth",
+    "token",
+    "secret",
+    "password",
+    "passwd",
+    "pwd",
+    "key",
+    "jwt",
+    "bearer",
+    "sso",
+    "saml",
+    "csrf",
+    "xsrf",
+    "credentials",
+    "session",
+    "sid",
+    "identity"
+  ]
+
+  @default_scrubbed_header_keys ["authorization", "authentication", "cookie"]
+
   @moduledoc """
   Shared, framework-agnostic helpers for scrubbing sensitive data before it is
   sent to Sentry.
@@ -15,22 +43,33 @@ defmodule Sentry.Scrubber do
   ## Defaults
 
   The default sensitive *parameter* keys (used for body params, query strings,
-  and arbitrary maps) are:
+  and arbitrary maps) are the denylist required by the
+  [Sentry Data Collection spec](https://develop.sentry.dev/sdk/foundations/client/data-collection/):
 
-  #{Enum.map_join(["password", "passwd", "secret"], "\n", &"  * `\"#{&1}\"`")}
+  #{Enum.map_join(@default_scrubbed_param_keys, "\n", &"  * `\"#{&1}\"`")}
+
+  A key counts as sensitive when any of those terms appears anywhere in its
+  name, compared case-insensitively — so `"auth"` covers both `"Authorization"`
+  and `"X-Auth-Token"`.
 
   The default sensitive *header* keys are:
 
-  #{Enum.map_join(["authorization", "authentication", "cookie"], "\n", &"  * `\"#{&1}\"`")}
+  #{Enum.map_join(@default_scrubbed_header_keys, "\n", &"  * `\"#{&1}\"`")}
 
   Values matching a credit-card-like pattern (13–16 digits, optionally
   separated by spaces or dashes) are also replaced with the placeholder.
 
   ## Custom scrubbing
 
-  The map/query/header functions accept an optional `:keys` option that
-  overrides the default list of sensitive keys. This makes it possible to
-  compose custom scrubbers on top of the defaults:
+  Add your own terms to the parameter denylist with the `:scrubber`
+  configuration, which extends the list above:
+
+      config :sentry, scrubber: [param_keys: ["internal_ref"]]
+
+  The map/query/header functions also accept an optional `:keys` option that
+  replaces the list outright for that call. Precedence is `:keys` > the
+  `scrubber: [param_keys: ...]` configuration > `default_param_keys/0`. This
+  makes it possible to compose custom scrubbers on top of the defaults:
 
       def scrub(map) do
         map
@@ -83,8 +122,6 @@ defmodule Sentry.Scrubber do
 
   @moduledoc since: "13.1.0"
 
-  @default_scrubbed_param_keys ["password", "passwd", "secret"]
-  @default_scrubbed_header_keys ["authorization", "authentication", "cookie"]
   @scrubbed_value "*********"
   @scrubber_pdict_key {__MODULE__, :scrubber}
   @scrubber_names [:body_scrubber, :header_scrubber, :cookie_scrubber, :url_scrubber]
@@ -152,11 +189,16 @@ defmodule Sentry.Scrubber do
           header_scrubber: (Plug.Conn.t() -> term()),
           cookie_scrubber: (Plug.Conn.t() -> term()),
           url_scrubber: (Plug.Conn.t() -> String.t()),
+          param_keys: [String.t()],
           private_allow_list: [atom()]
         }
 
   @enforce_keys @scrubber_names
-  defstruct @scrubber_names ++ [private_allow_list: @default_private_allow_list]
+  defstruct @scrubber_names ++
+              [
+                param_keys: @default_scrubbed_param_keys,
+                private_allow_list: @default_private_allow_list
+              ]
 
   @doc false
   @spec scrubber_names() :: [atom()]
@@ -184,13 +226,15 @@ defmodule Sentry.Scrubber do
 
   Each `*_scrubber` key, when omitted, falls back to the field's default
   scrubber — the matching `scrub(conn, field)` clause of `scrub/2`.
-  `:private_allow_list` defaults to `default_private_allow_list/0`.
+  `:param_keys` and `:private_allow_list` default to the corresponding
+  `:scrubber` configuration values.
   """
   @type conn_scrubber_opts :: [
           body_scrubber: field_scrubber(),
           header_scrubber: field_scrubber(),
           cookie_scrubber: field_scrubber(),
           url_scrubber: field_scrubber(),
+          param_keys: [String.t()],
           private_allow_list: [atom()]
         ]
 
@@ -202,7 +246,12 @@ defmodule Sentry.Scrubber do
   def scrubbed_value, do: @scrubbed_value
 
   @doc """
-  Returns the default list of sensitive parameter keys.
+  Returns the SDK default list of sensitive parameter keys.
+
+  This is the denylist required by the
+  [Sentry Data Collection spec](https://develop.sentry.dev/sdk/foundations/client/data-collection/),
+  matched as a case-insensitive substring of the key name. The
+  `scrubber: [param_keys: ...]` configuration option extends it.
   """
   @doc since: "13.1.0"
   @spec default_param_keys() :: [String.t()]
@@ -280,13 +329,13 @@ defmodule Sentry.Scrubber do
   @doc since: "13.1.0"
   @spec scrub_query_string(String.t(), [option()]) :: String.t()
   def scrub_query_string(query, opts \\ []) when is_binary(query) do
-    keys = Keyword.get(opts, :keys, @default_scrubbed_param_keys)
+    keys = param_keys(opts)
 
     query
     |> URI.query_decoder()
     |> Enum.map(fn {key, value} ->
       cond do
-        key in keys -> {key, @scrubbed_value}
+        sensitive_key?(key, keys) -> {key, @scrubbed_value}
         is_binary(value) and value =~ credit_card_regex() -> {key, @scrubbed_value}
         true -> {key, value}
       end
@@ -337,9 +386,19 @@ defmodule Sentry.Scrubber do
       header_scrubber: resolve_scrubber(opts, :header_scrubber, :headers),
       cookie_scrubber: resolve_scrubber(opts, :cookie_scrubber, :cookies),
       url_scrubber: resolve_scrubber(opts, :url_scrubber, :url),
-      private_allow_list: Keyword.get(opts, :private_allow_list, @default_private_allow_list)
+      param_keys: Keyword.get_lazy(opts, :param_keys, &configured_param_keys/0),
+      private_allow_list:
+        Keyword.get_lazy(opts, :private_allow_list, &configured_private_allow_list/0)
     }
   end
+
+  # The user-configured key lists. Read at most once per scrubber construction,
+  # and `scrubber/0` memoizes the struct per process, so the recursive scrubbing
+  # functions never reach the config store per map node.
+  defp configured_param_keys,
+    do: @default_scrubbed_param_keys ++ Sentry.Config.scrubber()[:param_keys]
+
+  defp configured_private_allow_list, do: Sentry.Config.scrubber()[:conn_private_allow_list]
 
   # Resolves a per-field scrubber option into a `(conn -> term)` function. A
   # missing option falls back to the field's default scrubber, expressed as an
@@ -523,7 +582,8 @@ defmodule Sentry.Scrubber do
   @spec scrub(Plug.Conn.t(), :body | :headers | :cookies | :url) :: term()
 
   def scrub(map, opts) when is_map(map) and not is_struct(map) and is_list(opts) do
-    keys = Keyword.get(opts, :keys, @default_scrubbed_param_keys)
+    keys = param_keys(opts)
+    opts = Keyword.put_new(opts, :keys, keys)
 
     Map.new(map, fn {key, value} ->
       {key, if(sensitive_key?(key, keys), do: @scrubbed_value, else: scrub(value, opts))}
@@ -673,11 +733,25 @@ defmodule Sentry.Scrubber do
 
   defp normalize(_field, value), do: value
 
-  # Matches a map key against the configured sensitive-key list. The list is
-  # string-based (HTTP params), but maps built from structs via `Map.from_struct/1`
-  # have atom keys, so atoms are also compared by their string form.
-  defp sensitive_key?(key, keys),
-    do: key in keys or (is_atom(key) and Atom.to_string(key) in keys)
+  # Resolves the sensitive parameter keys for a scrubbing call. An explicit
+  # `:keys` option wins; otherwise they come from the current process's scrubber,
+  # which is config-backed and memoized by `scrubber/0`.
+  defp param_keys(opts), do: Keyword.get_lazy(opts, :keys, fn -> scrubber().param_keys end)
+
+  # Matches a key against the sensitive-key list the way the Sentry Data
+  # Collection spec requires: a partial, case-insensitive match, so a key counts
+  # as sensitive when any listed term appears anywhere in its name. Maps built
+  # from structs via `Map.from_struct/1` have atom keys, so atoms are compared by
+  # their string form.
+  defp sensitive_key?(key, keys) when is_atom(key) and not is_nil(key),
+    do: key |> Atom.to_string() |> sensitive_key?(keys)
+
+  defp sensitive_key?(key, keys) when is_binary(key) do
+    downcased = String.downcase(key)
+    Enum.any?(keys, &String.contains?(downcased, String.downcase(&1)))
+  end
+
+  defp sensitive_key?(_key, _keys), do: false
 
   defp credit_card_regex, do: ~r/^(?:\d[ -]*?){13,16}$/
 end

--- a/test/plug_capture_test.exs
+++ b/test/plug_capture_test.exs
@@ -3,6 +3,7 @@ defmodule Sentry.PlugCaptureTest do
   import Plug.Test
 
   import Sentry.Test.Assertions
+  import Sentry.TestHelpers
 
   alias Sentry.Test, as: SentryTest
 
@@ -430,6 +431,28 @@ defmodule Sentry.PlugCaptureTest do
       assert [%{"exception" => [%{"value" => value}]}] = SentryTest.collect_sentry_events(ref, 1)
 
       assert value =~ ~s(path_params: %{"secret" => "#{@redacted}"})
+    end
+
+    test "redacts a query parameter whose name contains a sensitive term", %{ref: ref} do
+      assert_raise Phoenix.ActionClauseError, fn ->
+        conn(:get, "/action_clause_error?Reset-Token=#{@token}") |> call_phoenix_endpoint()
+      end
+
+      assert [%{"exception" => [%{"value" => value}]}] = SentryTest.collect_sentry_events(ref, 1)
+
+      refute value =~ @token
+    end
+
+    test "redacts a query parameter listed in the configured param keys", %{ref: ref} do
+      put_test_config(scrubber: [param_keys: ["internal_ref"]])
+
+      assert_raise Phoenix.ActionClauseError, fn ->
+        conn(:get, "/action_clause_error?internal_ref=#{@token}") |> call_phoenix_endpoint()
+      end
+
+      assert [%{"exception" => [%{"value" => value}]}] = SentryTest.collect_sentry_events(ref, 1)
+
+      refute value =~ @token
     end
   end
 

--- a/test/sentry/scrubber_test.exs
+++ b/test/sentry/scrubber_test.exs
@@ -42,6 +42,19 @@ defmodule Sentry.ScrubberTest do
                %{"password" => "*********", "ok" => 1}
     end
 
+    test "leaves a key that is not valid UTF-8 alone rather than failing on it" do
+      assert Scrubber.scrub(%{<<0xC3, 0x28>> => "value", "password" => "x"}) ==
+               %{<<0xC3, 0x28>> => "value", "password" => Scrubber.scrubbed_value()}
+    end
+
+    test "redacts a key that contains a sensitive term in any casing" do
+      assert Scrubber.scrub(%{"X-Auth-Token" => "x"}) == %{"X-Auth-Token" => "*********"}
+    end
+
+    test "leaves a key containing no sensitive term untouched" do
+      assert Scrubber.scrub(%{"page" => "2"}) == %{"page" => "2"}
+    end
+
     test "redacts sensitive keys given as atoms (e.g. struct fields)" do
       assert Scrubber.scrub(%{password: "x", ok: 1}) ==
                %{password: "*********", ok: 1}
@@ -152,6 +165,16 @@ defmodule Sentry.ScrubberTest do
       refute scrubbed =~ "hunter2"
       assert scrubbed =~ "visible=ok"
     end
+
+    test "matches keys that are not valid UTF-8" do
+      # A query string is arbitrary bytes, so a percent-encoded key can decode to
+      # something that is not valid UTF-8 at all. Case-insensitive matching must
+      # cope with that: scrubbing runs while an error is already being reported.
+      scrubbed = Scrubber.scrub_query_string("%FF%FEtoken=hunter2&keep=ok")
+
+      refute scrubbed =~ "hunter2"
+      assert scrubbed =~ "keep=ok"
+    end
   end
 
   describe "scrub/1 with no registered scrubber" do
@@ -230,7 +253,7 @@ defmodule Sentry.ScrubberTest do
     test "scrubs params with default sensitive keys", %{scrubbed: scrubbed} do
       assert scrubbed.params == %{
                "user" => %{"email" => "alice@example.com", "password" => "*********"},
-               "_csrf_token" => "csrf-leaky-token"
+               "_csrf_token" => "*********"
              }
     end
 
@@ -315,7 +338,7 @@ defmodule Sentry.ScrubberTest do
 
       refute scrubbed =~ "secret"
       refute scrubbed =~ "4242424242424242"
-      assert scrubbed =~ "token=abc"
+      refute scrubbed =~ "abc"
       assert scrubbed =~ "keep=ok"
     end
 


### PR DESCRIPTION
Now the default sensitive keys are the denylist the Data Collection spec requires, matched as a case-insensitive substring, and `config :sentry, scrubber: [param_keys: [...]]` extends that list with your own terms.

### Before

`internal_ref` is the row to focus on. Relay does not recognise that name, so it is the one value the panel shows exactly as the SDK left it — and there is no way to make the SDK redact it, because the `:param_keys` option does not exist yet:

- `internal_ref` — `cfgref-20260909-082441-before`, in both Body and Query String
- `token`, `api_key` — not in the old denylist
- `PASSWORD` — the same term as `password`, **missed because matching was case-sensitive**
- `user_password` — the same term again, missed because matching required exact equality

<img width="1433" height="656" alt="pr3-conn-dump-before" src="https://github.com/user-attachments/assets/902c7d31-576d-4c8a-8ade-3e0af50e339c" />

<img width="1411" height="587" alt="pr3-request-panel-before" src="https://github.com/user-attachments/assets/0c51020d-7783-4e29-bfcb-bd414c23c5c4" />


### After

Every one of those is redacted, each by a different rule:

- `internal_ref` — `*********`, sensitive only because the app configured `scrubber: [param_keys: ["internal_ref"]]`
- `token` — a key the spec denylist adds
- `api_key` — matched as a substring of `key`
- `PASSWORD` — matched too
- `user_password` — matched as a substring

<img width="1425" height="860" alt="pr3-conn-dump-after" src="https://github.com/user-attachments/assets/4cdfcddc-c576-4ba0-8d9f-92e43659f07a" />

<img width="1409" height="590" alt="pr3-request-panel-after" src="https://github.com/user-attachments/assets/e49c4185-86e3-4eec-8205-f3031fc5e228" />
